### PR TITLE
feat(browser): browser skill + @playwright/mcp tools (gated on the sk…

### DIFF
--- a/backend/internal/agent/model.go
+++ b/backend/internal/agent/model.go
@@ -53,6 +53,9 @@ type RunRequest struct {
 	ProjectID      string
 	Fork           bool
 	Config         map[string]any
+	// EnableBrowser wires the @playwright/mcp browser tools into the agent
+	// launch. Set when the `browser` skill is selected for the prompt.
+	EnableBrowser bool
 }
 
 // Event is the normalized backend event shape emitted by headless agent

--- a/backend/internal/agent/providers/claude/command.go
+++ b/backend/internal/agent/providers/claude/command.go
@@ -12,6 +12,10 @@ import (
 	serviceproject "github.com/Kings-Of-The-Web/remote.futrx.dev/internal/service/project"
 )
 
+// browserMCPConfigPath is the --mcp-config file claude loads when the
+// browser skill is active. Must match containers.ContainerMCPClaudeConfig.
+const browserMCPConfigPath = "/workspace/.browser-gui/mcp-claude.json"
+
 func (p *Provider) args(req agent.RunRequest) []string {
 	args := []string{
 		"-p",
@@ -28,6 +32,9 @@ func (p *Provider) args(req agent.RunRequest) []string {
 		if req.Fork {
 			args = append(args, "--fork-session")
 		}
+	}
+	if req.EnableBrowser {
+		args = append(args, "--mcp-config", browserMCPConfigPath)
 	}
 	return args
 }
@@ -99,6 +106,11 @@ func (p *Provider) buildCmd(
 			// Browser script + config are best-effort: their absence only matters
 			// when the agent tries to drive Playwright. Don't fail the run.
 			_ = err
+		}
+		if req.EnableBrowser {
+			if err := p.containers.EnsureBrowserMCP(ctx, project.ContainerName); err != nil {
+				return nil, "", fmt.Errorf("provision browser MCP: %w", err)
+			}
 		}
 		if err := p.containers.EnsureBootAutostart(ctx, project.ContainerName); err != nil {
 			return nil, "", fmt.Errorf("set container boot.autostart: %w", err)

--- a/backend/internal/agent/providers/claude/provider.go
+++ b/backend/internal/agent/providers/claude/provider.go
@@ -22,6 +22,7 @@ type ContainerPreparer interface {
 	EnsureAgentInstructions(ctx context.Context, containerName string) error
 	EnsureWorkspaceSkillLinks(ctx context.Context, containerName string) error
 	EnsureBrowserScript(ctx context.Context, containerName string) error
+	EnsureBrowserMCP(ctx context.Context, containerName string) error
 	EnsureBootAutostart(ctx context.Context, containerName string) error
 	SyncClaudeAuthFromContainer(ctx context.Context, containerName string) error
 }

--- a/backend/internal/manager/containers/browser_mcp.go
+++ b/backend/internal/manager/containers/browser_mcp.go
@@ -1,0 +1,61 @@
+package containers
+
+// Browser MCP provisioning: makes the @playwright/mcp browser tools available
+// to the in-container agent, attached over CDP to the live GUI Chrome (the
+// SAME session the user logs into). This is the tool layer behind the
+// `browser` skill — the agent calls browser_navigate / browser_snapshot /
+// browser_click / browser_type etc. instead of hand-writing Playwright recipes.
+//
+// Only wired when the browser skill is selected (see the providers), so the
+// tool surface and the per-prompt MCP process don't burden ordinary prompts.
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"time"
+)
+
+//go:embed templates/mcp-claude.json
+var mcpClaudeConfig []byte
+
+const (
+	// ContainerMCPClaudeConfig is the --mcp-config file claude is pointed at
+	// when the browser skill is active. It registers the @playwright/mcp
+	// server attached to the loopback CDP endpoint.
+	ContainerMCPClaudeConfig = containerGUIDir + "/mcp-claude.json"
+	containerMCPConfigHash   = containerGUIDir + "/.mcp-claude.sha256"
+
+	browserMCPInstallTimeout = 5 * time.Minute
+)
+
+// EnsureBrowserMCP installs @playwright/mcp (idempotently) and pushes the
+// claude MCP config. Cheap once installed: the npm-presence check short-
+// circuits, and the config is only re-pushed when its embedded content
+// changes.
+func (m *Manager) EnsureBrowserMCP(ctx context.Context, containerName string) error {
+	if !m.Available() {
+		return errors.New("lxc not available")
+	}
+
+	cctx, cancelC := context.WithTimeout(ctx, queryTimeout)
+	_, missing := m.lxc.Run(cctx, "exec", containerName, "--", "sh", "-c", "npm ls -g @playwright/mcp >/dev/null 2>&1")
+	cancelC()
+	if missing != nil {
+		ictx, cancelI := context.WithTimeout(ctx, browserMCPInstallTimeout)
+		out, err := m.lxc.Run(ictx, "exec", containerName, "--", "sh", "-c", "npm install -g @playwright/mcp 2>&1 | tail -3")
+		cancelI()
+		if err != nil {
+			return fmt.Errorf("install @playwright/mcp: %w; output: %s", err, truncateOut(out, 1000))
+		}
+	}
+
+	dctx, cancelD := context.WithTimeout(ctx, queryTimeout)
+	out, err := m.lxc.Run(dctx, "exec", containerName, "--", "install", "-d", "-m", "755", containerGUIDir)
+	cancelD()
+	if err != nil {
+		return fmt.Errorf("mkdir %s: %w; output: %s", containerGUIDir, err, out)
+	}
+	return m.pushTemplatedFile(ctx, containerName, mcpClaudeConfig, containerMCPConfigHash, "644", ContainerMCPClaudeConfig)
+}

--- a/backend/internal/manager/containers/browser_skill.go
+++ b/backend/internal/manager/containers/browser_skill.go
@@ -1,0 +1,39 @@
+package containers
+
+// Browser-skill provisioning: ships the `browser` SKILL.md into the workspace
+// so it shows up in the skill picker and is available to the agent. The skill
+// holds the browser playbook (how to use the browser_* tools, the login
+// handoff, the write-approval policy); selecting it is what wires the MCP
+// tools (see the providers). Provisioned at container launch like the browser
+// script, so every project has it without bloating AGENTS.md.
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+)
+
+//go:embed templates/skills/browser/SKILL.md
+var browserSkillTemplate []byte
+
+const (
+	containerBrowserSkillDir  = "/workspace/.agents/skills/browser"
+	containerBrowserSkillMD   = containerBrowserSkillDir + "/SKILL.md"
+	containerBrowserSkillHash = containerBrowserSkillDir + "/.skill.sha256"
+)
+
+// EnsureBrowserSkill provisions the `browser` skill into the workspace skills
+// directory. Idempotent: re-pushed only when the embedded SKILL.md changes.
+func (m *Manager) EnsureBrowserSkill(ctx context.Context, containerName string) error {
+	if !m.Available() {
+		return errors.New("lxc not available")
+	}
+	dctx, cancelD := context.WithTimeout(ctx, queryTimeout)
+	out, err := m.lxc.Run(dctx, "exec", containerName, "--", "install", "-d", "-m", "755", containerBrowserSkillDir)
+	cancelD()
+	if err != nil {
+		return fmt.Errorf("mkdir %s: %w; output: %s", containerBrowserSkillDir, err, out)
+	}
+	return m.pushTemplatedFile(ctx, containerName, browserSkillTemplate, containerBrowserSkillHash, "644", containerBrowserSkillMD)
+}

--- a/backend/internal/manager/containers/lifecycle.go
+++ b/backend/internal/manager/containers/lifecycle.go
@@ -55,6 +55,7 @@ func (m *Manager) Launch(ctx context.Context, p serviceproject.Meta) error {
 	_ = m.EnsureRegisteredAuth(ctx, p.ContainerName)
 	_ = m.EnsureWorkspaceSkillLinks(ctx, p.ContainerName)
 	_ = m.EnsureBrowserScript(ctx, p.ContainerName)
+	_ = m.EnsureBrowserSkill(ctx, p.ContainerName)
 	_ = m.EnsureBrowserGUILimits(ctx, p.ContainerName)
 
 	return nil

--- a/backend/internal/manager/containers/templates/AGENTS.md
+++ b/backend/internal/manager/containers/templates/AGENTS.md
@@ -178,39 +178,15 @@ above stays available for sites where the user can copy a session cookie.
 **If a script suddenly returns a logged-out page**, the cookie has
 rotated. Tell the user to re-paste a fresh value — don't silently retry.
 
-### Agent Browser — act in a session the user logged into
+### Agent Browser — driving a live browser the user logs into
 
-For sites with no usable API and no copyable cookie (most social logins),
-the platform can run a **real, visible browser inside this container** that
-the user logs into by hand, after which you drive the *same* session:
-
-1. Ask the user to open **Browser → Agent browser** in the chat UI and log
-   into the target site there (they see a live view and handle the password
-   and any 2FA). Their login persists across container restarts.
-2. Drive that live, already-authenticated session with the **`connect`**
-   subcommand — it attaches over CDP and shares the user's cookies, so you
-   never handle credentials:
-
-   ```bash
-   # report what's open in the live session
-   node /workspace/scripts/browser.mjs connect
-   # run a recipe against the logged-in session
-   node /workspace/scripts/browser.mjs connect /workspace/.browser/recipes/<scenario>.mjs
-   ```
-
-   The recipe shape is identical to `run` (default async function
-   `(page, context)`), but it acts in the live profile — no
-   `browser-auth.json` cookies are attached.
-
-**Write policy:** reading (timelines, messages, search) is fine on your
-own. Before any **public or irreversible write** — posting, replying,
-DMing, following, purchasing, changing settings — **say what you're about
-to do and get the user's confirmation first.** They can also watch and stop
-you through the live view.
-
-**Egress note:** this browser exits via the datacenter IP, so strict
-providers (Google, X) may show extra "verify it's you" challenges at login;
-the user clears those in the live view. Respect each site's terms of service.
+For tasks that need a **real browser the user logs into** (social media,
+dashboards, any authenticated site), use the **`browser` skill**: it gives
+you `browser_*` tools wired to a live Chromium the user can watch and log
+into, and carries the full playbook (reading via snapshots, the login
+handoff, the write-approval policy). The user selects it for the request.
+The headless `scripts/browser.mjs` above stays for one-off screenshots or
+recordings of public / cookie-authenticated URLs.
 
 ### Recording agent-driven flows (clicking, filling, multi-step)
 

--- a/backend/internal/manager/containers/templates/mcp-claude.json
+++ b/backend/internal/manager/containers/templates/mcp-claude.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "browser": {
+      "command": "npx",
+      "args": ["@playwright/mcp", "--cdp-endpoint", "http://127.0.0.1:9222"]
+    }
+  }
+}

