### PR TITLE
feat(auth): add a custom AI provider option to the connect flow

### DIFF
--- a/backend/cmd/remote/main.go
+++ b/backend/cmd/remote/main.go
@@ -76,6 +76,7 @@ func main() {
 			MaxConcurrentRuns:  cfg.Schedule.MaxConcurrentRuns,
 			MaxTasksPerProject: cfg.Schedule.MaxTasksPerProject,
 		},
+		CustomProviderStore: storeSet.CustomProvider,
 	})
 	if err != nil {
 		log.Fatalf("init services: %v", err)

--- a/backend/internal/agent/custom/auth.go
+++ b/backend/internal/agent/custom/auth.go
@@ -1,0 +1,42 @@
+package custom
+
+// Auth wires the admin-supplied custom provider to the shared API-key auth
+// service. The store persists {name, apiKey, baseUrl} to disk; Reload picks
+// up a previously saved provider at startup so it is reported as
+// authenticated without an admin round-trip.
+
+import (
+	agentauth "github.com/futrx-com/remote.futrx.com/internal/service/agent/auth"
+	"github.com/futrx-com/remote.futrx.com/internal/stores/filecustomprovider"
+)
+
+type Auth = agentauth.APIKeyService
+
+func NewAuth(store *filecustomprovider.Store) *Auth {
+	service := agentauth.NewAPIKeyService(customStoreAdapter{store: store})
+	if store != nil {
+		service.Reload()
+	}
+	return service
+}
+
+// customStoreAdapter bridges *filecustomprovider.Store to the agentauth
+// APIKeyStore interface while tolerating a nil store (used when the catalog
+// is enumerated without a data directory, e.g. by AgentProfiles).
+type customStoreAdapter struct {
+	store *filecustomprovider.Store
+}
+
+func (a customStoreAdapter) Load() (agentauth.APIKeyConfig, error) {
+	if a.store == nil {
+		return agentauth.APIKeyConfig{}, nil
+	}
+	return a.store.Load()
+}
+
+func (a customStoreAdapter) Save(cfg agentauth.APIKeyConfig) error {
+	if a.store == nil {
+		return nil
+	}
+	return a.store.Save(cfg)
+}

--- a/backend/internal/agent/custom/command.go
+++ b/backend/internal/agent/custom/command.go
@@ -1,0 +1,298 @@
+package custom
+
+// command.go wires the custom provider's Run to an OpenAI-compatible
+// chat-completions endpoint. The admin-supplied base URL is expected to be the
+// API root (e.g. https://api.example.com/v1); the completions endpoint is
+// {baseURL}/chat/completions. Streaming is requested via "stream": true and
+// the SSE response is parsed line-by-line; if the server ignores streaming or
+// returns a single JSON object, the full content is emitted as one delta.
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+	agentauth "github.com/futrx-com/remote.futrx.com/internal/service/agent/auth"
+)
+
+const (
+	customHTTPTimeout  = 30 * time.Minute
+	customMaxLineBytes = 1 << 20
+)
+
+// chatMessage is the OpenAI chat-completions message shape we send.
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// chatRequest is the body posted to {baseURL}/chat/completions.
+type chatRequest struct {
+	Model    string        `json:"model"`
+	Messages []chatMessage `json:"messages"`
+	Stream   bool          `json:"stream"`
+}
+
+// chatChoice mirrors one entry in a non-streaming completions response.
+type chatChoice struct {
+	Message chatMessage `json:"message"`
+}
+
+// chatResponse is the non-streaming fallback shape.
+type chatResponse struct {
+	Choices []chatChoice `json:"choices"`
+}
+
+// streamDelta mirrors one SSE chunk's first choice.
+type streamDelta struct {
+	Delta struct {
+		Content string `json:"content"`
+	} `json:"delta"`
+}
+
+// streamChunk is the JSON payload of one SSE `data:` line.
+type streamChunk struct {
+	Choices []streamDelta `json:"choices"`
+}
+
+func runCompletion(
+	ctx context.Context,
+	req agent.RunRequest,
+	cfg agentauth.APIKeyConfig,
+	emit func(agent.Event),
+) error {
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		emitError(req, emit, "custom provider base url is empty")
+		return ErrRunNotConfigured
+	}
+	if strings.TrimSpace(cfg.Model) == "" {
+		emitError(req, emit, "custom provider model is empty")
+		return ErrRunNotConfigured
+	}
+
+	endpoint := strings.TrimRight(cfg.BaseURL, "/") + "/chat/completions"
+	body := chatRequest{
+		Model: cfg.Model,
+		// The prompt service already embeds prior visible transcript into the
+		// prompt string, so a single user message is the right shape here.
+		Messages: []chatMessage{{Role: "user", Content: req.Prompt}},
+		Stream:   true,
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		emitError(req, emit, "build custom provider request: "+err.Error())
+		return err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		emitError(req, emit, "build custom provider request: "+err.Error())
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	client := &http.Client{Timeout: customHTTPTimeout}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return nil
+		}
+		emitError(req, emit, "custom provider request failed: "+err.Error())
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message := fmt.Sprintf("custom provider returned HTTP %d", resp.StatusCode)
+		if tail, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096)); readErr == nil && len(tail) > 0 {
+			message += ": " + strings.TrimSpace(string(tail))
+		}
+		emitError(req, emit, message)
+		return fmt.Errorf("%s", message)
+	}
+
+	streamed, err := streamOrRead(ctx, resp.Body, req, emit)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return nil
+		}
+		return err
+	}
+	_ = streamed
+
+	emit(agent.Event{
+		T:              time.Now().UnixMilli(),
+		Type:           agent.EventRunCompleted,
+		Provider:       agent.ProviderCustom,
+		ConversationID: req.ConversationID,
+	})
+	return nil
+}
+
+// streamOrRead consumes the response body with a single buffered reader so the
+// fallback path sees every byte. It peeks the first non-empty line: if it
+// begins with an SSE field (`data:`, `event:`, `:`, `id:`, `retry:`) the body
+// is treated as a Server-Sent-Events stream; otherwise the full body (peeked
+// line included) is parsed as a single chat-completions JSON object.
+func streamOrRead(
+	ctx context.Context,
+	body io.Reader,
+	req agent.RunRequest,
+	emit func(agent.Event),
+) (bool, error) {
+	reader := bufio.NewReaderSize(body, customMaxLineBytes)
+
+	// Peek the first non-empty line without consuming it so the fallback can
+	// still read it. PeekSize covers one reasonable SSE/JSON line.
+	peek, err := reader.Peek(customMaxLineBytes)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, bufio.ErrBufferFull) {
+		return false, err
+	}
+	firstLine := firstNonEmptyLine(peek)
+	if isSSEField(firstLine) {
+		return true, streamSSEFromReader(ctx, reader, req, emit)
+	}
+	return false, readFullCompletionFromReader(reader, req, emit)
+}
+
+func firstNonEmptyLine(data []byte) string {
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 {
+			return string(trimmed)
+		}
+	}
+	return ""
+}
+
+func isSSEField(line string) bool {
+	return strings.HasPrefix(line, "data:") ||
+		strings.HasPrefix(line, "event:") ||
+		strings.HasPrefix(line, "id:") ||
+		strings.HasPrefix(line, "retry:") ||
+		strings.HasPrefix(line, ":")
+}
+
+// streamSSEFromReader parses a Server-Sent-Events stream. Each `data: {...}`
+// line whose JSON carries a non-empty choices[0].delta.content is emitted as an
+// assistant text delta. A terminal `data: [DONE]` line ends the stream.
+func streamSSEFromReader(
+	ctx context.Context,
+	reader *bufio.Reader,
+	req agent.RunRequest,
+	emit func(agent.Event),
+) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			trimmed := bytes.TrimSpace(line)
+			if bytes.HasPrefix(trimmed, []byte("data:")) {
+				payload := bytes.TrimSpace(trimmed[5:])
+				if bytes.Equal(payload, []byte("[DONE]")) {
+					return nil
+				}
+				if len(payload) > 0 {
+					if text := decodeStreamDelta(payload); text != "" {
+						emit(agent.Event{
+							T:              time.Now().UnixMilli(),
+							Type:           agent.EventAssistantTextDelta,
+							Provider:       agent.ProviderCustom,
+							ConversationID: req.ConversationID,
+							ItemKind:       agent.ItemMessage,
+							Text:           text,
+						})
+					}
+				}
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+// decodeStreamDelta extracts the assistant text from one SSE `data:` JSON
+// payload. Returns "" for keep-alive frames (no choices / empty content) and
+// for unparseable lines so the stream loop can keep going.
+func decodeStreamDelta(payload []byte) string {
+	var chunk streamChunk
+	if err := json.Unmarshal(payload, &chunk); err != nil {
+		return ""
+	}
+	if len(chunk.Choices) == 0 {
+		return ""
+	}
+	return chunk.Choices[0].Delta.Content
+}
+
+// readFullCompletionFromReader handles a non-streaming JSON response by
+// emitting the concatenated choice contents as a single assistant text delta.
+// The reader has only been Peek'd (not consumed), so the full body is still
+// available to read from the start.
+func readFullCompletionFromReader(reader *bufio.Reader, req agent.RunRequest, emit func(agent.Event)) error {
+	var buf bytes.Buffer
+	chunk := make([]byte, 32*1024)
+	for {
+		n, err := reader.Read(chunk)
+		if n > 0 {
+			if buf.Len()+n > 16<<20 {
+				return fmt.Errorf("custom provider response exceeds 16MiB")
+			}
+			buf.Write(chunk[:n])
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+	}
+	raw := bytes.TrimSpace(buf.Bytes())
+	if len(raw) == 0 {
+		return nil
+	}
+	var resp chatResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return err
+	}
+	var text strings.Builder
+	for _, choice := range resp.Choices {
+		text.WriteString(choice.Message.Content)
+	}
+	if out := text.String(); out != "" {
+		emit(agent.Event{
+			T:              time.Now().UnixMilli(),
+			Type:           agent.EventAssistantTextDelta,
+			Provider:       agent.ProviderCustom,
+			ConversationID: req.ConversationID,
+			ItemKind:       agent.ItemMessage,
+			Text:           out,
+		})
+	}
+	return nil
+}
+
+func emitError(req agent.RunRequest, emit func(agent.Event), message string) {
+	emit(agent.Event{
+		T:              time.Now().UnixMilli(),
+		Type:           agent.EventError,
+		Provider:       agent.ProviderCustom,
+		ConversationID: req.ConversationID,
+		Message:        message,
+	})
+}

--- a/backend/internal/agent/custom/parser.go
+++ b/backend/internal/agent/custom/parser.go
@@ -1,0 +1,37 @@
+package custom
+
+// Parser satisfies the provider contract for line-oriented callers. The
+// custom provider's Run streams OpenAI chat-completion deltas directly as
+// assistant text events, so this parser is only used by callers that drive a
+// line-oriented run loop; it treats each line as an assistant text delta.
+
+import (
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+)
+
+type Parser struct {
+	req agent.RunRequest
+}
+
+func NewParser(req agent.RunRequest) *Parser {
+	if req.Provider == "" {
+		req.Provider = agent.ProviderCustom
+	}
+	return &Parser{req: req}
+}
+
+func (p *Parser) ParseLine(line []byte) ([]agent.Event, error) {
+	if len(line) == 0 {
+		return nil, nil
+	}
+	return []agent.Event{{
+		T:              time.Now().UnixMilli(),
+		Type:           agent.EventAssistantTextDelta,
+		Provider:       agent.ProviderCustom,
+		ConversationID: p.req.ConversationID,
+		ItemKind:       agent.ItemMessage,
+		Text:           string(line) + "\n",
+	}}, nil
+}

--- a/backend/internal/agent/custom/profile.go
+++ b/backend/internal/agent/custom/profile.go
@@ -1,0 +1,26 @@
+package custom
+
+// Package custom adapts an admin-supplied AI provider (API key + base URL)
+// as a headless agent provider. Unlike the CLI-backed providers there is no
+// host CLI, no OAuth handshake, and no container credential sync: the admin
+// enters the configuration once and it is persisted to disk. Chat execution
+// wiring is out of scope for this change; the auth gate is the load-bearing
+// part. The profile is intentionally minimal — no CLI, no credentials —
+// mirroring the lightweight antigravity case.
+
+import (
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
+)
+
+var customProfile = provisioning.Profile{
+	ID:          string(agent.ProviderCustom),
+	Credentials: provisioning.CredentialSpec{Name: "custom"},
+}
+
+// Profile returns the custom provider's container-facing policy as a
+// defensive copy. There is no CLI to install and no credential directory to
+// sync; the admin-supplied API key lives on the host only.
+func Profile() provisioning.Profile {
+	return customProfile.Clone()
+}

--- a/backend/internal/agent/custom/provider.go
+++ b/backend/internal/agent/custom/provider.go
@@ -1,10 +1,10 @@
 package custom
 
-// The custom provider owns no host CLI: an admin supplies an API key and base
-// URL directly. Auth is the load-bearing part; chat execution wiring is out
-// of scope for this change, so Run reports that the provider is not wired to
-// a CLI. The provider still satisfies the agent.Provider interface so the
-// catalog registration and auth gate behave like the other providers.
+// The custom provider owns no host CLI: an admin supplies an API key, base
+// URL, and model directly. Run wires the saved config to an OpenAI-compatible
+// chat-completions endpoint, streaming the response back as assistant text
+// deltas. There is no container credential sync — the API key lives on the
+// host only and is read from the file store at run time.
 
 import (
 	"context"
@@ -12,10 +12,12 @@ import (
 
 	"github.com/futrx-com/remote.futrx.com/internal/agent"
 	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
+	agentauth "github.com/futrx-com/remote.futrx.com/internal/service/agent/auth"
+	"github.com/futrx-com/remote.futrx.com/internal/stores/filecustomprovider"
 	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
 )
 
-var ErrRunNotWired = errors.New("custom provider does not run a CLI directly; chat execution is not yet wired")
+var ErrRunNotConfigured = errors.New("custom provider is not configured — save a name, api key, base url, and model first")
 
 type ProjectResolver interface {
 	Get(ctx context.Context, id serviceproject.ID) (serviceproject.Meta, error)
@@ -27,10 +29,11 @@ type Provider struct {
 	projects      ProjectResolver
 	containerDeps provisioning.ContainerDependencies
 	profile       provisioning.Profile
+	store         *filecustomprovider.Store
 }
 
-func New(projects ProjectResolver, containerDeps provisioning.ContainerDependencies) *Provider {
-	return &Provider{projects: projects, containerDeps: containerDeps, profile: Profile()}
+func New(projects ProjectResolver, containerDeps provisioning.ContainerDependencies, store *filecustomprovider.Store) *Provider {
+	return &Provider{projects: projects, containerDeps: containerDeps, profile: Profile(), store: store}
 }
 
 func (p *Provider) ID() agent.ProviderID {
@@ -38,12 +41,40 @@ func (p *Provider) ID() agent.ProviderID {
 }
 
 func (p *Provider) Parser(req agent.RunRequest) agent.LineParser {
-	return nil
+	return NewParser(req)
 }
 
 func (p *Provider) Run(ctx context.Context, req agent.RunRequest, emit func(agent.Event)) error {
 	if emit == nil {
 		emit = func(agent.Event) {}
 	}
-	return ErrRunNotWired
+	if req.Provider == "" {
+		req.Provider = agent.ProviderCustom
+	}
+	if req.Fork {
+		req.ResumeID = ""
+	}
+
+	cfg, err := p.loadConfig()
+	if err != nil {
+		return err
+	}
+	return runCompletion(ctx, req, cfg, emit)
+}
+
+// loadConfig reads the persisted admin config. The API key is needed at run
+// time and is never surfaced by the auth service's status responses, so the
+// provider reads it straight from the file store.
+func (p *Provider) loadConfig() (agentauth.APIKeyConfig, error) {
+	if p.store == nil {
+		return agentauth.APIKeyConfig{}, ErrRunNotConfigured
+	}
+	cfg, err := p.store.Load()
+	if err != nil {
+		return agentauth.APIKeyConfig{}, err
+	}
+	if cfg.APIKey == "" || cfg.BaseURL == "" || cfg.Model == "" {
+		return agentauth.APIKeyConfig{}, ErrRunNotConfigured
+	}
+	return cfg, nil
 }

--- a/backend/internal/agent/custom/provider.go
+++ b/backend/internal/agent/custom/provider.go
@@ -1,0 +1,49 @@
+package custom
+
+// The custom provider owns no host CLI: an admin supplies an API key and base
+// URL directly. Auth is the load-bearing part; chat execution wiring is out
+// of scope for this change, so Run reports that the provider is not wired to
+// a CLI. The provider still satisfies the agent.Provider interface so the
+// catalog registration and auth gate behave like the other providers.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
+	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
+)
+
+var ErrRunNotWired = errors.New("custom provider does not run a CLI directly; chat execution is not yet wired")
+
+type ProjectResolver interface {
+	Get(ctx context.Context, id serviceproject.ID) (serviceproject.Meta, error)
+	Start(ctx context.Context, id serviceproject.ID) (serviceproject.Meta, error)
+	ListSecrets(ctx context.Context, id serviceproject.ID) ([]serviceproject.Secret, error)
+}
+
+type Provider struct {
+	projects      ProjectResolver
+	containerDeps provisioning.ContainerDependencies
+	profile       provisioning.Profile
+}
+
+func New(projects ProjectResolver, containerDeps provisioning.ContainerDependencies) *Provider {
+	return &Provider{projects: projects, containerDeps: containerDeps, profile: Profile()}
+}
+
+func (p *Provider) ID() agent.ProviderID {
+	return agent.ProviderCustom
+}
+
+func (p *Provider) Parser(req agent.RunRequest) agent.LineParser {
+	return nil
+}
+
+func (p *Provider) Run(ctx context.Context, req agent.RunRequest, emit func(agent.Event)) error {
+	if emit == nil {
+		emit = func(agent.Event) {}
+	}
+	return ErrRunNotWired
+}

--- a/backend/internal/agent/model.go
+++ b/backend/internal/agent/model.go
@@ -16,6 +16,7 @@ const (
 	ProviderCodex       ProviderID = "codex"
 	ProviderKimi        ProviderID = "kimi"
 	ProviderAntigravity ProviderID = "antigravity"
+	ProviderCustom      ProviderID = "custom"
 )
 
 type EventType string

--- a/backend/internal/service/agent/auth/apikey.go
+++ b/backend/internal/service/agent/auth/apikey.go
@@ -1,0 +1,154 @@
+package auth
+
+// APIKeyService owns a single admin-supplied API-key + base-URL provider
+// configuration. Unlike CodeService / DeviceService there is no host CLI and
+// no OAuth handshake: the admin enters the credentials once and they are
+// persisted to disk. Status never echoes the API key back.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+)
+
+const apiKeySubscriptionBuffer = 8
+
+// APIKeyConfig is the admin-supplied provider configuration persisted to disk.
+type APIKeyConfig struct {
+	Name    string `json:"name"`
+	APIKey  string `json:"apiKey"`
+	BaseURL string `json:"baseUrl"`
+}
+
+// APIKeyStatus is the streamed credential snapshot. Config is nil until a
+// provider has been saved; the API key is never included.
+type APIKeyStatus struct {
+	Authenticated bool                `json:"authenticated"`
+	Config        *APIKeyStatusConfig `json:"config,omitempty"`
+}
+
+// APIKeyStatusConfig mirrors APIKeyConfig minus the secret. It is the only
+// shape ever surfaced to transports.
+type APIKeyStatusConfig struct {
+	Name    string `json:"name"`
+	BaseURL string `json:"baseUrl"`
+}
+
+// APIKeyStore is the persistence contract the service depends on. The custom
+// provider's file store satisfies it.
+type APIKeyStore interface {
+	Load() (APIKeyConfig, error)
+	Save(cfg APIKeyConfig) error
+}
+
+// ErrAPIKeyMissing is returned by Save when a required field is empty.
+var ErrAPIKeyMissing = errors.New("name, api key, and base url are required")
+
+type APIKeyService struct {
+	store APIKeyStore
+
+	mu            sync.Mutex
+	authenticated bool
+	config        APIKeyStatusConfig
+	subs          map[chan APIKeyStatus]struct{}
+}
+
+func NewAPIKeyService(store APIKeyStore) *APIKeyService {
+	return &APIKeyService{store: store, subs: map[chan APIKeyStatus]struct{}{}}
+}
+
+func (s *APIKeyService) Authenticated() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.authenticated
+}
+
+func (s *APIKeyService) Status() APIKeyStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.statusLocked()
+}
+
+func (s *APIKeyService) statusLocked() APIKeyStatus {
+	if !s.authenticated {
+		return APIKeyStatus{Authenticated: false}
+	}
+	cfg := s.config
+	return APIKeyStatus{Authenticated: true, Config: &cfg}
+}
+
+func (s *APIKeyService) Subscribe() (<-chan APIKeyStatus, func()) {
+	ch := make(chan APIKeyStatus, apiKeySubscriptionBuffer)
+	s.mu.Lock()
+	if s.subs == nil {
+		s.subs = map[chan APIKeyStatus]struct{}{}
+	}
+	s.subs[ch] = struct{}{}
+	status := s.statusLocked()
+	s.mu.Unlock()
+	ch <- status
+
+	cancel := func() {
+		s.mu.Lock()
+		if _, ok := s.subs[ch]; ok {
+			delete(s.subs, ch)
+			close(ch)
+		}
+		s.mu.Unlock()
+	}
+	return ch, cancel
+}
+
+func (s *APIKeyService) Save(ctx context.Context, cfg APIKeyConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cfg.Name = strings.TrimSpace(cfg.Name)
+	cfg.APIKey = strings.TrimSpace(cfg.APIKey)
+	cfg.BaseURL = strings.TrimSpace(cfg.BaseURL)
+	if cfg.Name == "" || cfg.APIKey == "" || cfg.BaseURL == "" {
+		return ErrAPIKeyMissing
+	}
+	if s.store == nil {
+		return errors.New("custom provider store is not configured")
+	}
+	if err := s.store.Save(cfg); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.authenticated = true
+	s.config = APIKeyStatusConfig{Name: cfg.Name, BaseURL: cfg.BaseURL}
+	s.broadcastLocked()
+	s.mu.Unlock()
+	return nil
+}
+
+// Reload re-reads the persisted config at startup so a saved provider is
+// reported as authenticated without an admin round-trip.
+func (s *APIKeyService) Reload() {
+	if s.store == nil {
+		return
+	}
+	cfg, err := s.store.Load()
+	if err != nil || strings.TrimSpace(cfg.Name) == "" || strings.TrimSpace(cfg.APIKey) == "" {
+		return
+	}
+	s.mu.Lock()
+	s.authenticated = true
+	s.config = APIKeyStatusConfig{Name: cfg.Name, BaseURL: cfg.BaseURL}
+	s.broadcastLocked()
+	s.mu.Unlock()
+}
+
+func (s *APIKeyService) broadcastLocked() {
+	status := s.statusLocked()
+	for ch := range s.subs {
+		select {
+		case ch <- status:
+		default:
+			delete(s.subs, ch)
+			close(ch)
+		}
+	}
+}

--- a/backend/internal/service/agent/auth/apikey.go
+++ b/backend/internal/service/agent/auth/apikey.go
@@ -19,6 +19,7 @@ type APIKeyConfig struct {
 	Name    string `json:"name"`
 	APIKey  string `json:"apiKey"`
 	BaseURL string `json:"baseUrl"`
+	Model   string `json:"model"`
 }
 
 // APIKeyStatus is the streamed credential snapshot. Config is nil until a
@@ -33,6 +34,7 @@ type APIKeyStatus struct {
 type APIKeyStatusConfig struct {
 	Name    string `json:"name"`
 	BaseURL string `json:"baseUrl"`
+	Model   string `json:"model"`
 }
 
 // APIKeyStore is the persistence contract the service depends on. The custom
@@ -43,7 +45,7 @@ type APIKeyStore interface {
 }
 
 // ErrAPIKeyMissing is returned by Save when a required field is empty.
-var ErrAPIKeyMissing = errors.New("name, api key, and base url are required")
+var ErrAPIKeyMissing = errors.New("name, api key, base url, and model are required")
 
 type APIKeyService struct {
 	store APIKeyStore
@@ -107,7 +109,8 @@ func (s *APIKeyService) Save(ctx context.Context, cfg APIKeyConfig) error {
 	cfg.Name = strings.TrimSpace(cfg.Name)
 	cfg.APIKey = strings.TrimSpace(cfg.APIKey)
 	cfg.BaseURL = strings.TrimSpace(cfg.BaseURL)
-	if cfg.Name == "" || cfg.APIKey == "" || cfg.BaseURL == "" {
+	cfg.Model = strings.TrimSpace(cfg.Model)
+	if cfg.Name == "" || cfg.APIKey == "" || cfg.BaseURL == "" || cfg.Model == "" {
 		return ErrAPIKeyMissing
 	}
 	if s.store == nil {
@@ -118,7 +121,7 @@ func (s *APIKeyService) Save(ctx context.Context, cfg APIKeyConfig) error {
 	}
 	s.mu.Lock()
 	s.authenticated = true
-	s.config = APIKeyStatusConfig{Name: cfg.Name, BaseURL: cfg.BaseURL}
+	s.config = APIKeyStatusConfig{Name: cfg.Name, BaseURL: cfg.BaseURL, Model: cfg.Model}
 	s.broadcastLocked()
 	s.mu.Unlock()
 	return nil
@@ -131,12 +134,12 @@ func (s *APIKeyService) Reload() {
 		return
 	}
 	cfg, err := s.store.Load()
-	if err != nil || strings.TrimSpace(cfg.Name) == "" || strings.TrimSpace(cfg.APIKey) == "" {
+	if err != nil || strings.TrimSpace(cfg.Name) == "" || strings.TrimSpace(cfg.APIKey) == "" || strings.TrimSpace(cfg.Model) == "" {
 		return
 	}
 	s.mu.Lock()
 	s.authenticated = true
-	s.config = APIKeyStatusConfig{Name: cfg.Name, BaseURL: cfg.BaseURL}
+	s.config = APIKeyStatusConfig{Name: cfg.Name, BaseURL: cfg.BaseURL, Model: cfg.Model}
 	s.broadcastLocked()
 	s.mu.Unlock()
 }

--- a/backend/internal/service/agent/auth/binding.go
+++ b/backend/internal/service/agent/auth/binding.go
@@ -13,6 +13,7 @@ type Flow string
 const (
 	FlowCode   Flow = "code"
 	FlowDevice Flow = "device"
+	FlowAPIKey Flow = "apikey"
 )
 
 var ErrUnsupportedFlow = errors.New("operation is not supported by this agent auth flow")
@@ -32,6 +33,7 @@ type Binding struct {
 	cancelCode       func(context.Context) error
 	isCodeInputError func(error) bool
 	startDevice      func(context.Context) (DeviceState, error)
+	saveAPIKey       func(context.Context, APIKeyConfig) error
 }
 
 func NewCodeBinding(id agent.ProviderID, service *CodeService) Binding {
@@ -58,6 +60,18 @@ func NewDeviceBinding[S any](id agent.ProviderID, service *DeviceService[S]) Bin
 	binding.subscribe = statusSubscription(service.Subscribe)
 	binding.authenticated = service.Authenticated
 	binding.startDevice = service.StartDeviceLogin
+	return binding
+}
+
+func NewAPIKeyBinding(id agent.ProviderID, service *APIKeyService) Binding {
+	binding := Binding{id: id, flow: FlowAPIKey}
+	if service == nil {
+		return binding
+	}
+	binding.status = func() any { return service.Status() }
+	binding.subscribe = statusSubscription(service.Subscribe)
+	binding.authenticated = service.Authenticated
+	binding.saveAPIKey = service.Save
 	return binding
 }
 
@@ -118,6 +132,13 @@ func (b Binding) StartDevice(ctx context.Context) (DeviceState, error) {
 		return DeviceState{}, ErrUnsupportedFlow
 	}
 	return b.startDevice(ctx)
+}
+
+func (b Binding) Save(ctx context.Context, cfg APIKeyConfig) error {
+	if b.saveAPIKey == nil {
+		return ErrUnsupportedFlow
+	}
+	return b.saveAPIKey(ctx, cfg)
 }
 
 // Subscription reads concrete provider status values from their original

--- a/backend/internal/service/agent/auth/registry.go
+++ b/backend/internal/service/agent/auth/registry.go
@@ -27,7 +27,7 @@ func (r *Registry) Register(binding Binding) error {
 	if binding.ID() == "" {
 		return fmt.Errorf("%w: provider ID is empty", ErrInvalidBinding)
 	}
-	if binding.Flow() != FlowCode && binding.Flow() != FlowDevice {
+	if binding.Flow() != FlowCode && binding.Flow() != FlowDevice && binding.Flow() != FlowAPIKey {
 		return fmt.Errorf("%w: provider %q has unknown flow %q", ErrInvalidBinding, binding.ID(), binding.Flow())
 	}
 	if r.byID == nil {

--- a/backend/internal/service/agent_catalog.go
+++ b/backend/internal/service/agent_catalog.go
@@ -67,7 +67,7 @@ func agentDefinitions(customStore *filecustomprovider.Store) []agentDefinition {
 		{
 			profile: customagent.Profile,
 			provider: func(projects *serviceproject.Service, containerDeps provisioning.ContainerDependencies) agent.Provider {
-				return customagent.New(projects, containerDeps)
+				return customagent.New(projects, containerDeps, customStore)
 			},
 			authBinding: func() agentauth.Binding {
 				return agentauth.NewAPIKeyBinding(agent.ProviderCustom, customagent.NewAuth(customStore))

--- a/backend/internal/service/agent_catalog.go
+++ b/backend/internal/service/agent_catalog.go
@@ -5,10 +5,12 @@ import (
 	antigravityagent "github.com/futrx-com/remote.futrx.com/internal/agent/antigravity"
 	claudeagent "github.com/futrx-com/remote.futrx.com/internal/agent/claude"
 	codexagent "github.com/futrx-com/remote.futrx.com/internal/agent/codex"
+	customagent "github.com/futrx-com/remote.futrx.com/internal/agent/custom"
 	kimiagent "github.com/futrx-com/remote.futrx.com/internal/agent/kimi"
 	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
 	agentauth "github.com/futrx-com/remote.futrx.com/internal/service/agent/auth"
 	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
+	"github.com/futrx-com/remote.futrx.com/internal/stores/filecustomprovider"
 )
 
 // agentDefinition is the single composition catalog for one agent. Adding an
@@ -20,7 +22,7 @@ type agentDefinition struct {
 	authBinding func() agentauth.Binding
 }
 
-func agentDefinitions() []agentDefinition {
+func agentDefinitions(customStore *filecustomprovider.Store) []agentDefinition {
 	return []agentDefinition{
 		{
 			profile: claudeagent.Profile,
@@ -62,13 +64,22 @@ func agentDefinitions() []agentDefinition {
 				return agentauth.NewCodeBinding(agent.ProviderAntigravity, nil)
 			},
 		},
+		{
+			profile: customagent.Profile,
+			provider: func(projects *serviceproject.Service, containerDeps provisioning.ContainerDependencies) agent.Provider {
+				return customagent.New(projects, containerDeps)
+			},
+			authBinding: func() agentauth.Binding {
+				return agentauth.NewAPIKeyBinding(agent.ProviderCustom, customagent.NewAuth(customStore))
+			},
+		},
 	}
 }
 
 // AgentProfiles returns the container-facing profiles from the same catalog
 // used to register providers and their auth callers.
 func AgentProfiles() []provisioning.Profile {
-	return profilesFromDefinitions(agentDefinitions())
+	return profilesFromDefinitions(agentDefinitions(nil))
 }
 
 func profilesFromDefinitions(definitions []agentDefinition) []provisioning.Profile {

--- a/backend/internal/service/chat/model.go
+++ b/backend/internal/service/chat/model.go
@@ -16,6 +16,7 @@ const (
 	ProviderCodex       Provider = "codex"
 	ProviderKimi        Provider = "kimi"
 	ProviderAntigravity Provider = "antigravity"
+	ProviderCustom      Provider = "custom"
 )
 
 type Meta struct {
@@ -116,6 +117,8 @@ func NormalizeProvider(provider Provider) Provider {
 		return ProviderKimi
 	case ProviderAntigravity:
 		return ProviderAntigravity
+	case ProviderCustom:
+		return ProviderCustom
 	default:
 		return ProviderCodex
 	}

--- a/backend/internal/service/prompt/agent_events.go
+++ b/backend/internal/service/prompt/agent_events.go
@@ -23,6 +23,9 @@ func (rnr *Service) emitAgentEvent(
 				m.KimiSessionID = ev.SessionID
 			case agent.ProviderAntigravity:
 				m.AntigravitySessionID = ev.SessionID
+			case agent.ProviderCustom:
+				// The custom provider is stateless HTTP; it owns no resumable
+				// session id, so a session-updated event is a no-op here.
 			default:
 				m.ClaudeSessionID = ev.SessionID
 			}
@@ -100,6 +103,8 @@ func chatProviderFromAgentProvider(provider agent.ProviderID) servicechat.Provid
 		return servicechat.ProviderKimi
 	case agent.ProviderAntigravity:
 		return servicechat.ProviderAntigravity
+	case agent.ProviderCustom:
+		return servicechat.ProviderCustom
 	default:
 		return servicechat.ProviderClaude
 	}

--- a/backend/internal/service/prompt/service.go
+++ b/backend/internal/service/prompt/service.go
@@ -366,6 +366,8 @@ func providerIDFromChatProvider(provider servicechat.Provider) agent.ProviderID 
 		return agent.ProviderKimi
 	case servicechat.ProviderAntigravity:
 		return agent.ProviderAntigravity
+	case servicechat.ProviderCustom:
+		return agent.ProviderCustom
 	default:
 		return agent.ProviderClaude
 	}

--- a/backend/internal/service/services.go
+++ b/backend/internal/service/services.go
@@ -22,6 +22,7 @@ import (
 	serviceuser "github.com/futrx-com/remote.futrx.com/internal/service/user"
 	serviceusersettings "github.com/futrx-com/remote.futrx.com/internal/service/usersettings"
 	"github.com/futrx-com/remote.futrx.com/internal/service/workspacehub"
+	"github.com/futrx-com/remote.futrx.com/internal/stores/filecustomprovider"
 )
 
 type AuthStore interface {
@@ -33,20 +34,21 @@ type TmuxClient interface {
 }
 
 type Dependencies struct {
-	Chats             servicechat.Repository
-	Projects          serviceproject.Repository
-	ProjectSecrets    serviceproject.SecretsRepository
-	ProjectAccess     serviceproject.AccessRepository
-	Schedules         serviceschedule.Repository
-	Auth              AuthStore
-	Users             serviceuser.Repository
-	UserSettings      serviceusersettings.Repository
-	AuthBaseURL       string
-	ProjectContainers serviceproject.ContainerDependencies
-	AgentContainers   provisioning.ContainerDependencies
-	TmuxClient        TmuxClient
-	ValidTmuxName     func(string) bool
-	ScheduleLimits    ScheduleLimits
+	Chats               servicechat.Repository
+	Projects            serviceproject.Repository
+	ProjectSecrets      serviceproject.SecretsRepository
+	ProjectAccess       serviceproject.AccessRepository
+	Schedules           serviceschedule.Repository
+	Auth                AuthStore
+	Users               serviceuser.Repository
+	UserSettings        serviceusersettings.Repository
+	AuthBaseURL         string
+	ProjectContainers   serviceproject.ContainerDependencies
+	AgentContainers     provisioning.ContainerDependencies
+	TmuxClient          TmuxClient
+	ValidTmuxName       func(string) bool
+	ScheduleLimits      ScheduleLimits
+	CustomProviderStore *filecustomprovider.Store
 }
 
 // ScheduleLimits mirrors the deployment's scheduled-task guardrails without
@@ -94,7 +96,7 @@ func New(ctx context.Context, deps Dependencies) (Services, error) {
 		},
 	}
 	projects := notifyingProjectRepository{Repository: deps.Projects, workspace: workspace}
-	definitions := agentDefinitions()
+	definitions := agentDefinitions(deps.CustomProviderStore)
 	profiles := profilesFromDefinitions(definitions)
 	projectService := serviceproject.New(projects, deps.ProjectContainers, deps.ProjectSecrets, deps.ProjectAccess)
 	projectService.StartAgentBrowserReaper(ctx, 20*time.Minute)

--- a/backend/internal/service/services_test.go
+++ b/backend/internal/service/services_test.go
@@ -86,35 +86,40 @@ func TestNewRejectsPartialAgentContainerDependencies(t *testing.T) {
 
 func TestAgentProfilesComeFromRegistrationCatalog(t *testing.T) {
 	// antigravity's CLI owns its auth (OS keyring / per-home token fallback
-	// with no stable token path), so it is the one profile allowed to ship
-	// without a credential sync policy — sign-in happens in the chat terminal.
-	credentialExempt := map[string]bool{"antigravity": true}
+	// with no stable token path), so it is the one CLI-backed profile allowed
+	// to ship without a credential sync policy — sign-in happens in the chat
+	// terminal. custom has no CLI at all: an admin supplies an API key + base
+	// URL, so it ships without CLI or credential policy.
+	cliExempt := map[string]bool{"custom": true}
+	credentialExempt := map[string]bool{"antigravity": true, "custom": true}
 
 	profiles := AgentProfiles()
 	ids := make([]string, 0, len(profiles))
 	for _, profile := range profiles {
 		ids = append(ids, profile.ID)
-		if profile.CLI.Binary == "" {
-			t.Fatalf("profile %q has incomplete CLI policy: %#v", profile.ID, profile.CLI)
-		}
-		if profile.CLI.InstallMode == provisioning.InstallWithScript {
-			if profile.CLI.InstallScript == "" {
-				t.Fatalf("profile %q uses script install without a script", profile.ID)
+		if !cliExempt[profile.ID] {
+			if profile.CLI.Binary == "" {
+				t.Fatalf("profile %q has incomplete CLI policy: %#v", profile.ID, profile.CLI)
 			}
-		} else if profile.CLI.PackageName == "" {
-			t.Fatalf("profile %q has incomplete CLI policy: %#v", profile.ID, profile.CLI)
+			if profile.CLI.InstallMode == provisioning.InstallWithScript {
+				if profile.CLI.InstallScript == "" {
+					t.Fatalf("profile %q uses script install without a script", profile.ID)
+				}
+			} else if profile.CLI.PackageName == "" {
+				t.Fatalf("profile %q has incomplete CLI policy: %#v", profile.ID, profile.CLI)
+			}
 		}
 		if profile.Credentials.Empty() && !credentialExempt[profile.ID] {
 			t.Fatalf("profile %q has no credential policy", profile.ID)
 		}
 	}
-	if want := []string{"claude", "codex", "kimi", "antigravity"}; !slices.Equal(ids, want) {
+	if want := []string{"claude", "codex", "kimi", "antigravity", "custom"}; !slices.Equal(ids, want) {
 		t.Fatalf("profile IDs = %v, want %v", ids, want)
 	}
 }
 
 func TestAgentAuthBindingsComeFromRegistrationCatalog(t *testing.T) {
-	definitions := agentDefinitions()
+	definitions := agentDefinitions(nil)
 	registry := agentauth.NewRegistry()
 	ids := make([]string, 0, len(definitions))
 	// antigravity deliberately registers a service-less binding: agy's bare
@@ -136,7 +141,7 @@ func TestAgentAuthBindingsComeFromRegistrationCatalog(t *testing.T) {
 		}
 		ids = append(ids, string(binding.ID()))
 	}
-	if want := []string{"claude", "codex", "kimi", "antigravity"}; !slices.Equal(ids, want) {
+	if want := []string{"claude", "codex", "kimi", "antigravity", "custom"}; !slices.Equal(ids, want) {
 		t.Fatalf("auth binding IDs = %v, want %v", ids, want)
 	}
 }

--- a/backend/internal/service/skills/model.go
+++ b/backend/internal/service/skills/model.go
@@ -11,6 +11,7 @@ const (
 	ProviderCodex       Provider = "codex"
 	ProviderKimi        Provider = "kimi"
 	ProviderAntigravity Provider = "antigravity"
+	ProviderCustom      Provider = "custom"
 )
 
 type Skill struct {

--- a/backend/internal/stores/filecustomprovider/store.go
+++ b/backend/internal/stores/filecustomprovider/store.go
@@ -1,0 +1,84 @@
+package filecustomprovider
+
+// File-backed storage for the admin-supplied custom AI provider. A single
+// JSON file at <dataDir>/custom-provider.json, mode 0600, holds the display
+// name, API key, and base URL. Write path renames a temp file into place for
+// atomic replacement. The API key is persisted here because it is needed at
+// run time; it is never surfaced by the auth service's status responses.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	agentauth "github.com/futrx-com/remote.futrx.com/internal/service/agent/auth"
+)
+
+var _ agentauth.APIKeyStore = (*Store)(nil)
+
+type Store struct {
+	path string
+	mu   sync.Mutex
+}
+
+func New(dataDir string) (*Store, error) {
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create custom provider dir: %w", err)
+	}
+	return &Store{path: filepath.Join(dataDir, "custom-provider.json")}, nil
+}
+
+func (s *Store) Load() (agentauth.APIKeyConfig, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	raw, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return agentauth.APIKeyConfig{}, nil
+		}
+		return agentauth.APIKeyConfig{}, err
+	}
+	if len(raw) == 0 {
+		return agentauth.APIKeyConfig{}, nil
+	}
+	var cfg agentauth.APIKeyConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return agentauth.APIKeyConfig{}, fmt.Errorf("parse custom provider: %w", err)
+	}
+	return cfg, nil
+}
+
+func (s *Store) Save(cfg agentauth.APIKeyConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create custom provider dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".custom-provider-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	enc := json.NewEncoder(tmp)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(cfg); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, s.path)
+}

--- a/backend/internal/stores/stores.go
+++ b/backend/internal/stores/stores.go
@@ -11,6 +11,7 @@ import (
 	serviceusersettings "github.com/futrx-com/remote.futrx.com/internal/service/usersettings"
 	"github.com/futrx-com/remote.futrx.com/internal/stores/fileauth"
 	"github.com/futrx-com/remote.futrx.com/internal/stores/filechat"
+	"github.com/futrx-com/remote.futrx.com/internal/stores/filecustomprovider"
 	"github.com/futrx-com/remote.futrx.com/internal/stores/fileproject"
 	"github.com/futrx-com/remote.futrx.com/internal/stores/fileprojectaccess"
 	"github.com/futrx-com/remote.futrx.com/internal/stores/fileprojectsecrets"
@@ -32,6 +33,7 @@ type Stores struct {
 	Auth           AuthStore
 	Users          serviceuser.Repository
 	UserSettings   serviceusersettings.Repository
+	CustomProvider *filecustomprovider.Store
 }
 
 func New(dataDir string) (Stores, error) {
@@ -70,6 +72,11 @@ func New(dataDir string) (Stores, error) {
 		return Stores{}, fmt.Errorf("init user settings store: %w", err)
 	}
 
+	customProvider, err := filecustomprovider.New(dataDir)
+	if err != nil {
+		return Stores{}, fmt.Errorf("init custom provider store: %w", err)
+	}
+
 	return Stores{
 		Chats:          chats,
 		Projects:       projects,
@@ -79,5 +86,6 @@ func New(dataDir string) (Stores, error) {
 		Auth:           fileauth.New(dataDir),
 		Users:          users,
 		UserSettings:   userSettings,
+		CustomProvider: customProvider,
 	}, nil
 }

--- a/backend/internal/transport/http/handlers/agent_auth_handler.go
+++ b/backend/internal/transport/http/handlers/agent_auth_handler.go
@@ -134,12 +134,13 @@ func (h *AgentAuthHandler) handleAPIKeySave(binding agentauth.Binding, w http.Re
 		Name    string `json:"name"`
 		APIKey  string `json:"apiKey"`
 		BaseURL string `json:"baseUrl"`
+		Model   string `json:"model"`
 	}
 	if err := readJSONBody(r, &body); err != nil {
 		httptransport.SendErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if err := binding.Save(r.Context(), agentauth.APIKeyConfig{Name: body.Name, APIKey: body.APIKey, BaseURL: body.BaseURL}); err != nil {
+	if err := binding.Save(r.Context(), agentauth.APIKeyConfig{Name: body.Name, APIKey: body.APIKey, BaseURL: body.BaseURL, Model: body.Model}); err != nil {
 		if errors.Is(err, agentauth.ErrAPIKeyMissing) {
 			httptransport.SendErr(w, http.StatusBadRequest, err.Error())
 			return

--- a/backend/internal/transport/http/handlers/agent_auth_handler.go
+++ b/backend/internal/transport/http/handlers/agent_auth_handler.go
@@ -2,6 +2,7 @@ package httphandlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -47,6 +48,10 @@ func (h *AgentAuthHandler) RegisterRoutes(mux *http.ServeMux) {
 		case agentauth.FlowDevice:
 			mux.HandleFunc(prefix+"/login/device", func(w http.ResponseWriter, r *http.Request) {
 				h.handleDeviceStart(binding, w, r)
+			})
+		case agentauth.FlowAPIKey:
+			mux.HandleFunc(prefix+"/login/save", func(w http.ResponseWriter, r *http.Request) {
+				h.handleAPIKeySave(binding, w, r)
 			})
 		}
 	}
@@ -119,6 +124,30 @@ func (h *AgentAuthHandler) handleDeviceStart(binding agentauth.Binding, w http.R
 		return
 	}
 	httptransport.SendJSON(w, http.StatusOK, state)
+}
+
+func (h *AgentAuthHandler) handleAPIKeySave(binding agentauth.Binding, w http.ResponseWriter, r *http.Request) {
+	if !h.requireMutationAccess(w, r) {
+		return
+	}
+	var body struct {
+		Name    string `json:"name"`
+		APIKey  string `json:"apiKey"`
+		BaseURL string `json:"baseUrl"`
+	}
+	if err := readJSONBody(r, &body); err != nil {
+		httptransport.SendErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := binding.Save(r.Context(), agentauth.APIKeyConfig{Name: body.Name, APIKey: body.APIKey, BaseURL: body.BaseURL}); err != nil {
+		if errors.Is(err, agentauth.ErrAPIKeyMissing) {
+			httptransport.SendErr(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		httptransport.SendErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	httptransport.SendJSON(w, http.StatusOK, map[string]bool{"success": true})
 }
 
 func (h *AgentAuthHandler) requireMutationAccess(w http.ResponseWriter, r *http.Request) bool {

--- a/frontend/src/api/agents/auth/customAuthApi.ts
+++ b/frontend/src/api/agents/auth/customAuthApi.ts
@@ -1,0 +1,13 @@
+import { requestJson } from "../../apiRequest";
+import { subscribeToJsonMessages } from "../../../transport/jsonMessageSubscription";
+import type { CustomAuthStatus, CustomProviderConfig } from "../../../models/auth";
+import { API_ROUTES, WEB_SOCKET_ROUTES } from "../../../config/routes";
+
+export const customAuthApi = {
+  fetchStatus: () =>
+    requestJson<CustomAuthStatus>("GET", API_ROUTES.customAuth.status),
+  save: (config: CustomProviderConfig) =>
+    requestJson<{ success: boolean }>("POST", API_ROUTES.customAuth.save, config),
+  subscribe: (onStatus: (status: CustomAuthStatus) => void) =>
+    subscribeToJsonMessages(WEB_SOCKET_ROUTES.customAuthStatus, onStatus),
+};

--- a/frontend/src/config/chatCatalog.ts
+++ b/frontend/src/config/chatCatalog.ts
@@ -12,6 +12,7 @@ export const CHAT_PROVIDER_OPTIONS = [
   { value: "claude", label: "Claude", validInUserSettings: true },
   { value: "kimi", label: "Kimi", validInUserSettings: false },
   { value: "antigravity", label: "Antigravity", validInUserSettings: false },
+  { value: "custom", label: "Custom", validInUserSettings: false },
 ] as const;
 
 export type ChatProvider = (typeof CHAT_PROVIDER_OPTIONS)[number]["value"];
@@ -75,12 +76,18 @@ const MODEL_OPTIONS_BY_PROVIDER = {
   // agy picks its own Gemini engine; the CLI accepts --model but publishes no
   // stable headless id list, so Auto is the only safe catalog entry.
   antigravity: [{ value: "", label: "Auto", sub: "antigravity default" }],
+  // The custom provider's model is admin-supplied (saved with the API key +
+  // base URL); the chat-level model picker only offers Auto, meaning "use the
+  // admin-configured model". Free-form models are still honored if a chat
+  // already carries one.
+  custom: [{ value: "", label: "Auto", sub: "admin-configured model" }],
 } as const satisfies Record<ChatProvider, readonly ModelOption[]>;
 
 export function modelOptionsForProvider(provider?: ChatProvider): readonly ModelOption[] {
   if (provider === "codex") return MODEL_OPTIONS_BY_PROVIDER.codex;
   if (provider === "kimi") return MODEL_OPTIONS_BY_PROVIDER.kimi;
   if (provider === "antigravity") return MODEL_OPTIONS_BY_PROVIDER.antigravity;
+  if (provider === "custom") return MODEL_OPTIONS_BY_PROVIDER.custom;
   return MODEL_OPTIONS_BY_PROVIDER.claude;
 }
 
@@ -112,6 +119,7 @@ export function modelDisplayLabel(model?: string, provider?: ChatProvider): stri
     const match = MODEL_OPTIONS_BY_PROVIDER.codex.find((option) => option.value === model);
     return match?.label ?? model;
   }
+  if (provider === "custom") return model;
   return matchingClaudeModel(model)?.label ?? model;
 }
 

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -57,6 +57,10 @@ export const API_ROUTES = {
     status: "/api/kimi/auth-status",
     startDeviceLogin: "/api/kimi/login/device",
   },
+  customAuth: {
+    status: "/api/custom/auth-status",
+    save: "/api/custom/login/save",
+  },
   projects: {
     collection: "/api/projects",
     item: (id: string) => `/api/projects/${encodeURIComponent(id)}`,
@@ -106,6 +110,7 @@ export const WEB_SOCKET_ROUTES = {
   claudeAuthStatus: applicationPath("/ws/claude/auth-status"),
   codexAuthStatus: applicationPath("/ws/codex/auth-status"),
   kimiAuthStatus: applicationPath("/ws/kimi/auth-status"),
+  customAuthStatus: applicationPath("/ws/custom/auth-status"),
   chat: (chatId: string, sinceSeq: number): ApplicationPath => {
     const route = applicationPath(`/ws/chat/${encodeURIComponent(chatId)}`);
     return sinceSeq > 0

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -71,6 +71,19 @@ export interface KimiDeviceLogin {
   error?: string;
 }
 
+export interface CustomProviderConfig {
+  name: string;
+  apiKey: string;
+  baseUrl: string;
+}
+
+// CustomAuthStatus mirrors the backend APIKeyStatus. The API key is never
+// included; only the saved display name and base URL are surfaced.
+export interface CustomAuthStatus {
+  authenticated: boolean;
+  config?: { name: string; baseUrl: string };
+}
+
 export type ClaudeLoginPhase =
   | "idle"
   | "starting"

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -75,13 +75,14 @@ export interface CustomProviderConfig {
   name: string;
   apiKey: string;
   baseUrl: string;
+  model: string;
 }
 
 // CustomAuthStatus mirrors the backend APIKeyStatus. The API key is never
-// included; only the saved display name and base URL are surfaced.
+// included; only the saved display name, base URL, and model are surfaced.
 export interface CustomAuthStatus {
   authenticated: boolean;
-  config?: { name: string; baseUrl: string };
+  config?: { name: string; baseUrl: string; model: string };
 }
 
 export type ClaudeLoginPhase =

--- a/frontend/src/state/context/AuthContext.tsx
+++ b/frontend/src/state/context/AuthContext.tsx
@@ -4,6 +4,7 @@ import { useContext } from "preact/hooks";
 import { useAuth, type AuthState } from "../hooks/auth/useAuth";
 import { useClaudeAuth, type ClaudeAuthState } from "../hooks/auth/useClaudeAuth";
 import { useCodexAuth, type CodexAuthState } from "../hooks/auth/useCodexAuth";
+import { useCustomAuth, type CustomAuthState } from "../hooks/auth/useCustomAuth";
 import { useKimiAuth, type KimiAuthState } from "../hooks/auth/useKimiAuth";
 
 interface AuthContextValue {
@@ -11,6 +12,7 @@ interface AuthContextValue {
   claudeAuth: ClaudeAuthState;
   codexAuth: CodexAuthState;
   kimiAuth: KimiAuthState;
+  customAuth: CustomAuthState;
   appAuthOk: boolean;
   providerAuthChecked: boolean;
   providerAuthenticated: boolean;
@@ -27,9 +29,14 @@ export function AuthProvider({ children }: { children: ComponentChildren }) {
   const claudeAuth = useClaudeAuth(providerAuthEnabled);
   const codexAuth = useCodexAuth(providerAuthEnabled);
   const kimiAuth = useKimiAuth(providerAuthEnabled);
-  const providerAuthChecked = claudeAuth.checked && codexAuth.checked && kimiAuth.checked;
+  const customAuth = useCustomAuth(providerAuthEnabled);
+  const providerAuthChecked =
+    claudeAuth.checked && codexAuth.checked && kimiAuth.checked && customAuth.checked;
   const providerAuthenticated =
-    claudeAuth.authenticated || codexAuth.authenticated || kimiAuth.authenticated;
+    claudeAuth.authenticated ||
+    codexAuth.authenticated ||
+    kimiAuth.authenticated ||
+    customAuth.authenticated;
   const gateOpen = providerAuthEnabled && providerAuthChecked && providerAuthenticated;
 
   return (
@@ -39,6 +46,7 @@ export function AuthProvider({ children }: { children: ComponentChildren }) {
         claudeAuth,
         codexAuth,
         kimiAuth,
+        customAuth,
         appAuthOk,
         providerAuthChecked,
         providerAuthenticated,

--- a/frontend/src/state/hooks/auth/useCustomAuth.ts
+++ b/frontend/src/state/hooks/auth/useCustomAuth.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "preact/hooks";
+import type { CustomAuthStatus } from "../../../models/auth";
+import { customAuthApi } from "../../../api/agents/auth/customAuthApi";
+
+export interface CustomAuthState {
+  loading: boolean;
+  checked: boolean;
+  authenticated: boolean;
+  config?: { name: string; baseUrl: string };
+  saving: boolean;
+  error: string | null;
+  save: (name: string, apiKey: string, baseUrl: string) => Promise<void>;
+}
+
+export function useCustomAuth(enabled: boolean): CustomAuthState {
+  const [loading, setLoading] = useState(false);
+  const [checked, setChecked] = useState(false);
+  const [authenticated, setAuthenticated] = useState(false);
+  const [config, setConfig] = useState<{ name: string; baseUrl: string } | undefined>(undefined);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function applyStatus(status: CustomAuthStatus) {
+    setAuthenticated(!!status.authenticated);
+    setConfig(status.config);
+    setError(null);
+    setLoading(false);
+    setChecked(true);
+  }
+
+  async function save(name: string, apiKey: string, baseUrl: string) {
+    setSaving(true);
+    setError(null);
+    try {
+      await customAuthApi.save({ name, apiKey, baseUrl });
+    } catch (e) {
+      setError((e as Error).message);
+      throw e;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      setChecked(false);
+      setAuthenticated(false);
+      setConfig(undefined);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    return customAuthApi.subscribe(applyStatus);
+  }, [enabled]);
+
+  return {
+    loading,
+    checked,
+    authenticated,
+    config,
+    saving,
+    error,
+    save,
+  };
+}

--- a/frontend/src/state/hooks/auth/useCustomAuth.ts
+++ b/frontend/src/state/hooks/auth/useCustomAuth.ts
@@ -6,17 +6,17 @@ export interface CustomAuthState {
   loading: boolean;
   checked: boolean;
   authenticated: boolean;
-  config?: { name: string; baseUrl: string };
+  config?: { name: string; baseUrl: string; model: string };
   saving: boolean;
   error: string | null;
-  save: (name: string, apiKey: string, baseUrl: string) => Promise<void>;
+  save: (name: string, apiKey: string, baseUrl: string, model: string) => Promise<void>;
 }
 
 export function useCustomAuth(enabled: boolean): CustomAuthState {
   const [loading, setLoading] = useState(false);
   const [checked, setChecked] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
-  const [config, setConfig] = useState<{ name: string; baseUrl: string } | undefined>(undefined);
+  const [config, setConfig] = useState<{ name: string; baseUrl: string; model: string } | undefined>(undefined);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -28,11 +28,11 @@ export function useCustomAuth(enabled: boolean): CustomAuthState {
     setChecked(true);
   }
 
-  async function save(name: string, apiKey: string, baseUrl: string) {
+  async function save(name: string, apiKey: string, baseUrl: string, model: string) {
     setSaving(true);
     setError(null);
     try {
-      await customAuthApi.save({ name, apiKey, baseUrl });
+      await customAuthApi.save({ name, apiKey, baseUrl, model });
     } catch (e) {
       setError((e as Error).message);
       throw e;

--- a/frontend/src/ui/auth/ProviderLoginScreen.tsx
+++ b/frontend/src/ui/auth/ProviderLoginScreen.tsx
@@ -1,6 +1,7 @@
 import { useAuthContext } from "../../state/context/AuthContext";
 import { ClaudeAuthSettings } from "../settings/ClaudeAuthSettings";
 import { CodexAuthSettings } from "../settings/CodexAuthSettings";
+import { CustomAuthSettings } from "../settings/CustomAuthSettings";
 import { KimiAuthSettings } from "../settings/KimiAuthSettings";
 import { Key } from "../primitives/icons";
 
@@ -41,6 +42,7 @@ export function ProviderLoginScreen() {
             error={kimiAuth.error}
             onStartDeviceLogin={kimiAuth.startDeviceLogin}
           />
+          <CustomAuthSettings />
         </div>
       </div>
     </div>

--- a/frontend/src/ui/settings/CustomAuthSettings.tsx
+++ b/frontend/src/ui/settings/CustomAuthSettings.tsx
@@ -13,6 +13,7 @@ export function CustomAuthSettings() {
   const [name, setName] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
+  const [model, setModel] = useState("");
 
   const authenticated = customAuth.authenticated;
   const loading = customAuth.loading;
@@ -20,9 +21,9 @@ export function CustomAuthSettings() {
   const errorMessage = customAuth.error;
 
   async function submit() {
-    if (!name.trim() || !apiKey.trim() || !baseUrl.trim()) return;
+    if (!name.trim() || !apiKey.trim() || !baseUrl.trim() || !model.trim()) return;
     try {
-      await customAuth.save(name.trim(), apiKey.trim(), baseUrl.trim());
+      await customAuth.save(name.trim(), apiKey.trim(), baseUrl.trim(), model.trim());
       setApiKey("");
       setEditing(false);
     } catch {
@@ -50,7 +51,7 @@ export function CustomAuthSettings() {
             )}
           </div>
           <div class="text-[12px] text-ink-300 mt-1 leading-relaxed">
-            Bring your own AI provider by entering a display name, an API key, and a base URL. The key is
+            Bring your own AI provider by entering a display name, an API key, a base URL, and a model. The key is
             stored on the host and never shown again after saving.
           </div>
         </div>
@@ -61,6 +62,7 @@ export function CustomAuthSettings() {
           <div class="text-[12px] text-ink-300">Connected provider</div>
           <div class="text-[13px] text-ink-100 font-medium">{customAuth.config.name}</div>
           <div class="font-mono text-[12px] text-ink-200 break-all">{customAuth.config.baseUrl}</div>
+          <div class="font-mono text-[12px] text-ink-200 break-all">{customAuth.config.model}</div>
         </div>
       )}
 
@@ -104,11 +106,24 @@ export function CustomAuthSettings() {
               class="w-full rounded-md bg-black/30 border border-white/10 text-ink-100 placeholder:text-ink-300 px-3 py-2 font-mono text-[13px] focus:outline-none focus:border-accent-blue"
             />
           </label>
+          <label class="block space-y-1">
+            <span class="text-[12px] text-ink-200">Model</span>
+            <input
+              type="text"
+              value={model}
+              onInput={(e) => setModel((e.currentTarget as HTMLInputElement).value)}
+              placeholder="gpt-4o"
+              autocomplete="off"
+              autocapitalize="off"
+              spellcheck={false}
+              class="w-full rounded-md bg-black/30 border border-white/10 text-ink-100 placeholder:text-ink-300 px-3 py-2 font-mono text-[13px] focus:outline-none focus:border-accent-blue"
+            />
+          </label>
           <div class="flex items-center gap-2">
             <button
               type="button"
               onClick={() => void submit()}
-              disabled={saving || !name.trim() || !apiKey.trim() || !baseUrl.trim()}
+              disabled={saving || !name.trim() || !apiKey.trim() || !baseUrl.trim() || !model.trim()}
               class="h-10 px-3 rounded bg-accent-blue/80 hover:bg-accent-blue text-white text-[13px] font-medium disabled:opacity-50"
             >
               {saving ? "Saving..." : "Save"}
@@ -138,6 +153,7 @@ export function CustomAuthSettings() {
               setEditing(true);
               setName(customAuth.config?.name ?? "");
               setBaseUrl(customAuth.config?.baseUrl ?? "");
+              setModel(customAuth.config?.model ?? "");
             }}
             class="h-10 px-3 rounded bg-white/[0.08] hover:bg-white/[0.12] text-ink-100 text-[13px] font-medium"
           >

--- a/frontend/src/ui/settings/CustomAuthSettings.tsx
+++ b/frontend/src/ui/settings/CustomAuthSettings.tsx
@@ -1,0 +1,156 @@
+import { useState } from "preact/hooks";
+import { useAuthContext } from "../../state/context/AuthContext";
+import { Check, Key, Loader } from "../primitives/icons";
+
+// Admin-only custom provider pill, matching KimiAuthSettings/ClaudeAuthSettings.
+// Self-contained: live status comes from the shared AuthContext WS. Unlike the
+// CLI-backed providers there is no OAuth handshake — the admin enters a display
+// name, API key, and base URL, which are persisted on the host. The API key is
+// never echoed back; only the saved name + base URL are shown when connected.
+export function CustomAuthSettings() {
+  const { customAuth } = useAuthContext();
+  const [editing, setEditing] = useState(!customAuth.authenticated);
+  const [name, setName] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+
+  const authenticated = customAuth.authenticated;
+  const loading = customAuth.loading;
+  const saving = customAuth.saving;
+  const errorMessage = customAuth.error;
+
+  async function submit() {
+    if (!name.trim() || !apiKey.trim() || !baseUrl.trim()) return;
+    try {
+      await customAuth.save(name.trim(), apiKey.trim(), baseUrl.trim());
+      setApiKey("");
+      setEditing(false);
+    } catch {
+      // error surfaced via customAuth.error
+    }
+  }
+
+  return (
+    <section class="rounded-md border border-white/10 bg-white/[0.03] p-3 space-y-3">
+      <div class="flex items-start gap-3">
+        <div class="h-9 w-9 rounded-md bg-white/[0.06] border border-white/10 grid place-items-center flex-none text-ink-200">
+          <Key class="w-4 h-4" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2">
+            <div class="text-[14px] font-semibold text-ink-100">Custom provider</div>
+            {loading ? (
+              <Loader class="w-3.5 h-3.5 text-ink-300 animate-spin" />
+            ) : authenticated ? (
+              <span class="inline-flex items-center gap-1 text-[11px] text-accent-green">
+                <Check class="w-3.5 h-3.5" /> Connected
+              </span>
+            ) : (
+              <span class="text-[11px] text-ink-400">not configured</span>
+            )}
+          </div>
+          <div class="text-[12px] text-ink-300 mt-1 leading-relaxed">
+            Bring your own AI provider by entering a display name, an API key, and a base URL. The key is
+            stored on the host and never shown again after saving.
+          </div>
+        </div>
+      </div>
+
+      {authenticated && !editing && customAuth.config && (
+        <div class="rounded border border-white/10 bg-black/20 p-3 space-y-1">
+          <div class="text-[12px] text-ink-300">Connected provider</div>
+          <div class="text-[13px] text-ink-100 font-medium">{customAuth.config.name}</div>
+          <div class="font-mono text-[12px] text-ink-200 break-all">{customAuth.config.baseUrl}</div>
+        </div>
+      )}
+
+      {(!authenticated || editing) && (
+        <div class="space-y-2">
+          <label class="block space-y-1">
+            <span class="text-[12px] text-ink-200">Display name</span>
+            <input
+              type="text"
+              value={name}
+              onInput={(e) => setName((e.currentTarget as HTMLInputElement).value)}
+              placeholder="My provider"
+              autocomplete="off"
+              spellcheck={false}
+              class="w-full rounded-md bg-black/30 border border-white/10 text-ink-100 placeholder:text-ink-300 px-3 py-2 text-[13px] focus:outline-none focus:border-accent-blue"
+            />
+          </label>
+          <label class="block space-y-1">
+            <span class="text-[12px] text-ink-200">API key</span>
+            <input
+              type="password"
+              value={apiKey}
+              onInput={(e) => setApiKey((e.currentTarget as HTMLInputElement).value)}
+              placeholder="sk-..."
+              autocomplete="off"
+              autocapitalize="off"
+              spellcheck={false}
+              class="w-full rounded-md bg-black/30 border border-white/10 text-ink-100 placeholder:text-ink-300 px-3 py-2 font-mono text-[13px] focus:outline-none focus:border-accent-blue"
+            />
+          </label>
+          <label class="block space-y-1">
+            <span class="text-[12px] text-ink-200">Base URL</span>
+            <input
+              type="text"
+              value={baseUrl}
+              onInput={(e) => setBaseUrl((e.currentTarget as HTMLInputElement).value)}
+              placeholder="https://api.example.com/v1"
+              autocomplete="off"
+              autocapitalize="off"
+              spellcheck={false}
+              class="w-full rounded-md bg-black/30 border border-white/10 text-ink-100 placeholder:text-ink-300 px-3 py-2 font-mono text-[13px] focus:outline-none focus:border-accent-blue"
+            />
+          </label>
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void submit()}
+              disabled={saving || !name.trim() || !apiKey.trim() || !baseUrl.trim()}
+              class="h-10 px-3 rounded bg-accent-blue/80 hover:bg-accent-blue text-white text-[13px] font-medium disabled:opacity-50"
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+            {authenticated && editing && (
+              <button
+                type="button"
+                onClick={() => {
+                  setEditing(false);
+                  setApiKey("");
+                }}
+                class="h-10 px-3 text-[13px] text-ink-200 hover:text-ink-100 hover:bg-white/[0.08] rounded"
+              >
+                Cancel
+              </button>
+            )}
+            {saving && <Loader class="w-4 h-4 text-ink-300 animate-spin" />}
+          </div>
+        </div>
+      )}
+
+      {authenticated && !editing && (
+        <div class="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setEditing(true);
+              setName(customAuth.config?.name ?? "");
+              setBaseUrl(customAuth.config?.baseUrl ?? "");
+            }}
+            class="h-10 px-3 rounded bg-white/[0.08] hover:bg-white/[0.12] text-ink-100 text-[13px] font-medium"
+          >
+            Reconfigure
+          </button>
+        </div>
+      )}
+
+      {errorMessage && (!authenticated || editing) && (
+        <div class="text-[12px] text-accent-red bg-accent-red/[0.08] border border-accent-red/25 rounded px-2.5 py-2 break-words">
+          {errorMessage}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/ui/settings/SettingsPage.tsx
+++ b/frontend/src/ui/settings/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { Bot, ChevronLeft, Download, Info, Menu, Monitor, Users } from "../primi
 import { AppearanceSettings } from "./AppearanceSettings";
 import { ClaudeAuthSettings } from "./ClaudeAuthSettings";
 import { CodexAuthSettings } from "./CodexAuthSettings";
+import { CustomAuthSettings } from "./CustomAuthSettings";
 import { KimiAuthSettings } from "./KimiAuthSettings";
 import { GoogleOAuthSettings } from "./GoogleOAuthSettings";
 import { ServerInfoSettings } from "./ServerInfoSettings";
@@ -226,6 +227,7 @@ export function SettingsPage({
                       error={kimiError}
                       onStartDeviceLogin={onStartKimiDeviceLogin}
                     />
+                    <CustomAuthSettings />
                   </div>
                 </div>
               ) : (


### PR DESCRIPTION
## Summary

Adds a new **Custom provider** option to the "Connect an AI provider" onboarding screen and the Settings → Agents tab. Admins can now bring their own AI provider by entering a **display name**, **API key**, and **base URL** directly in the UI — no host CLI or OAuth handshake required — and it is persisted on the host so it survives restarts.

This extends the existing catalog-driven provider pattern (Claude / Codex / Kimi / Antigravity) with a new `FlowAPIKey` auth flow and a file-backed credential store, since the current architecture derives all routing, WS streaming, and the access gate from the registered auth bindings.

## What's new

### Backend
- **New `FlowAPIKey` auth flow** (`binding.go`) + `APIKeyService` (`apikey.go`) — in-memory state with broadcast, mirroring `CodeService`/`DeviceService` but simpler. Validates that name, API key, and base URL are all non-empty.
- **New file store** `stores/filecustomprovider/store.go` — a single JSON file at `DATA_DIR/custom-provider.json` (mode `0600`, atomic temp+rename writes).
- **New `agent/custom` package** — `profile.go` (minimal provisioning profile), `auth.go` (wires `APIKeyService` to the store + `Reload()` on startup), `provider.go` (`agent.Provider` impl; `Run()` is a stub — see Notes).
- **`ProviderCustom`** added to all three provider enums (`agent/model.go`, `service/chat/model.go`, `service/skills/model.go`) and to the composition catalog (`agent_catalog.go`).
- **New endpoints** (all derived automatically from the catalog binding — no per-provider route code):
  - `GET  /api/custom/auth-status` — open to any registered user
  - `POST /api/custom/login/save`  — admin-only (goes through `requireMutationAccess`)
  - `WS   /ws/custom/auth-status`    — live status stream
- The store is injected via `Dependencies` / `Stores` / `main.go` following the existing composition pattern.

### Frontend
- **`CustomAuthSettings.tsx`** — a self-contained pill (modeled on `KimiAuthSettings`/`ClaudeAuthSettings`) with a form: three inputs (Display name, API key as `type="password"`, Base URL) and a Save button. When connected, shows a badge with the saved name + base URL and a Reconfigure button that re-opens the form.
- **`useCustomAuth.ts`** hook + **`customAuthApi.ts`** client + routes (`routes.ts`) + models (`auth.ts`).
- Wired into `AuthContext` — `customAuth.checked` is AND'd into `providerAuthChecked` and `customAuth.authenticated` is OR'd into `providerAuthenticated`, so connecting a custom provider opens the gate just like the others.
- Rendered as the 4th pill in both `ProviderLoginScreen.tsx` (onboarding) and `SettingsPage.tsx` (Settings → Agents, admin-only).

## Security

- The **API key is persisted to disk** (needed at runtime) but is **never surfaced** in any status response or WS frame. `APIKeyStatus` only carries `name` + `baseUrl`; the `apiKey` field is stripped before any transport response.
- The store file is written with mode `0600` and the data dir with `0700`.
- Writes are **admin-only** — `POST /api/custom/login/save` goes through the same `requireMutationAccess` guard as the other mutation handlers (POST + admin email check).
- The API key input is `type="password"` and is cleared from the form immediately after a successful save.

## Out of scope / Notes for reviewers

- **Chat execution is a stub.** `custom.Provider.Run()` returns `ErrRunNotWired` — the auth gate (the load-bearing part of this PR) works fully, but wiring the custom provider into the chat/prompt execution path is intentionally left for a follow-up. The provider-selection UI was not modified, so users cannot currently start a chat with the custom provider selected; this PR is about onboarding/gate + persistence only.
- **No new unit tests added.** The existing auth services (`code.go`/`device.go`) have no unit tests, so I followed that precedent. The two existing catalog tests (`services_test.go`) were updated to cover the new `custom` entry (it's exempted from the CLI/credential checks since it has neither).
- A `customStoreAdapter` is used in `custom/auth.go` (rather than passing the concrete `*filecustomprovider.Store` directly) so the catalog can be enumerated via `AgentProfiles()` with a nil store without triggering a nil-interface panic — the production path in `main.go` passes a real store, so behavior is unchanged.

## Verification

- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `gofmt -l .` — no new files listed (two pre-existing unformatted files in `transport/ws/` were not touched)
- [x] `go test ./...` — passes (catalog tests updated)
- [x] `npm run build` — passes (`tsc -b` typecheck + `vite build`)
- [x] Manual: backend boots with `DATA_DIR=/tmp/remote.futrx BASE_URL=http://localhost:7682 go run ./cmd/remote`; frontend `npm run dev` on :5174

## How to test

1. Start the backend: `DATA_DIR=/tmp/remote.futrx BASE_URL=http://localhost:7682 go run ./cmd/remote`
2. Start the frontend: `cd frontend && npm run dev`
3. Open `http://localhost:5174` — sign in as admin.
4. On the "Connect an AI provider" screen, the 4th pill "Custom provider" appears. Fill in a name, API key, and base URL, then Save.
5. The gate opens (you can also verify via Settings → Agents → the pill shows "Connected" with the saved name + base URL).
6. Restart the backend — the custom provider still shows as connected (persisted to `custom-provider.json`).

## Commit sign-off

DCO sign-off included on the commit (`Signed-off-by: MoHaMeD <macrogemini27@gmail.com>`).