### PR TITLE
feat(ide): on-demand per-container code-server (Option A, additive)

### DIFF
--- a/backend/internal/manager/containers/baseimage.go
+++ b/backend/internal/manager/containers/baseimage.go
@@ -166,6 +166,11 @@ func (m *Manager) BuildBaseImage(ctx context.Context, alias string) error {
 		return fmt.Errorf("browser GUI install script: %w; output: %s", err, truncateOut(out, 2000))
 	}
 
+	// Layer the on-demand code-server IDE on top (per-container VS Code).
+	if out, err := m.lxc.Run(bctx, "exec", baseImageBuilderName, "--", "bash", "-c", string(codeServerUpScript)); err != nil {
+		return fmt.Errorf("code-server install script: %w; output: %s", err, truncateOut(out, 2000))
+	}
+
 	if out, err := m.lxc.Run(bctx, "stop", baseImageBuilderName); err != nil {
 		return fmt.Errorf("stop builder: %w; output: %s", err, out)
 	}

--- a/backend/internal/manager/containers/code_server.go
+++ b/backend/internal/manager/containers/code_server.go
@@ -1,0 +1,42 @@
+package containers
+
+// On-demand code-server: each project container runs its own code-server,
+// socket-activated and idle-stopped (see templates/code-server-up.sh). New
+// containers get it baked into the base image; EnsureCodeServer is the
+// migration path for containers created before that image. Reached from the
+// host edge at <slug>.code.<host> -> <slug>.lxd:8080, behind the same Google
+// admin gate as the dev-URL proxy.
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"time"
+)
+
+//go:embed templates/code-server-up.sh
+var codeServerUpScript []byte
+
+// EnsureCodeServer installs and enables the on-demand code-server stack inside
+// an existing project container. Idempotent and best-effort, mirroring
+// EnsureBrowserGUI: a no-op once the socket unit is present.
+func (m *Manager) EnsureCodeServer(ctx context.Context, containerName string) error {
+	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if _, err := m.lxc.Run(cctx, "exec", containerName, "--", "test", "-f", "/etc/systemd/system/code-server.socket"); err == nil {
+		return nil
+	}
+
+	ictx, icancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer icancel()
+	if out, err := m.lxc.Run(ictx, "exec", containerName, "--", "bash", "-c", string(codeServerUpScript)); err != nil {
+		return fmt.Errorf("install code-server: %w; output: %s", err, truncateOut(out, 2000))
+	}
+
+	ectx, ecancel := context.WithTimeout(ctx, 20*time.Second)
+	defer ecancel()
+	if out, err := m.lxc.Run(ectx, "exec", containerName, "--", "systemctl", "enable", "--now", "code-server.socket"); err != nil {
+		return fmt.Errorf("enable code-server.socket: %w; output: %s", err, truncateOut(out, 1000))
+	}
+	return nil
+}

--- a/backend/internal/manager/containers/code_server.go
+++ b/backend/internal/manager/containers/code_server.go
@@ -19,20 +19,34 @@ var codeServerUpScript []byte
 
 // EnsureCodeServer installs and enables the on-demand code-server stack inside
 // an existing project container. Idempotent and best-effort, mirroring