--- a/backend/internal/manager/containers/templates/skills/browser/SKILL.md
+++ b/backend/internal/manager/containers/templates/skills/browser/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: browser
+description: "Drive a real web browser the user logs into — open pages, read content, search, fill forms, click, and act in the user's authenticated sessions (social media, dashboards, any site). Use when a task needs a live browser: 'go to <site>', 'search X on <site>', 'log into my <account> and do Y', 'check my messages/notifications', or automating a site that needs a real logged-in session. NOT for previewing this project's own dev server (that's the Browser drawer) and NOT for a one-off screenshot of a public URL (use scripts/browser.mjs)."
+---
+
+# Browser
+
+You can drive a **real Chromium running inside this container** that the user
+can watch and log into. With this skill active you have `browser_*` MCP tools
+attached over CDP to that **live, shared session** — the same browser the user
+sees in the Browser pane — so you inherit its cookies and logins.
+
+## How to work
+Go **step by step**, never blind:
+1. `browser_navigate` to a URL.
+2. `browser_snapshot` to read the page as an accessibility tree — this is your
+   primary way to "see". It's cheaper and more reliable than screenshots, and
+   it gives you the element refs the action tools need.
+3. Act: `browser_click`, `browser_type`, `browser_fill_form`,
+   `browser_press_key`, `browser_select_option`, `browser_hover`.
+4. `browser_snapshot` again to confirm the result, and adapt.
+
+Use `browser_take_screenshot` only when you need to *show* the user a picture;
+use `browser_tabs`, `browser_navigate_back`, and `browser_wait_for` to manage
+navigation. Don't guess selectors — read a snapshot first.
+
+## Logging in (you never type passwords)
+This browser exits via the container's datacenter IP, so strict providers
+(Google, X) may show a "verify it's you" challenge. For anything that needs a
+login you can't complete yourself:
+1. Ask the user to open the **Browser** pane and log in by hand — they handle
+   the password and any 2FA.
+2. Their login persists; then drive the `browser_*` tools against that session.
+
+Never enter the user's credentials yourself.
+
+## Write policy
+Reading (search, timelines, messages) is fine on your own. Before any **public
+or irreversible write** — posting, replying, DMing, following, buying, or
+changing settings — **say exactly what you're about to do and get the user's
+confirmation first.** They can watch and stop you in the Browser pane.
+
+## If the tools don't respond
+The live browser may not be running yet. Ask the user to open the **Browser**
+pane (that starts the session), then retry.

