### PR TITLE
fix(browser): use Playwright Chromium + survive the apt lock

### DIFF
--- a/backend/internal/manager/containers/baseimage.go
+++ b/backend/internal/manager/containers/baseimage.go
@@ -86,31 +86,30 @@ gh --version | head -1`
 //     pre-date the GUI stack being baked into the image.
 const BrowserGUIInstallScript = `set -e
 export DEBIAN_FRONTEND=noninteractive
-apt-get update -qq
+# Wait for the apt/dpkg lock rather than failing if apt-daily / unattended-
+# upgrades is mid-run — a common race shortly after a container boots.
+APT="apt-get -o DPkg::Lock::Timeout=300"
+$APT update -qq
 
 # Virtual display + VNC bridge (x11vnc -> websockify/noVNC over HTTP/WS), a
 # lightweight window manager (openbox) so the browser window keeps stable
 # input focus, and xdotool to activate that window. Font packages cover
 # common web / CJK / emoji glyphs so real pages render legibly.
-apt-get install -y -qq \
+$APT install -y -qq \
     xvfb x11vnc novnc websockify openbox xdotool \
     libgtk-3-0t64 libgbm1 libasound2t64 libnss3 libxshmfence1 \
     dbus-x11 fonts-liberation fonts-noto-core fonts-noto-color-emoji
 
-# Real Google Chrome stable (NOT Chrome-for-Testing): it auto-updates and
-# lacks the "for automated testing" banner and build signature that make a
-# browser easier to flag as automation. amd64-only, matching the base image.
-curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
-    | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
-chmod go+r /usr/share/keyrings/google-chrome.gpg
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
-    > /etc/apt/sources.list.d/google-chrome.list
-apt-get update -qq
-apt-get install -y -qq google-chrome-stable
+# Browser: Playwright's Chromium (Chrome for Testing), NOT google-chrome-stable.
+# In an unprivileged LXC container google-chrome-stable's network service
+# cannot open the remote-debugging socket (CreatePlatformSocket: EPERM), so the
+# agent could never attach over CDP; the Chromium build can. It installs into
+# /root/.cache/ms-playwright, where gui-up.sh and browser.mjs both find it.
+npx --yes playwright@1.60.0 install chromium 2>&1 | tail -3
 
-# Sanity check the GUI toolchain.
-which Xvfb x11vnc websockify openbox google-chrome
-google-chrome --version`
+# Sanity check the GUI toolchain (the chromium glob fails the build if absent).
+which Xvfb x11vnc websockify openbox
+ls /root/.cache/ms-playwright/chromium-*/chrome-linux64/chrome`
 
 // BuildBaseImage launches a fresh BaseImageSourceImage container, runs the
 // install script, publishes the result under alias, and removes the

--- a/backend/internal/manager/containers/browser_gui.go
+++ b/backend/internal/manager/containers/browser_gui.go
@@ -69,9 +69,9 @@ func (m *Manager) EnsureBrowserGUI(ctx context.Context, containerName string) er
 	}
 
 	cctx, cancelC := context.WithTimeout(ctx, queryTimeout)
-	_, chromeErr := m.lxc.Run(cctx, "exec", containerName, "--", "sh", "-c", "command -v google-chrome >/dev/null 2>&1")
+	_, stackErr := m.lxc.Run(cctx, "exec", containerName, "--", "sh", "-c", "command -v Xvfb >/dev/null 2>&1 && ls /root/.cache/ms-playwright/chromium-*/chrome-linux64/chrome >/dev/null 2>&1")
 	cancelC()
-	if chromeErr != nil {
+	if stackErr != nil {
 		ictx, cancelI := context.WithTimeout(ctx, browserGUIInstallTimeout)
 		out, err := m.lxc.Run(ictx, "exec", containerName, "--", "bash", "-c", BrowserGUIInstallScript)
 		cancelI()

--- a/backend/internal/manager/containers/templates/gui-up.sh
+++ b/backend/internal/manager/containers/templates/gui-up.sh
@@ -19,7 +19,11 @@ CDP_PORT=9222
 SCREEN=1366x768x24
 export DISPLAY=":$DISPLAY_NUM"
 
-CHROME="$(command -v google-chrome 2>/dev/null || echo /usr/bin/google-chrome)"
+# Prefer Playwright's Chromium (Chrome for Testing): in an unprivileged LXC
+# its network service can open the CDP socket, whereas google-chrome-stable
+# cannot (CreatePlatformSocket EPERM). Fall back to system Chrome if absent.
+CHROME="$(ls -1 /root/.cache/ms-playwright/chromium-*/chrome-linux64/chrome 2>/dev/null | sort -V | tail -1)"
+[ -n "$CHROME" ] || CHROME="$(command -v google-chrome 2>/dev/null || echo /usr/bin/google-chrome)"
 
 log() { echo "[gui-up] $*"; }
 


### PR DESCRIPTION
Two production failures opening the Agent Browser in a container:

1) apt-lock race: the on-demand GUI install ran apt-get while apt-daily /
   unattended-upgrades held the dpkg lock (just after boot), and bailed
   ("Could not get lock /var/lib/dpkg/lock-frontend"). Now apt-get waits
   for the lock (-o DPkg::Lock::Timeout=300).

2) CDP never came up: google-chrome-stable in an unprivileged LXC cannot
   open the remote-debugging socket — its network service hits
   CreatePlatformSocket: Permission denied (EPERM) even with --no-sandbox
   and security.nesting. Verified that Playwright Chromium (Chrome for
   Testing) opens CDP fine in the SAME container. So the Agent Browser now
   runs the Playwright Chromium: gui-up.sh resolves it from
   /root/.cache/ms-playwright (falling back to system Chrome), and the
   install script fetches it via playwright instead of google-chrome.
   EnsureBrowser GUI gate now checks for Xvfb + a chromium instead of
   google-chrome.

Trade-off: Chrome for Testing shows an automation infobar and is a touch more fingerprintable than stable Chrome — but the agent being able to attach over CDP is non-negotiable, and stable Chrome simply cannot here.