-// EnsureBrowserGUI: a no-op once the socket unit is present.
+// EnsureBrowserGUI. It returns early only when the socket is actually active;
+// if the unit file exists but is disabled/stopped (e.g. a base-image bake that
+// didn't enable it, or a unit that was turned off later) it still (re-)enables
+// it, so a present-but-inert socket can't leave IDE routing silently broken.
 func (m *Manager) EnsureCodeServer(ctx context.Context, containerName string) error {
+	// Fast path: socket already armed and listening -> nothing to do.
 	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	if _, err := m.lxc.Run(cctx, "exec", containerName, "--", "test", "-f", "/etc/systemd/system/code-server.socket"); err == nil {
+	if _, err := m.lxc.Run(cctx, "exec", containerName, "--", "systemctl", "is-active", "--quiet", "code-server.socket"); err == nil {
 		return nil
 	}
 
-	ictx, icancel := context.WithTimeout(ctx, 5*time.Minute)
-	defer icancel()
-	if out, err := m.lxc.Run(ictx, "exec", containerName, "--", "bash", "-c", string(codeServerUpScript)); err != nil {
-		return fmt.Errorf("install code-server: %w; output: %s", err, truncateOut(out, 2000))
+	// Install the units only when they're not present yet. The base image may
+	// already ship them; re-running the install script is harmless but slow,
+	// so skip it when the unit file exists and just (re-)enable below.
+	tctx, tcancel := context.WithTimeout(ctx, 10*time.Second)
+	defer tcancel()
+	if _, err := m.lxc.Run(tctx, "exec", containerName, "--", "test", "-f", "/etc/systemd/system/code-server.socket"); err != nil {
+		ictx, icancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer icancel()
+		if out, err := m.lxc.Run(ictx, "exec", containerName, "--", "bash", "-c", string(codeServerUpScript)); err != nil {
+			return fmt.Errorf("install code-server: %w; output: %s", err, truncateOut(out, 2000))
+		}
 	}
 
+	// Always enable --now: arms a freshly-installed socket, and recovers a
+	// baked-but-disabled/stopped one -- the case the old file-exists check
+	// reported as complete while routing was actually dead.
 	ectx, ecancel := context.WithTimeout(ctx, 20*time.Second)
 	defer ecancel()
 	if out, err := m.lxc.Run(ectx, "exec", containerName, "--", "systemctl", "enable", "--now", "code-server.socket"); err != nil {

--- a/backend/internal/manager/containers/lifecycle.go
+++ b/backend/internal/manager/containers/lifecycle.go
@@ -57,6 +57,7 @@ func (m *Manager) Launch(ctx context.Context, p serviceproject.Meta) error {
 	_ = m.EnsureBrowserScript(ctx, p.ContainerName)
 	_ = m.EnsureBrowserSkill(ctx, p.ContainerName)
 	_ = m.EnsureBrowserGUILimits(ctx, p.ContainerName)
+	_ = m.EnsureCodeServer(ctx, p.ContainerName)
 
 	return nil
 }

--- a/backend/internal/manager/containers/templates/code-server-up.sh
+++ b/backend/internal/manager/containers/templates/code-server-up.sh
@@ -5,7 +5,7 @@ set -e
 #
 # Lifecycle (systemd socket activation -> full scale-to-zero):
 #   code-server.socket         listens on 0.0.0.0:8080 (cheap; always armed)
-#   code-server-proxy.service  systemd-socket-proxyd --exit-idle-time=20min,
+#   code-server-proxy.service  systemd-socket-proxyd --exit-idle-time=10min,
 #                              forwards to 127.0.0.1:8081, Requires= the real
 #                              service so a first connection pulls it up
 #   code-server.service        code-server itself, StopWhenUnneeded=yes so it
@@ -52,7 +52,7 @@ Requires=code-server.service
 After=code-server.service
 
 [Service]
-ExecStart=/usr/lib/systemd/systemd-socket-proxyd --exit-idle-time=20min 127.0.0.1:8081
+ExecStart=/usr/lib/systemd/systemd-socket-proxyd --exit-idle-time=10min 127.0.0.1:8081
 UNIT
 
 cat > /etc/systemd/system/code-server.socket <<'UNIT'

--- a/backend/internal/manager/containers/templates/code-server-up.sh
+++ b/backend/internal/manager/containers/templates/code-server-up.sh
@@ -1,0 +1,90 @@
+set -e
+# Managed by containers/code_server.go. Installs an on-demand, idle-stopped
+# code-server inside a project container. Reached from the host edge at
+# <slug>.code.<host> -> <slug>.lxd:8080.
+#
+# Lifecycle (systemd socket activation -> full scale-to-zero):
+#   code-server.socket         listens on 0.0.0.0:8080 (cheap; always armed)
+#   code-server-proxy.service  systemd-socket-proxyd --exit-idle-time=20min,
+#                              forwards to 127.0.0.1:8081, Requires= the real
+#                              service so a first connection pulls it up
+#   code-server.service        code-server itself, StopWhenUnneeded=yes so it
+#                              stops once the proxy idle-exits
+CODE_SERVER_VERSION=4.121.0
+
+if ! command -v code-server >/dev/null 2>&1 \
+   || [ "$(code-server --version 2>/dev/null | head -1 | awk '{print $1}')" != "$CODE_SERVER_VERSION" ]; then
+    ARCH="$(dpkg --print-architecture)"
+    curl -fsSL --retry 3 -o /tmp/code-server.deb \
+        "https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_${ARCH}.deb"
+    apt-get install -y -qq /tmp/code-server.deb
+    rm -f /tmp/code-server.deb
+fi
+
+install -d -m 0700 /root/.config/code-server
+cat > /root/.config/code-server/config.yaml <<'YAML'
+# code-server listens on loopback only; the socket-activation proxy on :8080
+# is the sole reachable port and Caddy's forward_auth gates it, so auth=none
+# is safe here (same rationale as the host config).
+bind-addr: 127.0.0.1:8081
+auth: none
+cert: false
+app-name: Futrx IDE
+YAML
+chmod 0600 /root/.config/code-server/config.yaml
+
+cat > /etc/systemd/system/code-server.service <<'UNIT'
+[Unit]
+Description=code-server (VS Code in the browser) - on-demand
+StopWhenUnneeded=yes
+
+[Service]
+Type=exec
+Environment=VSCODE_RECONNECTION_GRACE_TIME=60000
+ExecStart=/usr/bin/code-server
+ExecStartPost=/usr/bin/bash -c 'for i in $(seq 1 50); do curl -fsS -o /dev/null http://127.0.0.1:8081/healthz && exit 0; sleep 0.2; done; exit 0'
+UNIT
+
+cat > /etc/systemd/system/code-server-proxy.service <<'UNIT'
+[Unit]
+Description=code-server on-demand proxy (idle-exits and releases the IDE)
+Requires=code-server.service
+After=code-server.service
+
+[Service]
+ExecStart=/usr/lib/systemd/systemd-socket-proxyd --exit-idle-time=20min 127.0.0.1:8081
+UNIT
+
+cat > /etc/systemd/system/code-server.socket <<'UNIT'
+[Unit]
+Description=code-server socket (on-demand activation)
+
+[Socket]
+ListenStream=0.0.0.0:8080
+Service=code-server-proxy.service
+
+[Install]
+WantedBy=sockets.target
+UNIT
+
+install -d -m 0755 /root/.local/share/code-server/User
+cat > /root/.local/share/code-server/User/settings.json <<'JSON'
+{
+  "telemetry.telemetryLevel": "off",
+  "git.openRepositoryInParentFolders": "always",
+  "security.workspace.trust.enabled": false
+}
+JSON
+
+# Pinned extensions, best-effort: a flaky Open VSX must never fail the build.
+for ext in \
+    anan.jetbrains-darcula-theme \
+    pkief.material-icon-theme \
+    golang.go \
+    dbcode.dbcode \
+    ; do
+    code-server --install-extension "$ext" >/dev/null 2>&1 || true
+done
+
+systemctl daemon-reload 2>/dev/null || true
+systemctl enable code-server.socket >/dev/null 2>&1 || true

--- a/backend/internal/transport/http/handlers/project_handler.go
+++ b/backend/internal/transport/http/handlers/project_handler.go
@@ -255,6 +255,11 @@ func (h *ProjectHandler) HandleResource(w http.ResponseWriter, r *http.Request) 
 
 var projectHostPattern = regexp.MustCompile(`^([a-z0-9][a-z0-9-]*)--(\d{4,5})\.dev\.remote\.futrx\.dev$`)
 
+// codeHostPattern matches the per-project IDE host <slug>.code.remote.futrx.dev
+// (no port segment). Used by HandleTLSAsk so Caddy's on-demand TLS will issue
+// certs for code subdomains of real projects only.
+var codeHostPattern = regexp.MustCompile(`^([a-z0-9][a-z0-9-]*)\.code\.remote\.futrx\.dev$`)
+
 func (h *ProjectHandler) HandleTLSAsk(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -265,17 +270,21 @@ func (h *ProjectHandler) HandleTLSAsk(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing domain", http.StatusBadRequest)
 		return
 	}
-	m := projectHostPattern.FindStringSubmatch(domain)
-	if m == nil {
-		http.Error(w, "host does not match <slug>--<port>.dev.remote.futrx.dev", http.StatusNotFound)
+	var slug string
+	if mm := projectHostPattern.FindStringSubmatch(domain); mm != nil {
+		slug = mm[1]
+		port, err := strconv.Atoi(mm[2])
+		if err != nil || port < 1024 || port > 65535 {
+			http.Error(w, "port out of range", http.StatusNotFound)
+			return
+		}
+	} else if mm := codeHostPattern.FindStringSubmatch(domain); mm != nil {
+		slug = mm[1]
+	} else {
+		http.Error(w, "host not a recognized project domain", http.StatusNotFound)
 		return
 	}
-	slug := m[1]
-	port, err := strconv.Atoi(m[2])
-	if err != nil || port < 1024 || port > 65535 {
-		http.Error(w, "port out of range", http.StatusNotFound)
-		return
-	}
+
 	if _, err := h.projects.GetBySlug(r.Context(), slug); err != nil {
 		http.Error(w, "no such project", http.StatusNotFound)
 		return

--- a/docs/per-container-code-server.md
+++ b/docs/per-container-code-server.md
@@ -1,0 +1,86 @@
+# Per-container code-server
+
+## Problem
+
+Today the platform runs a single code-server as **host root** at
+`code.<host>`. This has three sharp edges:
+
+1. **RAM stacks.** code-server keeps a VS Code server process alive per
+   connected workspace, and its default reconnection grace window is ~3h.
+   On a busy box every project the operator opens leaves a server resident
+   long after the tab is closed, so memory creeps up and never comes back
+   down until the host instance is restarted.
+2. **Wrong-uid git objects.** Because the host instance runs as uid 0 on the
+   *host*, any `git` operation it performs against a project's bind-mounted
+   workspace writes objects owned by host-root. Project containers are
+   idmapped (container-root is a high host uid), so those uid-0 objects land
+   inside the idmapped mount as an unmapped owner and the container's own
+   git refuses to touch them ("dubious ownership" / EPERM on pack files).
+3. **One blast radius.** A single shared IDE means one process with read/write
+   reach into *every* project's files at once.
+
+## Design (Option A: per-container code-server)
+
+Each project LXD container runs **its own** code-server, installed into the
+base image and reachable at `<slug>.code.<host>`. Inside the container the
+stack is fully socket-activated and scales to zero:
+
+- `code-server.socket` listens on `0.0.0.0:8080` (cheap; always armed).
+- `code-server-proxy.service` is `systemd-socket-proxyd` with
+  `--exit-idle-time=20min`, forwarding to `127.0.0.1:8081`. It `Requires=`
+  the real service, so the first connection pulls code-server up.
+- `code-server.service` is code-server itself, listening on loopback
+  `127.0.0.1:8081`, with `StopWhenUnneeded=yes` so it stops the moment the
+  proxy idle-exits.
+
+Net effect: a container with nobody connected runs only a listening socket
+(near-zero RAM); 20 minutes after the last IDE tab disconnects, the whole
+stack is gone. code-server runs as **container** root against the workspace,
+so git objects are written with the uid the container expects — fixing (2).
+Each project is isolated — fixing (3).
+
+### Routing
+
+`<slug>.code.<host>` is a new wildcard Caddy site (`*.code.${HOSTNAME}`). It
+sits behind the **same Google admin gate** (`forward_auth` →
+`/auth/verify`) as the existing `code.${HOSTNAME}` block, strips the
+platform's admin-session cookies before the request enters the container,
+and reverse-proxies to `<slug>.lxd:8080`. On-demand TLS is gated by the
+backend's `/internal/tls-ask`, now extended to also accept
+`<slug>.code.<host>` for real projects. `auth: none` inside the container is
+safe because :8080 is the only reachable port and Caddy gates it.
+
+## Files changed
+
+- `backend/internal/manager/containers/templates/code-server-up.sh` — new;
+  idempotent in-container install recipe (deb install, config, three systemd
+  units, settings, pinned extensions).
+- `backend/internal/manager/containers/code_server.go` — new;
+  `EnsureCodeServer` (migration path for pre-image containers), mirrors
+  `EnsureBrowserGUI`.
+- `backend/internal/manager/containers/baseimage.go` — bakes the recipe into
+  the base image after the browser-GUI layer.
+- `backend/internal/manager/containers/lifecycle.go` — best-effort
+  `EnsureCodeServer` on every `Launch`.
+- `backend/internal/transport/http/handlers/project_handler.go` — new
+  `codeHostPattern`; `HandleTLSAsk` accepts the dev-URL or code host.
+- `infra/templates/Caddyfile.tmpl` — new `*.code.${HOSTNAME}` block.
+
+## Validated
+
+- `go build ./...` and `go vet ./...`.
+- `bash -n code-server-up.sh` (shell syntax).
+- `caddy validate` on the rendered Caddyfile.
+- `systemd-analyze verify` on the three units.
+
+## NOT yet done (follow-ups)
+
+- **Base-image rebuild + live smoke test.** The recipe is baked by
+  `BuildBaseImage`, but the published image must actually be rebuilt and a
+  real container exercised end-to-end (cold connect pulls code-server up,
+  idle for 20 min tears it down).
+- **UI flip.** The frontend still links to the host `code.<host>` instance.
+  Pointing the UI at the per-container IDE means updating
+  `frontend/.../ideLinks.ts` and the backend `chat_handler.go` IDE-open
+  path, then **retiring the host code-server instance**. That is a separate
+  change once this one is verified live.

--- a/infra/templates/Caddyfile.tmpl
+++ b/infra/templates/Caddyfile.tmpl
@@ -43,6 +43,42 @@ code.${HOSTNAME} {
     reverse_proxy 127.0.0.1:${CODE_SERVER_PORT}
 }
 
+# Per-project IDE. <slug>.code.${HOSTNAME} proxies into the project's LXD
+# container at <slug>.lxd:${CODE_SERVER_PORT}, where an on-demand, idle-stopped
+# code-server lives (systemd socket activation inside the container). Same
+# Google admin gate as code.${HOSTNAME}; on-demand TLS is gated by the
+# backend's /internal/tls-ask, which now also allows <slug>.code.${HOSTNAME}.
+*.code.${HOSTNAME} {
+    encode zstd gzip
+    tls {
+        on_demand
+    }
+    forward_auth 127.0.0.1:${SERVICE_PORT} {
+        uri /auth/verify
+    }
+    @valid {
+        header_regexp host Host ^([a-z0-9][a-z0-9-]*)\.code\.${HOSTNAME_RE}$
+    }
+    handle @valid {
+        reverse_proxy {re.host.1}.lxd:${CODE_SERVER_PORT} {
+            # On-demand backend: don't pool idle upstream connections, so the
+            # in-container systemd-socket-proxyd sees zero open connections soon
+            # after the tab closes and can reach its --exit-idle-time to stop
+            # code-server.
+            transport http {
+                keepalive off
+            }
+            # Strip the platform's admin-session cookies before the request
+            # enters the container (same rationale as the dev-URL block): the
+            # forward_auth above already validated the session on loopback, and
+            # in-container code must never see a token replayable against
+            # code.${HOSTNAME}.
+            header_up Cookie `(?:^|;\s*)(?:remote_session|remote_oauth_state|return_to)=[^;]*` ""
+        }
+    }
+    respond "Use <slug>.code.${HOSTNAME}" 400
+}
+
 # Per-project dev URLs. <slug>--<port>.dev.${HOSTNAME} proxies into the
 # project's LXD container at <slug>.lxd:<port>. The .lxd resolution
 # depends on the systemd-resolved drop-in installed by infra/steps/01-host-deps.sh.


### PR DESCRIPTION
Move the IDE from a single host-root code-server toward one code-server per project container, started on demand and stopped after 20 min idle via systemd socket activation. Closed/idle windows then free their RAM reliably instead of stacking up across project switches, and the IDE runs as the container user rather than host uid 0 (which was writing root-owned git objects into the idmapped workspace mounts and breaking in-container git).

ADDITIVE and non-breaking: the existing host code-server and the current "Open IDE" URL are untouched. This lands the mechanism + routing so it can be smoke-tested on one container before the UI is flipped over.

Mechanism (all inside each container):
  code-server.socket         :8080, always armed (cheap)
  code-server-proxy.service  systemd-socket-proxyd --exit-idle-time=20min
  code-server.service        code-server on :8081, StopWhenUnneeded=yes

Changes:
- containers/templates/code-server-up.sh: in-container install recipe
- containers/code_server.go: //go:embed recipe + EnsureCodeServer() (idempotent migration for existing containers; mirrors EnsureBrowserGUI)
- BuildBaseImage: bake the recipe into futrx-remote-dev-base
- lifecycle.Launch: EnsureCodeServer on each project launch
- project_handler: /internal/tls-ask also allows <slug>.code.<host>
- Caddyfile.tmpl: *.code.<host> -> <slug>.lxd:8080 (forward_auth, on-demand TLS, cookie strip, keepalive off so idle-stop actually fires)
- docs/per-container-code-server.md: design + rollout + follow-ups

Validated: go build/vet, caddy validate, systemd-analyze verify, bash -n. Not yet done (follow-up): base-image rebuild + live smoke test; flip frontend ideLinks.ts + backend chat_handler IDE-open to the per-project URL; retire the host code-server.