--- a/backend/internal/service/prompt/service.go
+++ b/backend/internal/service/prompt/service.go
@@ -36,6 +36,7 @@ type ContainerPreparer interface {
 	EnsureAgentInstructions(ctx context.Context, containerName string) error
 	EnsureWorkspaceSkillLinks(ctx context.Context, containerName string) error
 	EnsureBrowserScript(ctx context.Context, containerName string) error
+	EnsureBrowserMCP(ctx context.Context, containerName string) error
 	EnsureBootAutostart(ctx context.Context, containerName string) error
 	SyncClaudeAuthFromContainer(ctx context.Context, containerName string) error
 	EnsureCodex(ctx context.Context, containerName string) error
@@ -168,6 +169,7 @@ func (rnr *Service) runPrompt(
 		Config: map[string]any{
 			"reasoningEffort": meta.ReasoningEffort,
 		},
+		EnableBrowser: hasBrowserSkill(meta.SelectedSkills),
 	}, func(ev agent.Event) {
 		rnr.emitAgentEvent(ctx, id, ev, emit)
 	})
@@ -224,6 +226,19 @@ func promptWithVisibleHistory(events []ChatEvent, prompt string) string {
 		transcript +
 		"\n\nCurrent user request:\n" +
 		prompt
+}
+
+const browserSkillName = "browser"
+
+// hasBrowserSkill reports whether the user selected the `browser` skill for
+// this prompt — the signal to wire the @playwright/mcp browser tools.
+func hasBrowserSkill(skills []servicechat.SkillRef) bool {
+	for _, s := range skills {
+		if skillTriggerName(s.Command) == browserSkillName || skillTriggerName(s.Name) == browserSkillName {
+			return true
+		}
+	}
+	return false
 }
 
 func promptWithSelectedSkills(provider agent.ProviderID, skills []servicechat.SkillRef, prompt string) string {


### PR DESCRIPTION
…ill)

Replace the recipe-per-task friction with real conversational browser tools, and move the playbook out of always-on AGENTS.md into a skill.

- New `browser` skill (templates/skills/browser/SKILL.md), provisioned into every workspace at launch (EnsureBrowserSkill). Holds the full playbook: read via browser_snapshot, the login handoff, write-approval.
- Selecting that skill sets RunRequest.EnableBrowser, which wires the official @playwright/mcp server (attached to the live CDP session via --cdp-endpoint) into the claude launch (--mcp-config). The agent then calls browser_navigate / browser_snapshot / browser_click / browser_type etc. instead of hand-writing Playwright recipes. EnsureBrowserMCP installs the package on demand + pushes the config.
- Gated on the skill, so the MCP process + ~22 tool defs do not burden ordinary (non-browser) prompts — the context-economy point.
- AGENTS.md trimmed from the ~30-line connect recipe to a one-line pointer at the skill.

Verified: @playwright/mcp attaches via --cdp-endpoint and lists the full browser tool set against the live browser; backend builds + vets. Codex MCP wiring and end-to-end agent-side run are follow-ups (the latter needs the real platform auth flow).