### PR TITLE
feat(projects): stack templates (blank, wordpress, laravel, node, python)

### DIFF
--- a/backend/cmd/build-template-image/main.go
+++ b/backend/cmd/build-template-image/main.go
@@ -1,0 +1,174 @@
+// build-template-image publishes a dedicated LXD image for one project
+// template — the optional FAST PATH described in
+// docs/02-workspaces/08-project-templates.md.
+//
+// Without a template image, a project created from e.g. the WordPress template
+// launches from futrx-remote-dev-base and installs PHP, MariaDB, and WP-CLI
+// inside its own container on first start (minutes on a small host). With one,
+// the lifecycle launches straight from futrx-remote-<template>-base and the
+// provisioning is already baked in.
+//
+// Usage:
+//
+//	go run ./cmd/build-template-image -template wordpress
+//	go run ./cmd/build-template-image -template wordpress -overwrite
+//	go run ./cmd/build-template-image -list
+//
+// Publishing compresses the whole rootfs and regularly exceeds the default
+// 5-minute budget on a 1 vCPU box, so the publish (and build) budgets are
+// overridable:
+//
+//	go run ./cmd/build-template-image -template wordpress -publish-timeout 30m
+//	FUTRX_IMAGE_PUBLISH_TIMEOUT=30m go run ./cmd/build-template-image -template wordpress
+//
+// The base image must already be published; run cmd/build-base-image first.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/config"
+	"github.com/futrx-com/remote.futrx.com/internal/integration/lxc"
+	"github.com/futrx-com/remote.futrx.com/internal/service"
+	serviceimage "github.com/futrx-com/remote.futrx.com/internal/service/container/image"
+	servicetemplates "github.com/futrx-com/remote.futrx.com/internal/service/container/templates"
+)
+
+const (
+	publishTimeoutEnv = "FUTRX_IMAGE_PUBLISH_TIMEOUT"
+	buildTimeoutEnv   = "FUTRX_IMAGE_BUILD_TIMEOUT"
+)
+
+func main() {
+	templateName := flag.String("template", "", "template to build an image for (see -list)")
+	alias := flag.String("alias", "", "image alias to publish under (default futrx-remote-<template>-base)")
+	base := flag.String("base", serviceimage.Alias, "image the builder container starts from")
+	overwrite := flag.Bool("overwrite", false, "delete any existing image at the alias before publishing")
+	list := flag.Bool("list", false, "list the templates that can be built into an image and exit")
+	publishTimeout := flag.Duration(
+		"publish-timeout", 0,
+		"override the publish budget (env "+publishTimeoutEnv+"); publishing is slow on small hosts",
+	)
+	buildTimeout := flag.Duration(
+		"build-timeout", 0,
+		"override the provisioning budget (env "+buildTimeoutEnv+")",
+	)
+	flag.Parse()
+
+	log.SetFlags(log.Ltime)
+	catalog := servicetemplates.MustLoad()
+
+	if *list {
+		printTemplates(catalog)
+		return
+	}
+	if *templateName == "" {
+		fmt.Fprintln(os.Stderr, "-template is required")
+		printTemplates(catalog)
+		os.Exit(2)
+	}
+	template, ok := catalog.Get(*templateName)
+	if !ok {
+		log.Fatalf("unknown template %q; run with -list to see the available templates", *templateName)
+	}
+	program := servicetemplates.ProvisionProgram(template)
+	if program == "" {
+		log.Fatalf("template %q installs nothing, so it has no image to build", template.Name)
+	}
+	target := *alias
+	if target == "" {
+		target = servicetemplates.ImageAlias(template.Name)
+	}
+	if !template.PrebuiltImage {
+		log.Printf(
+			"note: template %q does not declare prebuiltImage, so the runtime will not "+
+				"look for %q; set prebuiltImage in its template.json to use this image",
+			template.Name, target,
+		)
+	}
+
+	lxcClient := lxc.New()
+	if !lxcClient.Available() {
+		log.Fatalf("lxc CLI not found on PATH - install LXD on the host first")
+	}
+	containerStack := config.NewContainerStack(
+		lxcClient,
+		service.AgentProfiles(),
+		config.ContainerStackOptions{
+			ImageBuildProgress: newLogBuildProgressReporter(log.Default()),
+		},
+	)
+	containerStack.Images.SetBuildTimeout(resolveTimeout(*buildTimeout, buildTimeoutEnv))
+	containerStack.Images.SetPublishTimeout(resolveTimeout(*publishTimeout, publishTimeoutEnv))
+
+	// The overall budget must comfortably exceed build + publish, both of
+	// which are individually overridable above.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Hour)
+	defer cancel()
+
+	if *overwrite {
+		log.Printf("removing existing image %q (if any)...", target)
+		if out, err := lxcClient.Run(ctx, "image", "delete", target); err != nil {
+			log.Printf("note: image delete returned: %v; output: %s", err, out)
+		}
+	}
+
+	log.Printf("building %q from %q (template %q)...", target, *base, template.Name)
+	log.Printf("(progress is reported every 30 seconds)")
+
+	if err := containerStack.Images.BuildTemplate(ctx, serviceimage.TemplateSpec{
+		Name:      template.Name,
+		Alias:     target,
+		BaseAlias: *base,
+		Program:   program,
+		Description: "futrx remote " + template.Name + " template: " +
+			*base + " + " + template.Title,
+	}); err != nil {
+		log.Fatalf("build failed: %v", err)
+	}
+
+	log.Printf(
+		"done. published %q. new %q projects will launch from it instead of provisioning in-container.",
+		target, template.Name,
+	)
+}
+
+func printTemplates(catalog *servicetemplates.Catalog) {
+	fmt.Fprintln(os.Stderr, "templates:")
+	for _, template := range catalog.List() {
+		marker := " "
+		if template.PrebuiltImage {
+			marker = "*"
+		}
+		if !template.Provisions() {
+			fmt.Fprintf(os.Stderr, "  %s %-12s %s (installs nothing - no image to build)\n",
+				marker, template.Name, template.Title)
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "  %s %-12s %s -> %s\n",
+			marker, template.Name, template.Title, servicetemplates.ImageAlias(template.Name))
+	}
+	fmt.Fprintln(os.Stderr, "  (* declares a pre-built image the runtime will look for)")
+}
+
+// resolveTimeout prefers the flag, falls back to the environment variable, and
+// returns zero to keep the builder's default.
+func resolveTimeout(flagValue time.Duration, envName string) time.Duration {
+	if flagValue > 0 {
+		return flagValue
+	}
+	raw := os.Getenv(envName)
+	if raw == "" {
+		return 0
+	}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Fatalf("invalid %s=%q: %v", envName, raw, err)
+	}
+	return parsed
+}

--- a/backend/cmd/build-template-image/progress.go
+++ b/backend/cmd/build-template-image/progress.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	serviceimage "github.com/futrx-com/remote.futrx.com/internal/service/container/image"
+)
+
+type logBuildProgressReporter struct {
+	logger *log.Logger
+}
+
+func newLogBuildProgressReporter(logger *log.Logger) logBuildProgressReporter {
+	return logBuildProgressReporter{logger: logger}
+}
+
+func (r logBuildProgressReporter) ReportImageBuildProgress(progress serviceimage.Progress) {
+	label := fmt.Sprintf("[%d/%d] %s", progress.Stage, progress.StageCount, progress.Description)
+	switch progress.State {
+	case serviceimage.ProgressStarted:
+		r.logger.Printf("%s...", label)
+	case serviceimage.ProgressRunning:
+		r.logger.Printf("%s still running (%s elapsed)", label, progress.Elapsed)
+	case serviceimage.ProgressSucceeded:
+		r.logger.Printf("%s finished in %s", label, progress.Elapsed)
+	case serviceimage.ProgressFailed:
+		r.logger.Printf("%s failed after %s", label, progress.Elapsed)
+	}
+}

--- a/backend/cmd/remote/main.go
+++ b/backend/cmd/remote/main.go
@@ -114,6 +114,7 @@ func main() {
 		Files:          workspaceFileService,
 		GitHistory:     gitHistoryService,
 		IDE:            workspaceIDEService,
+		Templates:      containerStack.Templates,
 	})
 	if err != nil {
 		log.Fatalf("init http handler: %v", err)

--- a/backend/internal/config/containers.go
+++ b/backend/internal/config/containers.go
@@ -16,6 +16,7 @@ import (
 	containernetwork "github.com/futrx-com/remote.futrx.com/internal/integration/containers/network"
 	containerresources "github.com/futrx-com/remote.futrx.com/internal/integration/containers/resources"
 	containerscheduletools "github.com/futrx-com/remote.futrx.com/internal/integration/containers/scheduletools"
+	containertemplates "github.com/futrx-com/remote.futrx.com/internal/integration/containers/templates"
 	containerworkspace "github.com/futrx-com/remote.futrx.com/internal/integration/containers/workspace"
 	"github.com/futrx-com/remote.futrx.com/internal/integration/hostfs"
 	servicebrowser "github.com/futrx-com/remote.futrx.com/internal/service/container/browser"
@@ -26,6 +27,7 @@ import (
 	containerlaunch "github.com/futrx-com/remote.futrx.com/internal/service/container/launch"
 	servicelifecycle "github.com/futrx-com/remote.futrx.com/internal/service/container/lifecycle"
 	serviceprofiles "github.com/futrx-com/remote.futrx.com/internal/service/container/profiles"
+	servicetemplates "github.com/futrx-com/remote.futrx.com/internal/service/container/templates"
 	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
 )
 
@@ -45,6 +47,7 @@ type ContainerStack struct {
 	Network       *containernetwork.Repairer
 	Workspace     *containerworkspace.Provisioner
 	Images        *serviceimage.Builder
+	Templates     *servicetemplates.Service
 }
 
 // ContainerStackOptions supplies presentation and installation-specific
@@ -65,6 +68,7 @@ func (s ContainerStack) ProjectDependencies() serviceproject.ContainerDependenci
 		Network:     s.Network,
 		Listeners:   s.Listeners,
 		Browser:     s.Browser,
+		Templates:   s.Templates,
 	}
 }
 
@@ -116,6 +120,10 @@ func NewContainerStack(
 		containercodeserver.InstallScript(),
 		options.ImageBuildProgress,
 	)
+	templates := servicetemplates.NewService(
+		servicetemplates.MustLoad(),
+		containertemplates.NewAdapter(runner),
+	)
 	launchProvisioner := containerlaunch.NewProvisioner(
 		credentials,
 		workspace,
@@ -130,6 +138,7 @@ func NewContainerStack(
 		hostfs.NewWorkspacePreparer(hostMappedUID, hostMappedUID),
 		resources,
 		launchProvisioner,
+		templates,
 	)
 	inspectionAdapter := containerinspection.NewAdapter(
 		runner,
@@ -157,5 +166,6 @@ func NewContainerStack(
 		Network:       network,
 		Workspace:     workspace,
 		Images:        images,
+		Templates:     templates,
 	}
 }

--- a/backend/internal/integration/containers/templates/adapter.go
+++ b/backend/internal/integration/containers/templates/adapter.go
@@ -1,0 +1,120 @@
+// Package templates translates project-template provisioning into container
+// runtime commands.
+package templates
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/integration/containers/command"
+)
+
+const (
+	queryTimeout = 15 * time.Second
+	pushTimeout  = 60 * time.Second
+)
+
+// Adapter is the command adapter for the project-template workflow.
+type Adapter struct {
+	runner command.Runner
+}
+
+// NewAdapter returns a template runtime backed by runner.
+func NewAdapter(runner command.Runner) *Adapter {
+	return &Adapter{runner: runner}
+}
+
+func (a *Adapter) Available() bool {
+	return a.runner.Available()
+}
+
+// FileExists reports whether path exists inside the container.
+//
+// Two failures mean "absent" rather than "broken": a non-zero exit with no
+// output is `test -e` answering no, and a container that does not exist
+// obviously holds no marker — the project status endpoint polls this for
+// containers that were never created, and neither case deserves an error.
+func (a *Adapter) FileExists(ctx context.Context, containerName, path string) (bool, error) {
+	out, err := command.RunWithTimeout(
+		ctx, a.runner, queryTimeout,
+		"exec", containerName, "--", "test", "-e", path,
+	)
+	if err == nil {
+		return true, nil
+	}
+	if strings.TrimSpace(out) == "" || missingInstance(out) {
+		return false, nil
+	}
+	return false, fmt.Errorf("probe %s in %s: %w; output: %s", path, containerName, err, out)
+}
+
+// missingInstance recognizes LXD's "Error: Instance not found".
+func missingInstance(output string) bool {
+	return strings.Contains(strings.ToLower(output), "instance not found")
+}
+
+// EnsureDirectory creates path (and parents) inside the container.
+func (a *Adapter) EnsureDirectory(ctx context.Context, containerName, path string) error {
+	if out, err := command.RunWithTimeout(
+		ctx, a.runner, queryTimeout,
+		"exec", containerName, "--", "install", "-d", "-m", "755", path,
+	); err != nil {
+		return fmt.Errorf("create %s in %s: %w; output: %s", path, containerName, err, out)
+	}
+	return nil
+}
+
+// PushFile writes content to an absolute container path.
+func (a *Adapter) PushFile(
+	ctx context.Context,
+	containerName string,
+	content []byte,
+	target, fileMode string,
+) error {
+	tmp, err := os.CreateTemp("", "futrx-template-seed-*")
+	if err != nil {
+		return fmt.Errorf("temp file: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write seed: %w", err)
+	}
+	tmp.Close()
+
+	if out, err := command.RunWithTimeout(
+		ctx, a.runner, pushTimeout,
+		"file", "push", "--mode="+fileMode, tmp.Name(), containerName+target,
+	); err != nil {
+		return fmt.Errorf("push %s to %s: %w; output: %s", target, containerName, err, out)
+	}
+	return nil
+}
+
+// RunScript executes a bash program inside the container. The caller owns the
+// deadline: a stack install runs for minutes.
+func (a *Adapter) RunScript(ctx context.Context, containerName, script string) (string, error) {
+	return a.runner.Run(ctx, "exec", containerName, "--", "bash", "-c", script)
+}
+
+// ImageExists reports whether an image alias is published on this host.
+func (a *Adapter) ImageExists(ctx context.Context, alias string) (bool, error) {
+	out, err := command.RunWithTimeout(
+		ctx, a.runner, queryTimeout,
+		"image", "list", "--format", "csv", alias,
+	)
+	if err != nil {
+		return false, fmt.Errorf("list image %s: %w; output: %s", alias, err, out)
+	}
+	// `lxc image list <alias>` filters by fingerprint OR alias and prints one
+	// CSV row per match. An alias that resolves nothing prints nothing.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), alias+",") {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/backend/internal/integration/containers/templates/adapter_test.go
+++ b/backend/internal/integration/containers/templates/adapter_test.go
@@ -1,0 +1,169 @@
+package templates
+
+import (
+	"context"
+	"errors"
+	"io"
+	"slices"
+	"testing"
+)
+
+type recordingRunner struct {
+	available bool
+	output    string
+	err       error
+	calls     [][]string
+}
+
+func (r *recordingRunner) Available() bool { return r.available }
+
+func (r *recordingRunner) Run(_ context.Context, args ...string) (string, error) {
+	r.calls = append(r.calls, slices.Clone(args))
+	return r.output, r.err
+}
+
+func (r *recordingRunner) RunStdin(ctx context.Context, _ io.Reader, args ...string) (string, error) {
+	return r.Run(ctx, args...)
+}
+
+func TestFileExists(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		err     error
+		want    bool
+		wantErr bool
+	}{
+		{name: "present", want: true},
+		{
+			name: "absent is not an error",
+			err:  errors.New("exit status 1"),
+			want: false,
+		},
+		{
+			name:   "a container that does not exist holds no marker",
+			output: "Error: Instance not found",
+			err:    errors.New("exit status 1"),
+			want:   false,
+		},
+		{
+			name:    "any other failure is an error",
+			output:  "Error: cannot connect to the LXD server",
+			err:     errors.New("exit status 1"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &recordingRunner{available: true, output: tt.output, err: tt.err}
+			got, err := NewAdapter(runner).FileExists(context.Background(), "project-1", "/var/lib/x")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("FileExists() error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Fatalf("FileExists() = %t, want %t", got, tt.want)
+			}
+			want := []string{"exec", "project-1", "--", "test", "-e", "/var/lib/x"}
+			if len(runner.calls) != 1 || !slices.Equal(runner.calls[0], want) {
+				t.Fatalf("calls = %q, want [%q]", runner.calls, want)
+			}
+		})
+	}
+}
+
+func TestImageExists(t *testing.T) {
+	tests := []struct {
+		name   string
+		alias  string
+		output string
+		want   bool
+	}{
+		{
+			name:   "published",
+			alias:  "futrx-remote-wordpress-base",
+			output: "futrx-remote-wordpress-base,abc123,no,CONTAINER,1.2GB,x86_64\n",
+			want:   true,
+		},
+		{name: "absent", alias: "futrx-remote-wordpress-base", output: "\n"},
+		{
+			name:   "a different alias in the listing does not count",
+			alias:  "futrx-remote-wordpress-base",
+			output: "futrx-remote-dev-base,abc123,no,CONTAINER,1.2GB,x86_64\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &recordingRunner{available: true, output: tt.output}
+			got, err := NewAdapter(runner).ImageExists(context.Background(), tt.alias)
+			if err != nil {
+				t.Fatalf("ImageExists() = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ImageExists() = %t, want %t", got, tt.want)
+			}
+			want := []string{"image", "list", "--format", "csv", tt.alias}
+			if len(runner.calls) != 1 || !slices.Equal(runner.calls[0], want) {
+				t.Fatalf("calls = %q, want [%q]", runner.calls, want)
+			}
+		})
+	}
+}
+
+func TestRunScriptAndEnsureDirectoryTranslateToCommands(t *testing.T) {
+	tests := []struct {
+		name     string
+		invoke   func(*Adapter) error
+		wantArgs []string
+	}{
+		{
+			name: "run script",
+			invoke: func(a *Adapter) error {
+				_, err := a.RunScript(context.Background(), "project-1", "echo hi")
+				return err
+			},
+			wantArgs: []string{"exec", "project-1", "--", "bash", "-c", "echo hi"},
+		},
+		{
+			name: "ensure directory",
+			invoke: func(a *Adapter) error {
+				return a.EnsureDirectory(context.Background(), "project-1", "/workspace/sub")
+			},
+			wantArgs: []string{"exec", "project-1", "--", "install", "-d", "-m", "755", "/workspace/sub"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &recordingRunner{available: true}
+			if err := tt.invoke(NewAdapter(runner)); err != nil {
+				t.Fatalf("invoke = %v", err)
+			}
+			if len(runner.calls) != 1 || !slices.Equal(runner.calls[0], tt.wantArgs) {
+				t.Fatalf("calls = %q, want [%q]", runner.calls, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestPushFilePushesWithTheRequestedMode(t *testing.T) {
+	runner := &recordingRunner{available: true}
+	adapter := NewAdapter(runner)
+
+	if err := adapter.PushFile(
+		context.Background(), "project-1", []byte("hello"), "/workspace/README.md", "644",
+	); err != nil {
+		t.Fatalf("PushFile() = %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("calls = %q", runner.calls)
+	}
+	call := runner.calls[0]
+	if call[0] != "file" || call[1] != "push" || call[2] != "--mode=644" {
+		t.Fatalf("call = %q", call)
+	}
+	if call[len(call)-1] != "project-1/workspace/README.md" {
+		t.Fatalf("destination = %q", call[len(call)-1])
+	}
+}

--- a/backend/internal/service/container/image/builder.go
+++ b/backend/internal/service/container/image/builder.go
@@ -45,11 +45,15 @@ type buildStageResult struct {
 	err    error
 }
 
-func (b *Builder) runBuildStage(stage int, description string, run func() (string, error)) (string, error) {
+func (b *Builder) runBuildStage(
+	stage, stageCount int,
+	description string,
+	run func() (string, error),
+) (string, error) {
 	started := time.Now()
 	b.reportProgress(Progress{
 		Stage:       stage,
-		StageCount:  baseImageBuildStageCount,
+		StageCount:  stageCount,
 		Description: description,
 		State:       ProgressStarted,
 	})
@@ -69,7 +73,7 @@ func (b *Builder) runBuildStage(stage int, description string, run func() (strin
 			if result.err != nil {
 				b.reportProgress(Progress{
 					Stage:       stage,
-					StageCount:  baseImageBuildStageCount,
+					StageCount:  stageCount,
 					Description: description,
 					State:       ProgressFailed,
 					Elapsed:     elapsed,
@@ -77,7 +81,7 @@ func (b *Builder) runBuildStage(stage int, description string, run func() (strin
 			} else {
 				b.reportProgress(Progress{
 					Stage:       stage,
-					StageCount:  baseImageBuildStageCount,
+					StageCount:  stageCount,
 					Description: description,
 					State:       ProgressSucceeded,
 					Elapsed:     elapsed,
@@ -88,7 +92,7 @@ func (b *Builder) runBuildStage(stage int, description string, run func() (strin
 			elapsed := time.Since(started).Round(time.Second)
 			b.reportProgress(Progress{
 				Stage:       stage,
-				StageCount:  baseImageBuildStageCount,
+				StageCount:  stageCount,
 				Description: description,
 				State:       ProgressRunning,
 				Elapsed:     elapsed,
@@ -112,6 +116,8 @@ type Builder struct {
 	codeServerInstallScript []byte
 	networkWarmup           time.Duration
 	progress                ProgressReporter
+	buildTimeout            time.Duration
+	publishTimeout          time.Duration
 }
 
 // NewBuilder returns an image builder configured with the feature install
@@ -130,6 +136,25 @@ func NewBuilder(
 		codeServerInstallScript: codeServerInstallScript,
 		networkWarmup:           baseImageNetworkWarmup,
 		progress:                progress,
+		buildTimeout:            baseImageBuildTimeout,
+		publishTimeout:          baseImagePublishTimeout,
+	}
+}
+
+// SetBuildTimeout overrides the budget for the install stages. A slow or
+// contended host needs more than the default; zero keeps the default.
+func (b *Builder) SetBuildTimeout(timeout time.Duration) {
+	if timeout > 0 {
+		b.buildTimeout = timeout
+	}
+}
+
+// SetPublishTimeout overrides the budget for the publish stage. Publishing
+// compresses the whole rootfs, which on a 1 vCPU host regularly exceeds the
+// default; zero keeps the default.
+func (b *Builder) SetPublishTimeout(timeout time.Duration) {
+	if timeout > 0 {
+		b.publishTimeout = timeout
 	}
 }
 
@@ -158,7 +183,7 @@ func (b *Builder) Build(ctx context.Context, alias string) error {
 	_, _ = b.runtime.DeleteContainer(cleanCtx, baseImageBuilderName)
 	cleanCancel()
 
-	bctx, bcancel := context.WithTimeout(ctx, baseImageBuildTimeout)
+	bctx, bcancel := context.WithTimeout(ctx, b.buildTimeout)
 	defer bcancel()
 
 	// Cleanup deliberately outlives a canceled caller so interrupted builds do
@@ -169,7 +194,7 @@ func (b *Builder) Build(ctx context.Context, alias string) error {
 		_, _ = b.runtime.DeleteContainer(dctx, baseImageBuilderName)
 	}()
 
-	out, err := b.runBuildStage(1, "Downloading Ubuntu 24.04 and starting the builder", func() (string, error) {
+	out, err := b.runBuildStage(1, baseImageBuildStageCount, "Downloading Ubuntu 24.04 and starting the builder", func() (string, error) {
 		return b.runtime.LaunchContainer(bctx, SourceImage, baseImageBuilderName)
 	})
 	if err != nil {
@@ -189,37 +214,37 @@ func (b *Builder) Build(ctx context.Context, alias string) error {
 		return errors.New(ipv4EgressHint)
 	}
 
-	out, err = b.runBuildStage(2, "Installing system tools, Node.js, and agent CLIs", func() (string, error) {
+	out, err = b.runBuildStage(2, baseImageBuildStageCount, "Installing system tools, Node.js, and agent CLIs", func() (string, error) {
 		return b.runtime.ExecuteScript(bctx, baseImageBuilderName, installScript)
 	})
 	if err != nil {
 		return fmt.Errorf("install script: %w; output: %s", err, output.TruncateTail(out, 2000))
 	}
 
-	out, err = b.runBuildStage(3, "Installing the agent browser and Chromium", func() (string, error) {
+	out, err = b.runBuildStage(3, baseImageBuildStageCount, "Installing the agent browser and Chromium", func() (string, error) {
 		return b.runtime.ExecuteScript(bctx, baseImageBuilderName, b.browserInstallScript)
 	})
 	if err != nil {
 		return fmt.Errorf("agent browser install script: %w; output: %s", err, output.TruncateTail(out, 2000))
 	}
 
-	out, err = b.runBuildStage(4, "Installing the browser IDE", func() (string, error) {
+	out, err = b.runBuildStage(4, baseImageBuildStageCount, "Installing the browser IDE", func() (string, error) {
 		return b.runtime.ExecuteScript(bctx, baseImageBuilderName, string(b.codeServerInstallScript))
 	})
 	if err != nil {
 		return fmt.Errorf("code-server install script: %w; output: %s", err, output.TruncateTail(out, 2000))
 	}
 
-	out, err = b.runBuildStage(5, "Finalizing the builder container", func() (string, error) {
+	out, err = b.runBuildStage(5, baseImageBuildStageCount, "Finalizing the builder container", func() (string, error) {
 		return b.runtime.StopContainer(bctx, baseImageBuilderName)
 	})
 	if err != nil {
 		return fmt.Errorf("stop builder: %w; output: %s", err, out)
 	}
 
-	pctx, pcancel := context.WithTimeout(ctx, baseImagePublishTimeout)
+	pctx, pcancel := context.WithTimeout(ctx, b.publishTimeout)
 	defer pcancel()
-	out, err = b.runBuildStage(6, "Publishing the reusable workspace image", func() (string, error) {
+	out, err = b.runBuildStage(6, baseImageBuildStageCount, "Publishing the reusable workspace image", func() (string, error) {
 		return b.runtime.PublishImage(
 			pctx,
 			baseImageBuilderName,

--- a/backend/internal/service/container/image/template.go
+++ b/backend/internal/service/container/image/template.go
@@ -1,0 +1,144 @@
+package image
+
+// Template images are the optional FAST PATH for project templates. The
+// default (slow) path launches a project from the shared base image and runs
+// the template's provision script inside the new container, which costs the
+// user several minutes on first start. Publishing a dedicated image once —
+// ideally on a beefier machine — moves that cost to build time.
+//
+// The build is deliberately layered: the builder container starts from the
+// already-published base image, so a template image is base + one script and
+// never repeats the base recipe.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/shared/output"
+)
+
+const (
+	// templateImageBuilderName is the disposable builder used for template
+	// images. Kept stable so a retry cleans up a leftover from a failed run.
+	templateImageBuilderName = "futrx-remote-template-builder"
+
+	templateImageBuildStageCount = 4
+)
+
+// TemplateSpec describes one layered template image build.
+type TemplateSpec struct {
+	// Name is the template name, used for progress text and the description.
+	Name string
+	// Alias is the image alias to publish, e.g. futrx-remote-wordpress-base.
+	Alias string
+	// BaseAlias is the image the builder container starts from. Empty means
+	// the shared base image alias.
+	BaseAlias string
+	// Program is the complete provision program (harness included) to run
+	// inside the builder.
+	Program string
+	// Description is the published image's description.
+	Description string
+}
+
+// BuildTemplate publishes a dedicated image for one project template by
+// launching the base image, running the template's provision program, and
+// publishing the result. It uses the same staged progress reporting and the
+// same overridable timeouts as the base-image build.
+func (b *Builder) BuildTemplate(ctx context.Context, spec TemplateSpec) error {
+	if !b.runtime.Available() {
+		return errors.New("lxc CLI not found on PATH - install LXD on the host first")
+	}
+	if spec.Name == "" || spec.Alias == "" {
+		return errors.New("template image build needs a template name and an alias")
+	}
+	if spec.Program == "" {
+		return fmt.Errorf("template %q has no provisioning to bake into an image", spec.Name)
+	}
+	base := spec.BaseAlias
+	if base == "" {
+		base = Alias
+	}
+	description := spec.Description
+	if description == "" {
+		description = "futrx remote " + spec.Name + " template: " + base + " + " + spec.Name + " stack"
+	}
+
+	// Clean up any leftover builder from a previous interrupted run.
+	cleanCtx, cleanCancel := context.WithTimeout(ctx, deleteTimeout)
+	_, _ = b.runtime.DeleteContainer(cleanCtx, templateImageBuilderName)
+	cleanCancel()
+
+	bctx, bcancel := context.WithTimeout(ctx, b.buildTimeout)
+	defer bcancel()
+
+	// Cleanup outlives a canceled caller so an interrupted build does not
+	// strand its disposable container.
+	defer func() {
+		dctx, dcancel := context.WithTimeout(context.Background(), deleteTimeout)
+		defer dcancel()
+		_, _ = b.runtime.DeleteContainer(dctx, templateImageBuilderName)
+	}()
+
+	out, err := b.runBuildStage(
+		1, templateImageBuildStageCount,
+		"Starting the builder from "+base,
+		func() (string, error) {
+			return b.runtime.LaunchContainer(bctx, base, templateImageBuilderName)
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("launch builder from %s: %w; output: %s", base, err, out)
+	}
+
+	// Give cloud-init / systemd-resolved a moment so apt-get can reach the
+	// network on the first try.
+	select {
+	case <-time.After(b.networkWarmup):
+	case <-bctx.Done():
+		return bctx.Err()
+	}
+
+	// Fail fast on a container that can only reach IPv6 (see egress.go).
+	if _, err := b.runtime.ExecuteScript(bctx, templateImageBuilderName, ipv4EgressProbe); err != nil {
+		return errors.New(ipv4EgressHint)
+	}
+
+	out, err = b.runBuildStage(
+		2, templateImageBuildStageCount,
+		"Provisioning the "+spec.Name+" stack",
+		func() (string, error) {
+			return b.runtime.ExecuteScript(bctx, templateImageBuilderName, spec.Program)
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("provision %s: %w; output: %s", spec.Name, err, output.TruncateTail(out, 2000))
+	}
+
+	out, err = b.runBuildStage(
+		3, templateImageBuildStageCount,
+		"Finalizing the builder container",
+		func() (string, error) {
+			return b.runtime.StopContainer(bctx, templateImageBuilderName)
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("stop builder: %w; output: %s", err, out)
+	}
+
+	pctx, pcancel := context.WithTimeout(ctx, b.publishTimeout)
+	defer pcancel()
+	out, err = b.runBuildStage(
+		4, templateImageBuildStageCount,
+		"Publishing "+spec.Alias,
+		func() (string, error) {
+			return b.runtime.PublishImage(pctx, templateImageBuilderName, spec.Alias, description)
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("publish: %w; output: %s", err, out)
+	}
+	return nil
+}

--- a/backend/internal/service/container/image/template_test.go
+++ b/backend/internal/service/container/image/template_test.go
@@ -1,0 +1,169 @@
+package image
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTemplateBuilder(runtime *recordingRuntime) *Builder {
+	builder := NewBuilder(runtime, &recordingProfileSource{profiles: configuredProfiles()},
+		"browser-install", []byte("code-server-install"), nil)
+	builder.networkWarmup = 0
+	return builder
+}
+
+func TestBuildTemplateLayersOnTopOfThePublishedBaseImage(t *testing.T) {
+	runtime := &recordingRuntime{available: true}
+	builder := newTemplateBuilder(runtime)
+
+	err := builder.BuildTemplate(context.Background(), TemplateSpec{
+		Name:    "wordpress",
+		Alias:   "futrx-remote-wordpress-base",
+		Program: "install wordpress",
+	})
+	if err != nil {
+		t.Fatalf("BuildTemplate: %v", err)
+	}
+	want := []string{
+		"available",
+		"delete " + templateImageBuilderName,
+		// The builder starts from the shared base image, not from Ubuntu:
+		// a template image is base + one script, never a repeat of the
+		// base recipe.
+		"launch " + Alias + " " + templateImageBuilderName,
+		"script " + templateImageBuilderName + " " + ipv4EgressProbe,
+		"script " + templateImageBuilderName + " install wordpress",
+		"stop " + templateImageBuilderName,
+		"publish " + templateImageBuilderName + " futrx-remote-wordpress-base " +
+			"futrx remote wordpress template: " + Alias + " + wordpress stack",
+		"delete " + templateImageBuilderName,
+	}
+	assertEvents(t, runtime.events, want)
+}
+
+func TestBuildTemplateHonoursAnExplicitBaseAndDescription(t *testing.T) {
+	runtime := &recordingRuntime{available: true}
+
+	err := newTemplateBuilder(runtime).BuildTemplate(context.Background(), TemplateSpec{
+		Name:        "wordpress",
+		Alias:       "custom-alias",
+		BaseAlias:   "custom-base",
+		Program:     "install",
+		Description: "custom description",
+	})
+	if err != nil {
+		t.Fatalf("BuildTemplate: %v", err)
+	}
+	if !containsEvent(runtime.events, "launch custom-base "+templateImageBuilderName) {
+		t.Fatalf("events = %q", runtime.events)
+	}
+	if !containsEvent(runtime.events,
+		"publish "+templateImageBuilderName+" custom-alias custom description") {
+		t.Fatalf("events = %q", runtime.events)
+	}
+}
+
+func TestBuildTemplateRejectsIncompleteSpecs(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    TemplateSpec
+		wantErr string
+	}{
+		{
+			name:    "no name",
+			spec:    TemplateSpec{Alias: "a", Program: "p"},
+			wantErr: "template name and an alias",
+		},
+		{
+			name:    "no alias",
+			spec:    TemplateSpec{Name: "n", Program: "p"},
+			wantErr: "template name and an alias",
+		},
+		{
+			name:    "nothing to bake",
+			spec:    TemplateSpec{Name: "blank", Alias: "a"},
+			wantErr: "no provisioning to bake",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtime := &recordingRuntime{available: true}
+			err := newTemplateBuilder(runtime).BuildTemplate(context.Background(), tt.spec)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("BuildTemplate() = %v, want an error containing %q", err, tt.wantErr)
+			}
+			// A rejected spec must not launch anything.
+			for _, event := range runtime.events {
+				if strings.HasPrefix(event, "launch ") {
+					t.Fatalf("events = %q", runtime.events)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTemplateCleansUpTheBuilderOnFailure(t *testing.T) {
+	runtime := &recordingRuntime{
+		available: true,
+		scriptResponses: []runtimeResponse{
+			{}, // IPv4 egress probe succeeds
+			{output: "apt exploded", err: errors.New("exit 1")},
+		},
+	}
+
+	err := newTemplateBuilder(runtime).BuildTemplate(context.Background(), TemplateSpec{
+		Name: "wordpress", Alias: "futrx-remote-wordpress-base", Program: "install",
+	})
+	if err == nil || !strings.Contains(err.Error(), "apt exploded") {
+		t.Fatalf("BuildTemplate() = %v, want the script output preserved", err)
+	}
+	if runtime.events[len(runtime.events)-1] != "delete "+templateImageBuilderName {
+		t.Fatalf("builder was not cleaned up: %q", runtime.events)
+	}
+	for _, event := range runtime.events {
+		if strings.HasPrefix(event, "publish ") {
+			t.Fatalf("a failed build published an image: %q", runtime.events)
+		}
+	}
+}
+
+func TestBuildTemplateRequiresAnAvailableRuntime(t *testing.T) {
+	runtime := &recordingRuntime{}
+	err := newTemplateBuilder(runtime).BuildTemplate(context.Background(), TemplateSpec{
+		Name: "wordpress", Alias: "a", Program: "install",
+	})
+	if err == nil || !strings.Contains(err.Error(), "lxc CLI not found") {
+		t.Fatalf("BuildTemplate() = %v", err)
+	}
+}
+
+func TestTimeoutOverridesIgnoreNonPositiveValues(t *testing.T) {
+	builder := newTemplateBuilder(&recordingRuntime{available: true})
+
+	builder.SetBuildTimeout(0)
+	builder.SetPublishTimeout(-time.Minute)
+	if builder.buildTimeout != baseImageBuildTimeout || builder.publishTimeout != baseImagePublishTimeout {
+		t.Fatalf("defaults were overwritten: build=%s publish=%s",
+			builder.buildTimeout, builder.publishTimeout)
+	}
+
+	builder.SetBuildTimeout(90 * time.Minute)
+	builder.SetPublishTimeout(30 * time.Minute)
+	if builder.buildTimeout != 90*time.Minute || builder.publishTimeout != 30*time.Minute {
+		t.Fatalf("overrides not applied: build=%s publish=%s",
+			builder.buildTimeout, builder.publishTimeout)
+	}
+}
+
+func containsEvent(events []string, want string) bool {
+	for _, event := range events {
+		if event == want {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/service/container/lifecycle/service.go
+++ b/backend/internal/service/container/lifecycle/service.go
@@ -50,28 +50,76 @@ type LaunchProvisioner interface {
 	Provision(ctx context.Context, containerName, displayName string)
 }
 
+// TemplateProvisioner applies a project's stack preset. It is optional: a
+// deployment without a template catalog behaves exactly as before templates
+// existed.
+type TemplateProvisioner interface {
+	// ImageFor returns the dedicated pre-built image alias to launch a
+	// template's containers from, or "" to use the shared base image and
+	// provision the stack in-container instead.
+	ImageFor(ctx context.Context, template string) string
+	// Ensure runs the template's one-time provisioning unless the container's
+	// marker file says it already ran. The returned channel closes once any
+	// background work has settled.
+	Ensure(ctx context.Context, containerName, template string) <-chan struct{}
+}
+
 type Service struct {
 	runtime     Runtime
 	image       string
 	workspace   WorkspacePreparer
 	resources   ResourceEnsurer
 	provisioner LaunchProvisioner
+	templates   TemplateProvisioner
 }
 
+// NewService wires the lifecycle. templates is variadic so callers that do
+// not offer stack presets keep the original five-argument construction.
 func NewService(
 	runtime Runtime,
 	image string,
 	workspace WorkspacePreparer,
 	resources ResourceEnsurer,
 	provisioner LaunchProvisioner,
+	templates ...TemplateProvisioner,
 ) *Service {
-	return &Service{
+	service := &Service{
 		runtime:     runtime,
 		image:       image,
 		workspace:   workspace,
 		resources:   resources,
 		provisioner: provisioner,
 	}
+	if len(templates) > 0 {
+		service.templates = templates[0]
+	}
+	return service
+}
+
+// imageFor resolves the image a project's container is created from: the
+// template's dedicated pre-built alias when this host has published one, and
+// the shared base image otherwise.
+func (s *Service) imageFor(ctx context.Context, project serviceproject.Meta) string {
+	if s.templates == nil {
+		return s.image
+	}
+	if alias := s.templates.ImageFor(ctx, project.TemplateName()); alias != "" {
+		return alias
+	}
+	return s.image
+}
+
+// provisionTemplate applies the project's stack preset. It runs on every
+// convergence, not only on creation, because it is gated by a marker file in
+// the disposable rootfs: a replaced container (workspace upgrade) must be
+// re-provisioned, and an interrupted run must be retried. When the container
+// was launched from a pre-built template image the marker is already baked in
+// and this costs one probe.
+func (s *Service) provisionTemplate(ctx context.Context, project serviceproject.Meta) {
+	if s.templates == nil {
+		return
+	}
+	s.templates.Ensure(ctx, project.ContainerName, project.TemplateName())
 }
 
 func (s *Service) Available() bool {
@@ -128,7 +176,7 @@ func (s *Service) Ensure(ctx context.Context, project serviceproject.Meta) error
 				return fmt.Errorf("prepare %s: %w", mount.device, err)
 			}
 		}
-		if err := s.runtime.Init(ctx, s.image, project.ContainerName); err != nil {
+		if err := s.runtime.Init(ctx, s.imageFor(ctx, project), project.ContainerName); err != nil {
 			// A canceled or failed `lxc init` may still have created the instance.
 			return s.rollbackNewContainer(ctx, project.ContainerName, err)
 		}
@@ -255,6 +303,7 @@ func (s *Service) Ensure(ctx context.Context, project serviceproject.Meta) error
 	if created || len(changes) > 0 {
 		s.provisioner.Provision(ctx, project.ContainerName, project.Name)
 	}
+	s.provisionTemplate(ctx, project)
 	return nil
 }
 

--- a/backend/internal/service/container/lifecycle/template_test.go
+++ b/backend/internal/service/container/lifecycle/template_test.go
@@ -1,0 +1,180 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
+)
+
+type recordingTemplates struct {
+	events *[]string
+	// image is returned by ImageFor for every template except the default.
+	image string
+}
+
+func (r recordingTemplates) ImageFor(_ context.Context, template string) string {
+	*r.events = append(*r.events, "template image "+template)
+	if template == serviceproject.DefaultTemplate {
+		return ""
+	}
+	return r.image
+}
+
+func (r recordingTemplates) Ensure(_ context.Context, container, template string) <-chan struct{} {
+	*r.events = append(*r.events, "template ensure "+container+" "+template)
+	done := make(chan struct{})
+	close(done)
+	return done
+}
+
+func newTemplateService(
+	runtime *recordingRuntime,
+	events *[]string,
+	templates TemplateProvisioner,
+) *Service {
+	return NewService(
+		runtime,
+		"local:remote-base",
+		recordingWorkspace{events: events},
+		recordingResources{events: events},
+		recordingProvisioner{events: events},
+		templates,
+	)
+}
+
+func TestEnsureLaunchesFromThePrebuiltTemplateImageWhenOneExists(t *testing.T) {
+	tests := []struct {
+		name      string
+		template  string
+		available string
+		wantImage string
+	}{
+		{
+			name:      "template image published",
+			template:  "wordpress",
+			available: "futrx-remote-wordpress-base",
+			wantImage: "futrx-remote-wordpress-base",
+		},
+		{
+			name:      "no template image falls back to the shared base",
+			template:  "wordpress",
+			wantImage: "local:remote-base",
+		},
+		{
+			name:      "the default template always uses the shared base",
+			template:  "blank",
+			available: "futrx-remote-wordpress-base",
+			wantImage: "local:remote-base",
+		},
+		{
+			name:      "metadata without a template behaves like the default",
+			template:  "",
+			available: "futrx-remote-wordpress-base",
+			wantImage: "local:remote-base",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var events []string
+			runtime := &recordingRuntime{
+				events: &events, available: true, state: serviceproject.ContainerStateMissing,
+			}
+			project := testProject(t)
+			project.Template = tt.template
+			service := newTemplateService(
+				runtime, &events, recordingTemplates{events: &events, image: tt.available},
+			)
+
+			if err := service.Ensure(context.Background(), project); err != nil {
+				t.Fatal(err)
+			}
+			want := "runtime init " + tt.wantImage + " project-1"
+			if !slices.Contains(events, want) {
+				t.Fatalf("missing %q in %q", want, events)
+			}
+		})
+	}
+}
+
+func TestEnsureRunsTemplateProvisioningOnEveryConvergence(t *testing.T) {
+	// The marker file lives in the disposable rootfs, so provisioning must be
+	// offered on every convergence: a replaced container has to be
+	// re-provisioned and an interrupted run has to be retried. The template
+	// service itself is the one that short-circuits on the marker.
+	tests := []struct {
+		name  string
+		state serviceproject.ContainerState
+		ready bool
+	}{
+		{name: "newly created container", state: serviceproject.ContainerStateMissing},
+		{name: "already running and healthy", state: serviceproject.ContainerStateRunning, ready: true},
+		{name: "stopped container being started", state: serviceproject.ContainerStateStopped, ready: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var events []string
+			project := testProject(t)
+			project.Template = "wordpress"
+			runtime := &recordingRuntime{events: &events, available: true, state: tt.state}
+			if tt.ready {
+				runtime.devices = expectedDisks(project)
+			}
+			service := newTemplateService(runtime, &events, recordingTemplates{events: &events})
+
+			if err := service.Ensure(context.Background(), project); err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Contains(events, "template ensure project-1 wordpress") {
+				t.Fatalf("template provisioning was not offered: %q", events)
+			}
+		})
+	}
+}
+
+func TestEnsureWithoutATemplateProviderKeepsTheSharedBaseImage(t *testing.T) {
+	var events []string
+	runtime := &recordingRuntime{
+		events: &events, available: true, state: serviceproject.ContainerStateMissing,
+	}
+	project := testProject(t)
+	project.Template = "wordpress"
+
+	// The five-argument construction (no templates) must behave exactly as it
+	// did before templates existed.
+	if err := newTestService(runtime, &events).Ensure(context.Background(), project); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(events, "runtime init local:remote-base project-1") {
+		t.Fatalf("missing base-image init: %q", events)
+	}
+	for _, event := range events {
+		if event == "template ensure project-1 wordpress" {
+			t.Fatalf("template provisioning ran without a provider: %q", events)
+		}
+	}
+}
+
+func TestEnsureSkipsTemplateProvisioningWhenConvergenceFails(t *testing.T) {
+	var events []string
+	runtime := &recordingRuntime{
+		events: &events, available: true, state: serviceproject.ContainerStateMissing,
+		attachErr: errors.New("attach failed"),
+	}
+	project := testProject(t)
+	project.Template = "wordpress"
+	service := newTemplateService(runtime, &events, recordingTemplates{events: &events})
+
+	if err := service.Ensure(context.Background(), project); err == nil {
+		t.Fatal("Ensure() = nil, want the attach failure")
+	}
+	for _, event := range events {
+		if event == "template ensure project-1 wordpress" {
+			t.Fatalf("template provisioning ran against a rolled-back container: %q", events)
+		}
+	}
+}

--- a/backend/internal/service/container/templates/blank/template.json
+++ b/backend/internal/service/container/templates/blank/template.json
@@ -1,0 +1,6 @@
+{
+  "name": "blank",
+  "title": "Blank",
+  "description": "The plain workspace: Ubuntu 24.04, Node 22, Python 3, git, gh, and the agent CLIs. Nothing else is installed, and the container starts immediately.",
+  "icon": "blank"
+}

--- a/backend/internal/service/container/templates/catalog.go
+++ b/backend/internal/service/container/templates/catalog.go
@@ -1,0 +1,252 @@
+package templates
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// definitionFile is the manifest every template directory must contain.
+const definitionFile = "template.json"
+
+// templateFiles holds every shipped template. Each immediate subdirectory is
+// one template whose directory name must match its declared name.
+//
+//go:embed blank laravel node python wordpress
+var templateFiles embed.FS
+
+var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,31}$`)
+
+// order pins the presentation order of the shipped templates; anything not
+// listed sorts alphabetically after them. Keeping "blank" first makes the
+// default the first card in the picker.
+var order = map[string]int{
+	"blank":     0,
+	"wordpress": 1,
+	"laravel":   2,
+	"node":      3,
+	"python":    4,
+}
+
+// Catalog is the validated, immutable set of shipped templates.
+type Catalog struct {
+	byName map[string]Template
+	names  []string
+}
+
+// MustLoad loads the embedded catalog and panics on a malformed template.
+// Template data is compiled into the binary, so a failure here is a build
+// defect rather than an operational condition.
+func MustLoad() *Catalog {
+	catalog, err := Load()
+	if err != nil {
+		panic("load project templates: " + err.Error())
+	}
+	return catalog
+}
+
+// Load parses and validates every embedded template.
+func Load() (*Catalog, error) {
+	return LoadFS(templateFiles)
+}
+
+// LoadFS parses and validates templates from any filesystem laid out like the
+// embedded one. Exported for tests that exercise validation with fixtures.
+func LoadFS(files fs.FS) (*Catalog, error) {
+	entries, err := fs.ReadDir(files, ".")
+	if err != nil {
+		return nil, fmt.Errorf("read template root: %w", err)
+	}
+	catalog := &Catalog{byName: make(map[string]Template, len(entries))}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		template, err := loadTemplate(files, entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		if _, duplicate := catalog.byName[template.Name]; duplicate {
+			return nil, fmt.Errorf("template %q is declared twice", template.Name)
+		}
+		catalog.byName[template.Name] = template
+		catalog.names = append(catalog.names, template.Name)
+	}
+	if _, ok := catalog.byName[DefaultName]; !ok {
+		return nil, fmt.Errorf("default template %q is missing", DefaultName)
+	}
+	sort.Slice(catalog.names, func(i, j int) bool {
+		left, leftKnown := order[catalog.names[i]]
+		right, rightKnown := order[catalog.names[j]]
+		if leftKnown != rightKnown {
+			return leftKnown
+		}
+		if leftKnown && left != right {
+			return left < right
+		}
+		return catalog.names[i] < catalog.names[j]
+	})
+	return catalog, nil
+}
+
+func loadTemplate(files fs.FS, dir string) (Template, error) {
+	raw, err := fs.ReadFile(files, path.Join(dir, definitionFile))
+	if err != nil {
+		return Template{}, fmt.Errorf("template %q: read %s: %w", dir, definitionFile, err)
+	}
+	var definition Definition
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&definition); err != nil {
+		return Template{}, fmt.Errorf("template %q: parse %s: %w", dir, definitionFile, err)
+	}
+	template := Template{Definition: definition}
+	if err := validateDefinition(dir, definition); err != nil {
+		return Template{}, err
+	}
+	if definition.ProvisionScript != "" {
+		script, err := readTemplateFile(files, dir, definition.ProvisionScript)
+		if err != nil {
+			return Template{}, fmt.Errorf("template %q: provision script: %w", dir, err)
+		}
+		template.Script = script
+	}
+	if definition.AgentInstructions != "" {
+		instructions, err := readTemplateFile(files, dir, definition.AgentInstructions)
+		if err != nil {
+			return Template{}, fmt.Errorf("template %q: agent instructions: %w", dir, err)
+		}
+		template.Instructions = instructions
+	}
+	for _, seed := range definition.SeedFiles {
+		content, err := readTemplateFile(files, dir, seed.Source)
+		if err != nil {
+			return Template{}, fmt.Errorf("template %q: seed %s: %w", dir, seed.Source, err)
+		}
+		mode := seed.Mode
+		if mode == "" {
+			mode = "644"
+		}
+		template.Seeds = append(template.Seeds, Seed{
+			Target:  seed.Target,
+			Mode:    mode,
+			Content: content,
+		})
+	}
+	return template, nil
+}
+
+func validateDefinition(dir string, definition Definition) error {
+	if !namePattern.MatchString(definition.Name) {
+		return fmt.Errorf("template %q: name %q must match %s", dir, definition.Name, namePattern)
+	}
+	if definition.Name != dir {
+		return fmt.Errorf("template %q: name %q does not match its directory", dir, definition.Name)
+	}
+	if strings.TrimSpace(definition.Title) == "" {
+		return fmt.Errorf("template %q: title is required", dir)
+	}
+	if strings.TrimSpace(definition.Description) == "" {
+		return fmt.Errorf("template %q: description is required", dir)
+	}
+	if strings.TrimSpace(definition.Icon) == "" {
+		return fmt.Errorf("template %q: icon is required", dir)
+	}
+	for _, port := range definition.DefaultPorts {
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("template %q: default port %d is out of range", dir, port)
+		}
+	}
+	targets := make(map[string]bool, len(definition.SeedFiles))
+	for _, seed := range definition.SeedFiles {
+		if err := validateSeedTarget(seed.Target); err != nil {
+			return fmt.Errorf("template %q: seed %q: %w", dir, seed.Source, err)
+		}
+		if targets[seed.Target] {
+			return fmt.Errorf("template %q: seed target %q is declared twice", dir, seed.Target)
+		}
+		targets[seed.Target] = true
+	}
+	return nil
+}
+
+// validateSeedTarget keeps seeds inside the durable workspace mount. Writing
+// outside it would be lost on the next container replacement, and an escaping
+// path would let a template write anywhere in the rootfs.
+func validateSeedTarget(target string) error {
+	if target == "" {
+		return fmt.Errorf("target is required")
+	}
+	if target != path.Clean(target) || !strings.HasPrefix(target, "/workspace/") {
+		return fmt.Errorf("target %q must be a clean absolute path under /workspace", target)
+	}
+	for _, element := range strings.Split(target, "/") {
+		if element == ".." {
+			return fmt.Errorf("target %q must not traverse upwards", target)
+		}
+	}
+	return nil
+}
+
+func readTemplateFile(files fs.FS, dir, name string) ([]byte, error) {
+	if name != path.Clean(name) || strings.HasPrefix(name, "/") || strings.HasPrefix(name, "..") {
+		return nil, fmt.Errorf("%q must be a relative file name inside the template directory", name)
+	}
+	content, err := fs.ReadFile(files, path.Join(dir, name))
+	if err != nil {
+		return nil, err
+	}
+	if len(content) == 0 {
+		return nil, fmt.Errorf("%q is empty", name)
+	}
+	return content, nil
+}
+
+// Names returns every template name in presentation order.
+func (c *Catalog) Names() []string {
+	names := make([]string, len(c.names))
+	copy(names, c.names)
+	return names
+}
+
+// List returns every template in presentation order.
+func (c *Catalog) List() []Template {
+	out := make([]Template, 0, len(c.names))
+	for _, name := range c.names {
+		out = append(out, c.byName[name])
+	}
+	return out
+}
+
+// Get returns a template by name.
+func (c *Catalog) Get(name string) (Template, bool) {
+	template, ok := c.byName[NormalizeName(name)]
+	return template, ok
+}
+
+// Resolve returns the template for name, falling back to the default for an
+// empty name (projects created before templates existed) and for a name that
+// is no longer shipped. Provisioning must never fail because metadata refers
+// to a template that has since been removed.
+func (c *Catalog) Resolve(name string) Template {
+	if template, ok := c.Get(name); ok {
+		return template
+	}
+	return c.byName[DefaultName]
+}
+
+// Has reports whether name is a known template.
+func (c *Catalog) Has(name string) bool {
+	_, ok := c.Get(name)
+	return ok
+}
+
+// DefaultName returns the template assigned when a caller requests none.
+func (c *Catalog) DefaultName() string {
+	return DefaultName
+}

--- a/backend/internal/service/container/templates/catalog_test.go
+++ b/backend/internal/service/container/templates/catalog_test.go
@@ -1,0 +1,297 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestLoadShippedCatalog(t *testing.T) {
+	catalog, err := Load()
+	if err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+
+	want := []string{"blank", "wordpress", "laravel", "node", "python"}
+	got := catalog.Names()
+	if len(got) != len(want) {
+		t.Fatalf("Names() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Names() = %v, want %v", got, want)
+		}
+	}
+	if catalog.DefaultName() != DefaultName {
+		t.Fatalf("DefaultName() = %q, want %q", catalog.DefaultName(), DefaultName)
+	}
+}
+
+func TestShippedTemplateProperties(t *testing.T) {
+	catalog := MustLoad()
+
+	tests := []struct {
+		name           string
+		wantProvisions bool
+		wantImage      string
+		wantPorts      []int
+	}{
+		{name: "blank", wantProvisions: false, wantImage: ""},
+		{name: "wordpress", wantProvisions: true, wantImage: "futrx-remote-wordpress-base", wantPorts: []int{8080}},
+		{name: "laravel", wantProvisions: true, wantImage: "futrx-remote-laravel-base", wantPorts: []int{8000, 5173}},
+		{name: "node", wantProvisions: true, wantImage: "", wantPorts: []int{3000, 5173}},
+		{name: "python", wantProvisions: true, wantImage: "", wantPorts: []int{8000}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			template, ok := catalog.Get(tt.name)
+			if !ok {
+				t.Fatalf("Get(%q) missing", tt.name)
+			}
+			if template.Provisions() != tt.wantProvisions {
+				t.Fatalf("Provisions() = %t, want %t", template.Provisions(), tt.wantProvisions)
+			}
+			if template.ImageAlias() != tt.wantImage {
+				t.Fatalf("ImageAlias() = %q, want %q", template.ImageAlias(), tt.wantImage)
+			}
+			if len(template.DefaultPorts) != len(tt.wantPorts) {
+				t.Fatalf("DefaultPorts = %v, want %v", template.DefaultPorts, tt.wantPorts)
+			}
+			for i := range tt.wantPorts {
+				if template.DefaultPorts[i] != tt.wantPorts[i] {
+					t.Fatalf("DefaultPorts = %v, want %v", template.DefaultPorts, tt.wantPorts)
+				}
+			}
+			if tt.wantProvisions && len(template.Instructions) == 0 {
+				t.Fatal("a provisioning template must ship agent instructions")
+			}
+		})
+	}
+}
+
+func TestGetIsCaseInsensitiveAndResolveFallsBackToDefault(t *testing.T) {
+	catalog := MustLoad()
+
+	if _, ok := catalog.Get("  WordPress "); !ok {
+		t.Fatal("Get should normalize the requested name")
+	}
+	if !catalog.Has("PYTHON") {
+		t.Fatal("Has should normalize the requested name")
+	}
+	if catalog.Has("does-not-exist") {
+		t.Fatal("Has should reject an unknown template")
+	}
+	// A project created from a template that a later release dropped must keep
+	// starting; it degrades to the template that installs nothing.
+	if got := catalog.Resolve("retired-stack").Name; got != DefaultName {
+		t.Fatalf("Resolve(unknown) = %q, want %q", got, DefaultName)
+	}
+	if got := catalog.Resolve("").Name; got != DefaultName {
+		t.Fatalf("Resolve(\"\") = %q, want %q", got, DefaultName)
+	}
+}
+
+func TestLoadFSRejectsMalformedTemplates(t *testing.T) {
+	valid := `{"name":"blank","title":"Blank","description":"d","icon":"blank"}`
+
+	tests := []struct {
+		name    string
+		files   fstest.MapFS
+		wantErr string
+	}{
+		{
+			name: "missing default template",
+			files: fstest.MapFS{
+				"node/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"node","title":"Node","description":"d","icon":"node"}`),
+				},
+			},
+			wantErr: "default template",
+		},
+		{
+			name: "name does not match directory",
+			files: fstest.MapFS{
+				"blank/template.json": &fstest.MapFile{Data: []byte(valid)},
+				"other/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"node","title":"Node","description":"d","icon":"node"}`),
+				},
+			},
+			wantErr: "does not match its directory",
+		},
+		{
+			name: "invalid name",
+			files: fstest.MapFS{
+				"blank/template.json": &fstest.MapFile{Data: []byte(valid)},
+				"Bad_Name/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"Bad_Name","title":"x","description":"d","icon":"i"}`),
+				},
+			},
+			wantErr: "must match",
+		},
+		{
+			name: "missing title",
+			files: fstest.MapFS{
+				"blank/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"blank","title":" ","description":"d","icon":"i"}`),
+				},
+			},
+			wantErr: "title is required",
+		},
+		{
+			name: "unknown field",
+			files: fstest.MapFS{
+				"blank/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"blank","title":"t","description":"d","icon":"i","typo":1}`),
+				},
+			},
+			wantErr: "unknown field",
+		},
+		{
+			name: "port out of range",
+			files: fstest.MapFS{
+				"blank/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"blank","title":"t","description":"d","icon":"i","defaultPorts":[70000]}`),
+				},
+			},
+			wantErr: "out of range",
+		},
+		{
+			name: "seed escapes the workspace",
+			files: fstest.MapFS{
+				"blank/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"blank","title":"t","description":"d","icon":"i",` +
+						`"seedFiles":[{"source":"seed.txt","target":"/etc/passwd"}]}`),
+				},
+				"blank/seed.txt": &fstest.MapFile{Data: []byte("x")},
+			},
+			wantErr: "under /workspace",
+		},
+		{
+			name: "seed traverses upwards",
+			files: fstest.MapFS{
+				"blank/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"blank","title":"t","description":"d","icon":"i",` +
+						`"seedFiles":[{"source":"seed.txt","target":"/workspace/../etc/x"}]}`),
+				},
+				"blank/seed.txt": &fstest.MapFile{Data: []byte("x")},
+			},
+			wantErr: "clean absolute path",
+		},
+		{
+			name: "duplicate seed target",
+			files: fstest.MapFS{
+				"blank/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"blank","title":"t","description":"d","icon":"i",` +
+						`"seedFiles":[{"source":"a.txt","target":"/workspace/x"},` +
+						`{"source":"b.txt","target":"/workspace/x"}]}`),
+				},
+				"blank/a.txt": &fstest.MapFile{Data: []byte("a")},
+				"blank/b.txt": &fstest.MapFile{Data: []byte("b")},
+			},
+			wantErr: "declared twice",
+		},
+		{
+			name: "missing provision script",
+			files: fstest.MapFS{
+				"blank/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"blank","title":"t","description":"d","icon":"i","provisionScript":"gone.sh"}`),
+				},
+			},
+			wantErr: "provision script",
+		},
+		{
+			name: "script escapes the template directory",
+			files: fstest.MapFS{
+				"blank/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"blank","title":"t","description":"d","icon":"i","provisionScript":"../x.sh"}`),
+				},
+			},
+			wantErr: "relative file name",
+		},
+		{
+			name: "empty seed file",
+			files: fstest.MapFS{
+				"blank/template.json": &fstest.MapFile{
+					Data: []byte(`{"name":"blank","title":"t","description":"d","icon":"i",` +
+						`"seedFiles":[{"source":"a.txt","target":"/workspace/x"}]}`),
+				},
+				"blank/a.txt": &fstest.MapFile{Data: []byte("")},
+			},
+			wantErr: "is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadFS(tt.files)
+			if err == nil {
+				t.Fatal("LoadFS() = nil error, want failure")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("LoadFS() = %v, want an error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadFSResolvesReferencedFiles(t *testing.T) {
+	files := fstest.MapFS{
+		"blank/template.json": &fstest.MapFile{
+			Data: []byte(`{"name":"blank","title":"Blank","description":"d","icon":"i"}`),
+		},
+		"stack/template.json": &fstest.MapFile{
+			Data: []byte(`{"name":"stack","title":"Stack","description":"d","icon":"i",` +
+				`"provisionScript":"provision.sh","agentInstructions":"AGENTS.md",` +
+				`"seedFiles":[{"source":"README.md","target":"/workspace/README.md","mode":"600"}]}`),
+		},
+		"stack/provision.sh": &fstest.MapFile{Data: []byte("echo hi\n")},
+		"stack/AGENTS.md":    &fstest.MapFile{Data: []byte("# stack\n")},
+		"stack/README.md":    &fstest.MapFile{Data: []byte("readme\n")},
+	}
+
+	catalog, err := LoadFS(files)
+	if err != nil {
+		t.Fatalf("LoadFS() = %v", err)
+	}
+	template, ok := catalog.Get("stack")
+	if !ok {
+		t.Fatal("Get(stack) missing")
+	}
+	if string(template.Script) != "echo hi\n" {
+		t.Fatalf("Script = %q", template.Script)
+	}
+	if string(template.Instructions) != "# stack\n" {
+		t.Fatalf("Instructions = %q", template.Instructions)
+	}
+	if len(template.Seeds) != 1 ||
+		template.Seeds[0].Target != "/workspace/README.md" ||
+		template.Seeds[0].Mode != "600" ||
+		string(template.Seeds[0].Content) != "readme\n" {
+		t.Fatalf("Seeds = %+v", template.Seeds)
+	}
+	// The agent-instructions snippet is written as an implicit seed, after
+	// the declared ones.
+	seeds := template.allSeeds()
+	if len(seeds) != 2 || seeds[1].Target != InstructionsPath || seeds[1].Mode != "644" {
+		t.Fatalf("allSeeds() = %+v", seeds)
+	}
+}
+
+func TestSeedModeDefaultsTo644(t *testing.T) {
+	files := fstest.MapFS{
+		"blank/template.json": &fstest.MapFile{
+			Data: []byte(`{"name":"blank","title":"Blank","description":"d","icon":"i",` +
+				`"seedFiles":[{"source":"a.txt","target":"/workspace/a.txt"}]}`),
+		},
+		"blank/a.txt": &fstest.MapFile{Data: []byte("a")},
+	}
+	catalog, err := LoadFS(files)
+	if err != nil {
+		t.Fatalf("LoadFS() = %v", err)
+	}
+	template, _ := catalog.Get("blank")
+	if template.Seeds[0].Mode != "644" {
+		t.Fatalf("Mode = %q, want 644", template.Seeds[0].Mode)
+	}
+}

--- a/backend/internal/service/container/templates/laravel/AGENTS.md
+++ b/backend/internal/service/container/templates/laravel/AGENTS.md
@@ -1,0 +1,51 @@
+# Stack: Laravel
+
+This workspace was provisioned from the `laravel` project template.
+
+## What is installed
+
+| Piece | Detail |
+| --- | --- |
+| PHP | 8.3 CLI (`php`) with `mysql`, `sqlite3`, `curl`, `mbstring`, `xml`, `zip`, `intl`, `bcmath`, `gd` |
+| Composer | `/usr/local/bin/composer` |
+| Database | MariaDB, local only, started by systemd (`systemctl status mariadb`) |
+| DB auth | root, **no password**; database `laravel` already created |
+| Application | `/workspace/app` (`laravel/laravel` skeleton, `.env` already pointed at the local database) |
+| Node | 22 with `npm`, from the base image — used by Vite |
+
+The scaffold step is skipped when `/workspace` already has content, so a
+project cloned from git keeps its own application.
+
+## Rules that matter here
+
+- Keep everything under `/workspace`. The rest of the container filesystem is
+  replaced on workspace upgrade; this provisioning then re-runs automatically.
+- `.env` uses `DB_HOST=127.0.0.1` with user `root` and an empty password. The
+  database is reachable only from inside this container.
+- Run Composer with `COMPOSER_ALLOW_SUPERUSER=1` — the container is root-only.
+
+## Common tasks
+
+```bash
+cd /workspace/app
+
+php artisan migrate
+php artisan key:generate
+
+# Dev server. Bind 0.0.0.0 or the preview proxy cannot reach it.
+php artisan serve --host 0.0.0.0 --port 8000
+
+# Vite assets
+npm install && npm run dev -- --host 0.0.0.0
+```
+
+## Previews
+
+Ports 8000 (`artisan serve`) and 5173 (Vite) are this template's conventions;
+any listening port on `0.0.0.0` becomes a preview URL. Run long-lived servers
+as transient systemd units so they outlive the agent turn that started them:
+
+```bash
+systemd-run --unit=laravel-serve --working-directory=/workspace/app \
+  php artisan serve --host 0.0.0.0 --port 8000
+```

--- a/backend/internal/service/container/templates/laravel/provision.sh
+++ b/backend/internal/service/container/templates/laravel/provision.sh
@@ -1,0 +1,65 @@
+# PHP 8.3 is in the Ubuntu 24.04 repositories; no third-party PPA needed.
+# Node 22 (for Vite) is already in the base image.
+echo "--- installing PHP 8.3 and MariaDB ---"
+apt_retry update -qq
+apt_retry install -y -qq \
+    php8.3-cli php8.3-mysql php8.3-sqlite3 php8.3-curl php8.3-mbstring \
+    php8.3-xml php8.3-zip php8.3-intl php8.3-bcmath php8.3-gd \
+    mariadb-server mariadb-client \
+    unzip less
+
+echo "--- enabling MariaDB ---"
+systemctl enable mariadb
+systemctl start mariadb || service mariadb start
+
+for _ in $(seq 1 60); do
+    if mariadb-admin ping --silent 2>/dev/null || mysqladmin ping --silent 2>/dev/null; then
+        break
+    fi
+    sleep 2
+done
+
+# Container-local database, root over the unix socket, no password.
+echo "--- creating the laravel database ---"
+mysql -u root -e "CREATE DATABASE IF NOT EXISTS laravel DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+
+echo "--- installing Composer ---"
+curl -fsSL https://getcomposer.org/installer -o /tmp/composer-setup.php
+php /tmp/composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
+rm -f /tmp/composer-setup.php
+
+# Only scaffold into an empty workspace. A project restored from git, or a
+# container replaced after the first provisioning, must never be overwritten.
+if [ -f /workspace/app/artisan ]; then
+    echo "Laravel application already present in /workspace/app - skipping scaffold"
+elif [ -n "$(ls -A /workspace 2>/dev/null | grep -v -e '^\.agents$' -e '^\.browser$' -e '^scripts$' -e '^AGENTS\.md$' -e '^CLAUDE\.md$' -e '^README\.md$' || true)" ]; then
+    echo "/workspace is not empty - skipping the laravel/laravel scaffold"
+else
+    echo "--- creating the Laravel application ---"
+    COMPOSER_ALLOW_SUPERUSER=1 composer create-project --no-interaction \
+        laravel/laravel /workspace/app
+fi
+
+if [ -f /workspace/app/.env ]; then
+    echo "--- pointing .env at the local MariaDB ---"
+    sed -i \
+        -e 's/^# *DB_CONNECTION=.*/DB_CONNECTION=mysql/' \
+        -e 's/^DB_CONNECTION=.*/DB_CONNECTION=mysql/' \
+        -e 's/^# *DB_HOST=.*/DB_HOST=127.0.0.1/' \
+        -e 's/^DB_HOST=.*/DB_HOST=127.0.0.1/' \
+        -e 's/^# *DB_PORT=.*/DB_PORT=3306/' \
+        -e 's/^DB_PORT=.*/DB_PORT=3306/' \
+        -e 's/^# *DB_DATABASE=.*/DB_DATABASE=laravel/' \
+        -e 's/^DB_DATABASE=.*/DB_DATABASE=laravel/' \
+        -e 's/^# *DB_USERNAME=.*/DB_USERNAME=root/' \
+        -e 's/^DB_USERNAME=.*/DB_USERNAME=root/' \
+        -e 's/^# *DB_PASSWORD=.*/DB_PASSWORD=/' \
+        -e 's/^DB_PASSWORD=.*/DB_PASSWORD=/' \
+        /workspace/app/.env
+fi
+
+echo "--- versions ---"
+php --version | head -1
+composer --version
+node --version
+mysql --version

--- a/backend/internal/service/container/templates/laravel/template.json
+++ b/backend/internal/service/container/templates/laravel/template.json
@@ -1,0 +1,10 @@
+{
+  "name": "laravel",
+  "title": "Laravel",
+  "description": "PHP 8.3 with the Laravel extension set, Composer, a local MariaDB, and a fresh laravel/laravel skeleton in /workspace/app wired to the database. Node 22 for Vite comes from the base image.",
+  "icon": "laravel",
+  "provisionScript": "provision.sh",
+  "agentInstructions": "AGENTS.md",
+  "defaultPorts": [8000, 5173],
+  "prebuiltImage": true
+}

--- a/backend/internal/service/container/templates/model.go
+++ b/backend/internal/service/container/templates/model.go
@@ -1,0 +1,191 @@
+// Package templates owns the project stack presets ("templates") a project
+// container is created from.
+//
+// A template is deliberately a LAYER on top of the single shared base image
+// rather than its own full image: the target deployment is one small server,
+// so baking N complete images is expensive in build time and disk. A template
+// therefore is:
+//
+//  1. the shared base image (futrx-remote-dev-base), plus
+//  2. a post-provision script executed once inside the new container, plus
+//  3. optional seed files written into the durable /workspace mount, plus
+//  4. an optional agent-instructions snippet seeded as /workspace/AGENTS.md.
+//
+// A template MAY additionally declare a dedicated pre-built image alias
+// (futrx-remote-<name>-base). When that alias exists in the container runtime
+// the lifecycle launches from it directly (fast path); otherwise it falls back
+// to base image + provision script (slow path). Both paths converge on the
+// same rootfs contents, and both leave the same marker file behind.
+package templates
+
+import "strings"
+
+// DefaultName is the template used by projects created before templates
+// existed and by projects that do not request one. It installs nothing, which
+// is exactly the pre-template behaviour.
+const DefaultName = "blank"
+
+// Container paths owned by template provisioning. They live in the disposable
+// rootfs on purpose: replacing a container (workspace upgrade) must re-run the
+// provisioning, because everything the script installed outside /workspace is
+// gone with the old rootfs.
+const (
+	// LogPath collects every provisioning run's output inside the container.
+	LogPath = "/var/log/remote-template.log"
+	// MarkerPath exists only after a provisioning run completed successfully.
+	// Its presence makes every later run a no-op.
+	MarkerPath = "/var/lib/remote-template.done"
+	// FailurePath exists while a provisioning run is in flight and is removed
+	// on success, so a backend restart can still tell "failed" from "pending".
+	FailurePath = "/var/lib/remote-template.failed"
+	// InstructionsPath is where a template's agent-instructions snippet is
+	// seeded. Never overwritten when the file already exists.
+	InstructionsPath = "/workspace/AGENTS.md"
+)
+
+// imageAliasPrefix and imageAliasSuffix bracket the dedicated pre-built image
+// alias of a template that declares one.
+const (
+	imageAliasPrefix = "futrx-remote-"
+	imageAliasSuffix = "-base"
+)
+
+// Status is the observable state of one container's template provisioning.
+type Status string
+
+const (
+	// StatusNone means the template has nothing to provision (e.g. "blank").
+	StatusNone Status = "none"
+	// StatusPending means provisioning is required but has not started (or the
+	// backend restarted before it could finish).
+	StatusPending Status = "pending"
+	// StatusRunning means the provision script is executing.
+	StatusRunning Status = "running"
+	// StatusDone means the marker file is present.
+	StatusDone Status = "done"
+	// StatusFailed means the last provisioning attempt exited non-zero.
+	StatusFailed Status = "failed"
+)
+
+// SeedFile declares one file copied into the container when it is absent.
+// Seeding never overwrites: a workspace is durable and may already hold the
+// user's own file at that path.
+type SeedFile struct {
+	// Source is a file name relative to the template's directory.
+	Source string `json:"source"`
+	// Target is an absolute path inside the container. It must live under
+	// /workspace so the seed survives container replacement.
+	Target string `json:"target"`
+	// Mode is the octal file mode passed to the runtime. Defaults to 644.
+	Mode string `json:"mode,omitempty"`
+}
+
+// Definition is the on-disk shape of a template's template.json.
+type Definition struct {
+	Name        string `json:"name"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	// Icon is a stable key the frontend maps to a glyph. Unknown keys fall
+	// back to a generic icon, so adding a template never breaks the UI.
+	Icon string `json:"icon"`
+	// ProvisionScript is a file name relative to the template's directory.
+	// Empty means the template installs nothing.
+	ProvisionScript string `json:"provisionScript,omitempty"`
+	// AgentInstructions is a file name relative to the template's directory
+	// whose contents are seeded as /workspace/AGENTS.md.
+	AgentInstructions string `json:"agentInstructions,omitempty"`
+	// SeedFiles are additional files written into /workspace when absent.
+	SeedFiles []SeedFile `json:"seedFiles,omitempty"`
+	// DefaultPorts are the TCP ports this stack is expected to listen on.
+	// Purely informational: previews are discovered, never declared.
+	DefaultPorts []int `json:"defaultPorts,omitempty"`
+	// PrebuiltImage declares that this template has a dedicated image alias
+	// that `build-template-image` can publish.
+	PrebuiltImage bool `json:"prebuiltImage,omitempty"`
+}
+
+// Template is a validated definition with its referenced files resolved.
+type Template struct {
+	Definition
+	// Script is the provision program's payload (without the shared harness).
+	Script []byte
+	// Instructions is the agent-instructions snippet, if any.
+	Instructions []byte
+	// Seeds carries the resolved contents of Definition.SeedFiles.
+	Seeds []Seed
+}
+
+// Seed is a SeedFile with its content resolved from the embedded files.
+type Seed struct {
+	Target  string
+	Mode    string
+	Content []byte
+}
+
+// ImageAlias returns the dedicated pre-built image alias for a template, or an
+// empty string when the template does not declare one.
+func (t Template) ImageAlias() string {
+	if !t.PrebuiltImage {
+		return ""
+	}
+	return ImageAlias(t.Name)
+}
+
+// ImageAlias returns the conventional dedicated image alias for a template
+// name. Exported so the build CLI can name its publish target without loading
+// the catalog twice.
+func ImageAlias(name string) string {
+	return imageAliasPrefix + name + imageAliasSuffix
+}
+
+// Provisions reports whether this template has any post-launch work at all.
+// A template without work never issues a single runtime call.
+func (t Template) Provisions() bool {
+	return len(t.Script) > 0 || len(t.Seeds) > 0 || len(t.Instructions) > 0
+}
+
+// allSeeds returns the file seeds plus the implicit agent-instructions seed,
+// in the order they are written.
+func (t Template) allSeeds() []Seed {
+	seeds := make([]Seed, 0, len(t.Seeds)+1)
+	seeds = append(seeds, t.Seeds...)
+	if len(t.Instructions) > 0 {
+		seeds = append(seeds, Seed{
+			Target:  InstructionsPath,
+			Mode:    "644",
+			Content: t.Instructions,
+		})
+	}
+	return seeds
+}
+
+// Descriptor is the catalog entry published over HTTP. It carries the
+// presentation metadata plus whether the fast (pre-built image) path is
+// currently available on this host.
+type Descriptor struct {
+	Name                   string `json:"name"`
+	Title                  string `json:"title"`
+	Description            string `json:"description"`
+	Icon                   string `json:"icon"`
+	DefaultPorts           []int  `json:"defaultPorts,omitempty"`
+	Default                bool   `json:"default"`
+	Provisions             bool   `json:"provisions"`
+	PrebuiltImage          string `json:"prebuiltImage,omitempty"`
+	PrebuiltImageAvailable bool   `json:"prebuiltImageAvailable"`
+}
+
+// State is one container's template provisioning state.
+type State struct {
+	Template   string
+	Title      string
+	Status     Status
+	Error      string
+	LogPath    string
+	StartedAt  int64
+	FinishedAt int64
+}
+
+// NormalizeName lowercases and trims a requested template name.
+func NormalizeName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}

--- a/backend/internal/service/container/templates/node/AGENTS.md
+++ b/backend/internal/service/container/templates/node/AGENTS.md
@@ -1,0 +1,21 @@
+# Stack: Node.js
+
+This workspace was provisioned from the `node` project template.
+
+- Node 22, `npm`, `npx` are on `PATH` from the base image.
+- `pnpm` and `yarn` are enabled through `corepack`; prefer `pnpm`.
+- Nothing else is installed. `apt-get install` whatever the project needs.
+
+## Previews
+
+Dev servers must bind `0.0.0.0` (not `127.0.0.1`) to be reachable through the
+platform's preview URLs. Ports 3000 and 5173 are the conventional ones for
+this template, but any listening port is discovered automatically.
+
+Run long-lived dev servers as transient systemd units so they survive the
+agent turn that started them:
+
+```bash
+systemd-run --unit=dev-server --working-directory=/workspace/app \
+  pnpm dev --host 0.0.0.0 --port 5173
+```

--- a/backend/internal/service/container/templates/node/README.md
+++ b/backend/internal/service/container/templates/node/README.md
@@ -1,0 +1,18 @@
+# Node.js workspace
+
+This project was created from the **Node.js** template.
+
+- Node 22, `npm`, and `npx` come from the base image.
+- `pnpm` and `yarn` are enabled through `corepack`.
+
+## Start a project
+
+```bash
+cd /workspace
+pnpm create vite@latest app
+cd app && pnpm install
+pnpm dev --host 0.0.0.0 --port 5173
+```
+
+Bind dev servers to `0.0.0.0`. A server on `127.0.0.1` is invisible to the
+preview proxy, which reaches the container over its network address.

--- a/backend/internal/service/container/templates/node/provision.sh
+++ b/backend/internal/service/container/templates/node/provision.sh
@@ -1,0 +1,12 @@
+# Node 22, npm and npx are already in the base image. Corepack ships with
+# Node, so enabling pnpm/yarn costs no network round-trip to apt.
+echo "--- enabling corepack package managers ---"
+corepack enable
+corepack prepare pnpm@latest --activate
+corepack prepare yarn@stable --activate
+
+echo "--- versions ---"
+node --version
+npm --version
+pnpm --version
+yarn --version

--- a/backend/internal/service/container/templates/node/template.json
+++ b/backend/internal/service/container/templates/node/template.json
@@ -1,0 +1,12 @@
+{
+  "name": "node",
+  "title": "Node.js",
+  "description": "Node 22 (already in the base image) with pnpm and yarn enabled through corepack, plus a workspace README. Light: nothing is downloaded from apt.",
+  "icon": "node",
+  "provisionScript": "provision.sh",
+  "agentInstructions": "AGENTS.md",
+  "seedFiles": [
+    { "source": "README.md", "target": "/workspace/README.md" }
+  ],
+  "defaultPorts": [3000, 5173]
+}

--- a/backend/internal/service/container/templates/ports.go
+++ b/backend/internal/service/container/templates/ports.go
@@ -1,0 +1,21 @@
+package templates
+
+import "context"
+
+// Runtime is the template workflow's container port. Command arguments and
+// transport details stay behind it, so the provisioning policy above is
+// testable without LXD.
+type Runtime interface {
+	Available() bool
+	// FileExists reports whether an absolute path exists in the container.
+	FileExists(ctx context.Context, containerName, path string) (bool, error)
+	// EnsureDirectory creates a directory (and parents) in the container.
+	EnsureDirectory(ctx context.Context, containerName, path string) error
+	// PushFile writes content to an absolute container path with fileMode.
+	PushFile(ctx context.Context, containerName string, content []byte, target, fileMode string) error
+	// RunScript executes a bash program inside the container and returns its
+	// combined output.
+	RunScript(ctx context.Context, containerName, script string) (string, error)
+	// ImageExists reports whether an image alias is published on this host.
+	ImageExists(ctx context.Context, alias string) (bool, error)
+}

--- a/backend/internal/service/container/templates/provisioning.go
+++ b/backend/internal/service/container/templates/provisioning.go
@@ -1,0 +1,140 @@
+package templates
+
+import "strings"
+
+// Decision is the outcome of the provisioning rule for one container. It is a
+// pure function of the template and two observations, which keeps the policy
+// unit-testable without a container runtime.
+type Decision struct {
+	// Run reports whether the provision program must be executed now.
+	Run bool
+	// Status is the state to report while/after acting on this decision.
+	Status Status
+	// Reason explains the decision in logs and tests.
+	Reason string
+}
+
+// Observation is what the caller knows about a container before deciding.
+type Observation struct {
+	// MarkerPresent is true when MarkerPath exists in the container, meaning a
+	// previous run (or a pre-built template image) already provisioned it.
+	MarkerPresent bool
+	// FailurePresent is true when FailurePath exists, meaning the last attempt
+	// started and did not reach the end of the program.
+	FailurePresent bool
+	// InFlight is true when this process already has a provisioning goroutine
+	// running for the container.
+	InFlight bool
+}
+
+// Decide applies the provisioning rule:
+//
+//   - a template with nothing to install never touches the container;
+//   - the success marker wins over everything else, so a container launched
+//     from a pre-built template image is never re-provisioned;
+//   - one run at a time per container;
+//   - otherwise provision, including after a previous failure — the rootfs is
+//     disposable, and every script is written to be idempotent.
+func Decide(template Template, observation Observation) Decision {
+	if !template.Provisions() {
+		return Decision{Status: StatusNone, Reason: "template installs nothing"}
+	}
+	if observation.MarkerPresent {
+		return Decision{Status: StatusDone, Reason: "marker present"}
+	}
+	if observation.InFlight {
+		return Decision{Status: StatusRunning, Reason: "provisioning already in flight"}
+	}
+	if observation.FailurePresent {
+		return Decision{Run: true, Status: StatusRunning, Reason: "retrying after a failed run"}
+	}
+	return Decision{Run: true, Status: StatusRunning, Reason: "marker absent"}
+}
+
+// ObservedStatus reports the durable status of a container whose provisioning
+// this process is not tracking in memory — after a backend restart, say.
+func ObservedStatus(template Template, observation Observation) Status {
+	if !template.Provisions() {
+		return StatusNone
+	}
+	switch {
+	case observation.MarkerPresent:
+		return StatusDone
+	case observation.InFlight:
+		return StatusRunning
+	case observation.FailurePresent:
+		return StatusFailed
+	default:
+		return StatusPending
+	}
+}
+
+// provisionPreamble is the harness every template script runs inside. It
+// supplies the non-interactive apt environment, the shared log, the marker
+// protocol, and a single apt retry (package mirrors on a fresh container
+// occasionally answer before their network is fully up).
+const provisionPreamble = `set -eu
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+export APT_LISTCHANGES_FRONTEND=none
+REMOTE_TEMPLATE_NAME='__TEMPLATE__'
+REMOTE_TEMPLATE_LOG='__LOG__'
+REMOTE_TEMPLATE_MARKER='__MARKER__'
+REMOTE_TEMPLATE_FAILED='__FAILED__'
+mkdir -p "$(dirname "$REMOTE_TEMPLATE_LOG")" "$(dirname "$REMOTE_TEMPLATE_MARKER")"
+# Everything below is both streamed back to the caller and appended to the
+# in-container log, so a failure is diagnosable from the host and from inside.
+exec > >(tee -a "$REMOTE_TEMPLATE_LOG") 2>&1
+echo "=== remote template '$REMOTE_TEMPLATE_NAME' provisioning $(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
+if [ -f "$REMOTE_TEMPLATE_MARKER" ]; then
+  echo "marker $REMOTE_TEMPLATE_MARKER present - nothing to do"
+  exit 0
+fi
+# The failure marker exists for the duration of the run and is removed on
+# success, so an interrupted run is reported as failed rather than pending.
+printf 'started %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" > "$REMOTE_TEMPLATE_FAILED"
+
+# apt_retry runs apt-get once, then refreshes the index and retries exactly
+# once. Templates use it for every network-touching apt call.
+apt_retry() {
+  if apt-get "$@"; then
+    return 0
+  fi
+  echo "apt-get $* failed; refreshing package index and retrying once"
+  sleep 5
+  apt-get update -qq || true
+  apt-get "$@"
+}
+
+`
+
+// provisionEpilogue records success. Reaching it means every command in the
+// payload succeeded, because the harness runs under 'set -e'.
+const provisionEpilogue = `
+
+rm -f "$REMOTE_TEMPLATE_FAILED"
+printf '%s\n' "$REMOTE_TEMPLATE_NAME" > "$REMOTE_TEMPLATE_MARKER"
+echo "=== remote template '$REMOTE_TEMPLATE_NAME' provisioning complete ==="
+`
+
+// ProvisionProgram wraps a template's payload in the shared harness. The
+// result is a bash program: it is executed with 'bash -c' inside the
+// container and is safe to run repeatedly. A template with seeds but no
+// script still gets the harness, so that its marker is written once and the
+// seeding is not retried on every start.
+func ProvisionProgram(template Template) string {
+	if !template.Provisions() {
+		return ""
+	}
+	replacer := strings.NewReplacer(
+		"__TEMPLATE__", template.Name,
+		"__LOG__", LogPath,
+		"__MARKER__", MarkerPath,
+		"__FAILED__", FailurePath,
+	)
+	var program strings.Builder
+	program.WriteString(replacer.Replace(provisionPreamble))
+	program.WriteString(strings.TrimRight(string(template.Script), "\n"))
+	program.WriteString(provisionEpilogue)
+	return program.String()
+}

--- a/backend/internal/service/container/templates/provisioning_test.go
+++ b/backend/internal/service/container/templates/provisioning_test.go
@@ -1,0 +1,205 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+)
+
+func provisioningTemplate() Template {
+	return Template{
+		Definition: Definition{Name: "stack", Title: "Stack"},
+		Script:     []byte("echo install\n"),
+	}
+}
+
+func TestDecide(t *testing.T) {
+	blank := Template{Definition: Definition{Name: "blank"}}
+	stack := provisioningTemplate()
+	seedOnly := Template{
+		Definition: Definition{Name: "seeded"},
+		Seeds:      []Seed{{Target: "/workspace/README.md", Mode: "644", Content: []byte("x")}},
+	}
+
+	tests := []struct {
+		name        string
+		template    Template
+		observation Observation
+		wantRun     bool
+		wantStatus  Status
+	}{
+		{
+			name:       "template without work never touches the container",
+			template:   blank,
+			wantRun:    false,
+			wantStatus: StatusNone,
+		},
+		{
+			name:        "marker wins over everything",
+			template:    stack,
+			observation: Observation{MarkerPresent: true, FailurePresent: true, InFlight: true},
+			wantRun:     false,
+			wantStatus:  StatusDone,
+		},
+		{
+			name:        "already running is not started twice",
+			template:    stack,
+			observation: Observation{InFlight: true},
+			wantRun:     false,
+			wantStatus:  StatusRunning,
+		},
+		{
+			name:        "a previous failure is retried",
+			template:    stack,
+			observation: Observation{FailurePresent: true},
+			wantRun:     true,
+			wantStatus:  StatusRunning,
+		},
+		{
+			name:       "a fresh container is provisioned",
+			template:   stack,
+			wantRun:    true,
+			wantStatus: StatusRunning,
+		},
+		{
+			name:       "seeds alone are enough work to provision",
+			template:   seedOnly,
+			wantRun:    true,
+			wantStatus: StatusRunning,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Decide(tt.template, tt.observation)
+			if got.Run != tt.wantRun || got.Status != tt.wantStatus {
+				t.Fatalf("Decide() = %+v, want Run=%t Status=%q", got, tt.wantRun, tt.wantStatus)
+			}
+			if got.Reason == "" {
+				t.Fatal("Decide() must explain itself")
+			}
+		})
+	}
+}
+
+func TestObservedStatus(t *testing.T) {
+	blank := Template{Definition: Definition{Name: "blank"}}
+	stack := provisioningTemplate()
+
+	tests := []struct {
+		name        string
+		template    Template
+		observation Observation
+		want        Status
+	}{
+		{name: "nothing to install", template: blank, want: StatusNone},
+		{name: "done", template: stack, observation: Observation{MarkerPresent: true}, want: StatusDone},
+		{name: "running", template: stack, observation: Observation{InFlight: true}, want: StatusRunning},
+		{
+			name:        "an interrupted run reads as failed, not pending",
+			template:    stack,
+			observation: Observation{FailurePresent: true},
+			want:        StatusFailed,
+		},
+		{name: "pending", template: stack, want: StatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ObservedStatus(tt.template, tt.observation); got != tt.want {
+				t.Fatalf("ObservedStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProvisionProgram(t *testing.T) {
+	program := ProvisionProgram(provisioningTemplate())
+
+	for _, want := range []string{
+		"set -eu",
+		"DEBIAN_FRONTEND=noninteractive",
+		LogPath,
+		MarkerPath,
+		FailurePath,
+		"apt_retry()",
+		"echo install",
+	} {
+		if !strings.Contains(program, want) {
+			t.Fatalf("program is missing %q:\n%s", want, program)
+		}
+	}
+	// The marker check must precede the payload so a re-run is a no-op, and
+	// the marker write must follow it so a failure never records success.
+	markerCheck := strings.Index(program, `if [ -f "$REMOTE_TEMPLATE_MARKER" ]`)
+	payload := strings.Index(program, "echo install")
+	markerWrite := strings.LastIndex(program, `> "$REMOTE_TEMPLATE_MARKER"`)
+	if markerCheck < 0 || payload < 0 || markerWrite < 0 {
+		t.Fatalf("program is missing the marker protocol:\n%s", program)
+	}
+	if !(markerCheck < payload && payload < markerWrite) {
+		t.Fatalf("marker protocol is out of order (%d, %d, %d)", markerCheck, payload, markerWrite)
+	}
+}
+
+func TestProvisionProgramForTemplatesWithoutAScript(t *testing.T) {
+	// Nothing to do at all: no program, so no runtime call.
+	blank := Template{Definition: Definition{Name: "blank"}}
+	if got := ProvisionProgram(blank); got != "" {
+		t.Fatalf("ProvisionProgram(blank) = %q, want empty", got)
+	}
+
+	// Seeds but no script: the harness alone still runs, so the marker is
+	// written once and the seeding is not retried on every container start.
+	seeded := Template{
+		Definition: Definition{Name: "seeded"},
+		Seeds:      []Seed{{Target: "/workspace/README.md", Mode: "644", Content: []byte("x")}},
+	}
+	program := ProvisionProgram(seeded)
+	if !strings.Contains(program, MarkerPath) {
+		t.Fatalf("seed-only program must still write the marker:\n%s", program)
+	}
+}
+
+func TestShippedProvisionScriptsUseTheHarness(t *testing.T) {
+	catalog := MustLoad()
+	for _, template := range catalog.List() {
+		if len(template.Script) == 0 {
+			continue
+		}
+		script := string(template.Script)
+		// The harness owns the shebang, `set -eu`, the log, and the marker;
+		// a payload that redefines them would defeat the idempotency contract.
+		// (Heredocs inside a payload may of course carry their own shebang.)
+		if strings.HasPrefix(script, "#!") {
+			t.Errorf("template %q: payload must not start with a shebang", template.Name)
+		}
+		for _, forbidden := range []string{"set -e", MarkerPath, "DEBIAN_FRONTEND="} {
+			if strings.Contains(script, forbidden) {
+				t.Errorf("template %q: payload must not contain %q (the harness owns it)",
+					template.Name, forbidden)
+			}
+		}
+		// Network-touching apt calls must go through the retry helper.
+		for _, line := range strings.Split(script, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "apt-get ") || strings.HasPrefix(trimmed, "apt ") {
+				t.Errorf("template %q: use apt_retry instead of a bare apt call: %s",
+					template.Name, trimmed)
+			}
+		}
+	}
+}
+
+func TestImageAlias(t *testing.T) {
+	if got := ImageAlias("wordpress"); got != "futrx-remote-wordpress-base" {
+		t.Fatalf("ImageAlias() = %q", got)
+	}
+	declared := Template{Definition: Definition{Name: "wordpress", PrebuiltImage: true}}
+	if got := declared.ImageAlias(); got != "futrx-remote-wordpress-base" {
+		t.Fatalf("declared ImageAlias() = %q", got)
+	}
+	undeclared := Template{Definition: Definition{Name: "node"}}
+	if got := undeclared.ImageAlias(); got != "" {
+		t.Fatalf("undeclared ImageAlias() = %q, want empty", got)
+	}
+}

--- a/backend/internal/service/container/templates/python/AGENTS.md
+++ b/backend/internal/service/container/templates/python/AGENTS.md
@@ -1,0 +1,26 @@
+# Stack: Python
+
+This workspace was provisioned from the `python` project template.
+
+- `python3` is Python 3.12 (Ubuntu 24.04 system interpreter).
+- `/workspace/.venv` is a durable project virtualenv. Activate it with
+  `source /workspace/.venv/bin/activate`, or call
+  `/workspace/.venv/bin/python` directly.
+- `uv` is installed at `/usr/local/bin/uv`. Prefer `uv pip install` over bare
+  `pip` — it is much faster on a small host.
+- `pipx` is available for CLI tools. Poetry is intentionally NOT installed;
+  run `pipx install poetry` only if the project actually uses it.
+
+Never `pip install` into the system interpreter: Ubuntu marks it as an
+externally managed environment and the install will be refused. Use the venv.
+
+## Previews
+
+Bind servers to `0.0.0.0`, not `127.0.0.1`, or the preview proxy cannot reach
+them. Port 8000 is this template's convention. Run long-lived servers as
+transient systemd units so they outlive the agent turn:
+
+```bash
+systemd-run --unit=dev-server --working-directory=/workspace \
+  /workspace/.venv/bin/uvicorn app:app --host 0.0.0.0 --port 8000
+```

--- a/backend/internal/service/container/templates/python/README.md
+++ b/backend/internal/service/container/templates/python/README.md
@@ -1,0 +1,19 @@
+# Python workspace
+
+This project was created from the **Python** template.
+
+- System interpreter: Python 3.12 (`python3`).
+- Project virtualenv: `/workspace/.venv` — durable, survives container
+  replacement.
+- Package managers: `uv` (preferred) and `pip`.
+
+## Everyday use
+
+```bash
+source /workspace/.venv/bin/activate
+uv pip install fastapi uvicorn
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+Poetry is not installed. Add it with `pipx install poetry` if the project
+needs it.

--- a/backend/internal/service/container/templates/python/provision.sh
+++ b/backend/internal/service/container/templates/python/provision.sh
@@ -1,0 +1,26 @@
+# Ubuntu 24.04 ships Python 3.12 as the system interpreter; the base image
+# already pulled python3-pip. Add the venv module and pipx.
+echo "--- installing python tooling ---"
+apt_retry update -qq
+apt_retry install -y -qq python3.12-venv python3-dev pipx
+
+# uv: fast resolver/installer, used by most modern Python projects. Installed
+# to /usr/local/bin so every shell in the container sees it.
+echo "--- installing uv ---"
+export UV_INSTALL_DIR=/usr/local/bin
+export INSTALLER_NO_MODIFY_PATH=1
+curl -fsSL https://astral.sh/uv/install.sh | sh
+
+# A project virtualenv in the durable workspace, so it survives container
+# replacement along with the rest of /workspace.
+if [ ! -d /workspace/.venv ]; then
+  echo "--- creating /workspace/.venv ---"
+  python3 -m venv /workspace/.venv
+  /workspace/.venv/bin/python -m pip install --quiet --upgrade pip
+fi
+
+echo "--- versions ---"
+python3 --version
+/workspace/.venv/bin/python --version
+/usr/local/bin/uv --version
+pipx --version

--- a/backend/internal/service/container/templates/python/template.json
+++ b/backend/internal/service/container/templates/python/template.json
@@ -1,0 +1,12 @@
+{
+  "name": "python",
+  "title": "Python",
+  "description": "Python 3.12 with venv and pip, a ready-made /workspace/.venv, and the uv package manager. Poetry is left out on purpose; install it with pipx when a project needs it.",
+  "icon": "python",
+  "provisionScript": "provision.sh",
+  "agentInstructions": "AGENTS.md",
+  "seedFiles": [
+    { "source": "README.md", "target": "/workspace/README.md" }
+  ],
+  "defaultPorts": [8000]
+}

--- a/backend/internal/service/container/templates/service.go
+++ b/backend/internal/service/container/templates/service.go
@@ -1,0 +1,315 @@
+package templates
+
+import (
+	"context"
+	"log"
+	"path"
+	"sync"
+	"time"
+
+	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
+	"github.com/futrx-com/remote.futrx.com/internal/shared/output"
+)
+
+// provisionTimeout bounds one provisioning run. A WordPress or Laravel stack
+// on a small host is minutes of apt and composer work, so the budget is
+// generous; it exists to stop a wedged run from leaking a goroutine forever.
+const provisionTimeout = 45 * time.Minute
+
+// probeTimeout bounds the cheap marker/seed probes on the hot path (every
+// project start pays one of them for a provisioning template).
+const probeTimeout = 15 * time.Second
+
+var _ serviceproject.ContainerTemplates = (*Service)(nil)
+
+// Service applies templates to project containers. Provisioning runs in the
+// background because it can take many minutes; callers observe progress
+// through Status, which the project status payload surfaces.
+type Service struct {
+	catalog *Catalog
+	runtime Runtime
+	timeout time.Duration
+
+	mu     sync.Mutex
+	states map[string]State
+}
+
+// NewService returns a template service backed by a container runtime.
+func NewService(catalog *Catalog, runtime Runtime) *Service {
+	return &Service{
+		catalog: catalog,
+		runtime: runtime,
+		timeout: provisionTimeout,
+		states:  make(map[string]State),
+	}
+}
+
+// Catalog exposes the immutable template set.
+func (s *Service) Catalog() *Catalog { return s.catalog }
+
+// Has reports whether name is a known template.
+func (s *Service) Has(name string) bool { return s.catalog.Has(name) }
+
+// DefaultName returns the template assigned when a caller requests none.
+func (s *Service) DefaultName() string { return s.catalog.DefaultName() }
+
+// List returns the catalog annotated with per-host availability of each
+// template's dedicated pre-built image.
+func (s *Service) List(ctx context.Context) []Descriptor {
+	templates := s.catalog.List()
+	out := make([]Descriptor, 0, len(templates))
+	for _, template := range templates {
+		descriptor := Descriptor{
+			Name:          template.Name,
+			Title:         template.Title,
+			Description:   template.Description,
+			Icon:          template.Icon,
+			DefaultPorts:  template.DefaultPorts,
+			Default:       template.Name == DefaultName,
+			Provisions:    template.Provisions(),
+			PrebuiltImage: template.ImageAlias(),
+		}
+		if descriptor.PrebuiltImage != "" {
+			descriptor.PrebuiltImageAvailable = s.imagePublished(ctx, descriptor.PrebuiltImage)
+		}
+		out = append(out, descriptor)
+	}
+	return out
+}
+
+// ImageFor returns the dedicated image alias a template's containers should
+// launch from, or an empty string when the caller must fall back to the shared
+// base image plus a provision script.
+func (s *Service) ImageFor(ctx context.Context, name string) string {
+	alias := s.catalog.Resolve(name).ImageAlias()
+	if alias == "" || !s.imagePublished(ctx, alias) {
+		return ""
+	}
+	return alias
+}
+
+func (s *Service) imagePublished(ctx context.Context, alias string) bool {
+	if s.runtime == nil || !s.runtime.Available() {
+		return false
+	}
+	pctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	published, err := s.runtime.ImageExists(pctx, alias)
+	if err != nil {
+		log.Printf("templates: probe image %s: %v", alias, err)
+		return false
+	}
+	return published
+}
+
+// Ensure provisions a container for its template unless the marker file says a
+// previous run (or a pre-built template image) already did. It returns a
+// channel closed once any background work has settled; the lifecycle ignores
+// it, tests and future callers can wait on it.
+//
+// Ensure is called on every convergence of a project container, not only on
+// creation: the container rootfs is disposable, so a replaced container must
+// be re-provisioned, and an interrupted run must be retried.
+func (s *Service) Ensure(ctx context.Context, containerName, name string) <-chan struct{} {
+	done := make(chan struct{})
+	template := s.catalog.Resolve(name)
+	if !template.Provisions() || s.runtime == nil || !s.runtime.Available() {
+		close(done)
+		return done
+	}
+
+	observation := s.observe(ctx, containerName)
+	observation.InFlight = s.inFlight(containerName)
+	decision := Decide(template, observation)
+	if !decision.Run {
+		s.recordObserved(containerName, template, observation)
+		close(done)
+		return done
+	}
+
+	s.begin(containerName, template)
+	// Provisioning deliberately outlives the request that triggered it: the
+	// caller is a container start, which must not block for minutes.
+	go func() {
+		defer close(done)
+		runCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.timeout)
+		defer cancel()
+		s.finish(containerName, template, s.provision(runCtx, containerName, template))
+	}()
+	return done
+}
+
+// provision writes the seeds and runs the provision program. Seeding happens
+// first so the agent instructions are in place even if the install fails.
+func (s *Service) provision(ctx context.Context, containerName string, template Template) error {
+	for _, seed := range template.allSeeds() {
+		if err := s.seed(ctx, containerName, seed); err != nil {
+			return err
+		}
+	}
+	program := ProvisionProgram(template)
+	if program == "" {
+		return nil
+	}
+	if out, err := s.runtime.RunScript(ctx, containerName, program); err != nil {
+		return provisionError{
+			template: template.Name,
+			cause:    err,
+			output:   output.TruncateTail(out, 2000),
+		}
+	}
+	return nil
+}
+
+// seed writes one file, never overwriting an existing one: /workspace is
+// durable and may already hold the user's own version of that path.
+func (s *Service) seed(ctx context.Context, containerName string, seed Seed) error {
+	exists, err := s.runtime.FileExists(ctx, containerName, seed.Target)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	if err := s.runtime.EnsureDirectory(ctx, containerName, path.Dir(seed.Target)); err != nil {
+		return err
+	}
+	return s.runtime.PushFile(ctx, containerName, seed.Content, seed.Target, seed.Mode)
+}
+
+func (s *Service) observe(ctx context.Context, containerName string) Observation {
+	pctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	marker, err := s.runtime.FileExists(pctx, containerName, MarkerPath)
+	if err != nil {
+		log.Printf("templates: probe marker in %s: %v", containerName, err)
+	}
+	failure, err := s.runtime.FileExists(pctx, containerName, FailurePath)
+	if err != nil {
+		log.Printf("templates: probe failure marker in %s: %v", containerName, err)
+	}
+	return Observation{MarkerPresent: marker, FailurePresent: failure}
+}
+
+// Status reports one container's template provisioning state. In-memory state
+// from a run this process started wins; otherwise the container's marker files
+// are the source of truth, so the answer survives a backend restart.
+func (s *Service) Status(ctx context.Context, containerName, name string) State {
+	template := s.catalog.Resolve(name)
+	base := State{Template: template.Name, Title: template.Title, LogPath: LogPath}
+	if !template.Provisions() {
+		base.Status = StatusNone
+		base.LogPath = ""
+		return base
+	}
+	if state, ok := s.state(containerName); ok && state.Template == template.Name {
+		return state
+	}
+	if s.runtime == nil || !s.runtime.Available() {
+		base.Status = StatusPending
+		return base
+	}
+	base.Status = ObservedStatus(template, s.observe(ctx, containerName))
+	return base
+}
+
+// TemplateStatus adapts Status to the project status payload.
+func (s *Service) TemplateStatus(
+	ctx context.Context,
+	containerName, name string,
+) serviceproject.TemplateStatus {
+	state := s.Status(ctx, containerName, name)
+	return serviceproject.TemplateStatus{
+		Name:       state.Template,
+		Title:      state.Title,
+		Status:     string(state.Status),
+		Error:      state.Error,
+		LogPath:    state.LogPath,
+		StartedAt:  state.StartedAt,
+		FinishedAt: state.FinishedAt,
+	}
+}
+
+func (s *Service) state(containerName string) (State, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.states[containerName]
+	return state, ok
+}
+
+func (s *Service) inFlight(containerName string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.states[containerName].Status == StatusRunning
+}
+
+func (s *Service) begin(containerName string, template Template) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.states[containerName] = State{
+		Template:  template.Name,
+		Title:     template.Title,
+		Status:    StatusRunning,
+		LogPath:   LogPath,
+		StartedAt: time.Now().UnixMilli(),
+	}
+}
+
+func (s *Service) finish(containerName string, template Template, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.states[containerName]
+	state.Template = template.Name
+	state.Title = template.Title
+	state.LogPath = LogPath
+	state.FinishedAt = time.Now().UnixMilli()
+	if err != nil {
+		state.Status = StatusFailed
+		state.Error = err.Error()
+		log.Printf("templates: provision %s in %s: %v", template.Name, containerName, err)
+	} else {
+		state.Status = StatusDone
+		state.Error = ""
+	}
+	s.states[containerName] = state
+}
+
+func (s *Service) recordObserved(containerName string, template Template, observation Observation) {
+	status := ObservedStatus(template, observation)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, ok := s.states[containerName]
+	if ok && existing.Template == template.Name && existing.Status == status {
+		return
+	}
+	s.states[containerName] = State{
+		Template: template.Name,
+		Title:    template.Title,
+		Status:   status,
+		LogPath:  LogPath,
+	}
+}
+
+// ForgetTemplateState drops cached state for a container that no longer
+// exists, so a slug reused by a later project starts from a clean answer.
+func (s *Service) ForgetTemplateState(containerName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.states, containerName)
+}
+
+type provisionError struct {
+	template string
+	cause    error
+	output   string
+}
+
+func (e provisionError) Error() string {
+	message := "provision template " + e.template + ": " + e.cause.Error()
+	if e.output != "" {
+		message += "; output: " + e.output
+	}
+	return message
+}
+
+func (e provisionError) Unwrap() error { return e.cause }

--- a/backend/internal/service/container/templates/service_test.go
+++ b/backend/internal/service/container/templates/service_test.go
@@ -1,0 +1,355 @@
+package templates
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"testing/fstest"
+)
+
+type fakeRuntime struct {
+	mu sync.Mutex
+
+	available bool
+	files     map[string]bool
+	images    map[string]bool
+	scriptErr error
+	calls     []string
+	pushed    map[string]string
+	pushModes map[string]string
+	probeErr  error
+}
+
+func newFakeRuntime() *fakeRuntime {
+	return &fakeRuntime{
+		available: true,
+		files:     map[string]bool{},
+		images:    map[string]bool{},
+		pushed:    map[string]string{},
+		pushModes: map[string]string{},
+	}
+}
+
+func (f *fakeRuntime) Available() bool { return f.available }
+
+func (f *fakeRuntime) FileExists(_ context.Context, container, path string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "exists "+container+" "+path)
+	if f.probeErr != nil {
+		return false, f.probeErr
+	}
+	return f.files[path], nil
+}
+
+func (f *fakeRuntime) EnsureDirectory(_ context.Context, container, path string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "mkdir "+container+" "+path)
+	return nil
+}
+
+func (f *fakeRuntime) PushFile(_ context.Context, container string, content []byte, target, mode string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "push "+container+" "+target)
+	f.pushed[target] = string(content)
+	f.pushModes[target] = mode
+	f.files[target] = true
+	return nil
+}
+
+func (f *fakeRuntime) RunScript(_ context.Context, container, script string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "run "+container)
+	if f.scriptErr != nil {
+		return "boom output", f.scriptErr
+	}
+	// A real run ends by writing the marker inside the container.
+	f.files[MarkerPath] = true
+	return "ok", nil
+}
+
+func (f *fakeRuntime) ImageExists(_ context.Context, alias string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "image "+alias)
+	return f.images[alias], nil
+}
+
+func (f *fakeRuntime) recorded() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+func (f *fakeRuntime) setFile(path string, present bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.files[path] = present
+}
+
+func testCatalog(t *testing.T) *Catalog {
+	t.Helper()
+	catalog, err := LoadFS(fstest.MapFS{
+		"blank/template.json": &fstest.MapFile{
+			Data: []byte(`{"name":"blank","title":"Blank","description":"d","icon":"blank"}`),
+		},
+		"stack/template.json": &fstest.MapFile{
+			Data: []byte(`{"name":"stack","title":"Stack","description":"d","icon":"stack",` +
+				`"provisionScript":"provision.sh","agentInstructions":"AGENTS.md",` +
+				`"seedFiles":[{"source":"README.md","target":"/workspace/README.md"}],` +
+				`"prebuiltImage":true}`),
+		},
+		"stack/provision.sh": &fstest.MapFile{Data: []byte("echo install\n")},
+		"stack/AGENTS.md":    &fstest.MapFile{Data: []byte("# stack\n")},
+		"stack/README.md":    &fstest.MapFile{Data: []byte("readme\n")},
+	})
+	if err != nil {
+		t.Fatalf("LoadFS() = %v", err)
+	}
+	return catalog
+}
+
+func TestEnsureIsANoOpForTheDefaultTemplate(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(testCatalog(t), runtime)
+
+	<-service.Ensure(context.Background(), "project-1", "blank")
+
+	if calls := runtime.recorded(); len(calls) != 0 {
+		t.Fatalf("blank template touched the runtime: %v", calls)
+	}
+	state := service.Status(context.Background(), "project-1", "blank")
+	if state.Status != StatusNone {
+		t.Fatalf("Status = %q, want %q", state.Status, StatusNone)
+	}
+}
+
+func TestEnsureProvisionsThenBecomesANoOp(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(testCatalog(t), runtime)
+	ctx := context.Background()
+
+	<-service.Ensure(ctx, "project-1", "stack")
+
+	if runtime.pushed["/workspace/README.md"] != "readme\n" {
+		t.Fatalf("seed not written: %v", runtime.pushed)
+	}
+	if runtime.pushed[InstructionsPath] != "# stack\n" {
+		t.Fatalf("agent instructions not seeded: %v", runtime.pushed)
+	}
+	if state := service.Status(ctx, "project-1", "stack"); state.Status != StatusDone {
+		t.Fatalf("Status = %q, want %q", state.Status, StatusDone)
+	}
+
+	// Second convergence: the marker is present, so no script and no seeds.
+	before := len(runtime.recorded())
+	<-service.Ensure(ctx, "project-1", "stack")
+	after := runtime.recorded()
+	for _, call := range after[before:] {
+		if strings.HasPrefix(call, "run ") || strings.HasPrefix(call, "push ") {
+			t.Fatalf("re-run performed work: %v", after[before:])
+		}
+	}
+}
+
+func TestEnsureNeverOverwritesAnExistingSeed(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.setFile("/workspace/README.md", true)
+	service := NewService(testCatalog(t), runtime)
+
+	<-service.Ensure(context.Background(), "project-1", "stack")
+
+	if _, written := runtime.pushed["/workspace/README.md"]; written {
+		t.Fatal("an existing workspace file was overwritten")
+	}
+	if runtime.pushed[InstructionsPath] == "" {
+		t.Fatal("the absent agent-instructions seed should still be written")
+	}
+}
+
+func TestEnsureSkipsWhenTheMarkerIsAlreadyPresent(t *testing.T) {
+	// A container launched from a pre-built template image already carries
+	// the marker, so the slow path must not run.
+	runtime := newFakeRuntime()
+	runtime.setFile(MarkerPath, true)
+	service := NewService(testCatalog(t), runtime)
+
+	<-service.Ensure(context.Background(), "project-1", "stack")
+
+	for _, call := range runtime.recorded() {
+		if strings.HasPrefix(call, "run ") || strings.HasPrefix(call, "push ") {
+			t.Fatalf("provisioning ran despite the marker: %v", runtime.recorded())
+		}
+	}
+	if state := service.Status(context.Background(), "project-1", "stack"); state.Status != StatusDone {
+		t.Fatalf("Status = %q, want %q", state.Status, StatusDone)
+	}
+}
+
+func TestEnsureRecordsFailure(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.scriptErr = errors.New("exit 1")
+	service := NewService(testCatalog(t), runtime)
+	ctx := context.Background()
+
+	<-service.Ensure(ctx, "project-1", "stack")
+
+	state := service.Status(ctx, "project-1", "stack")
+	if state.Status != StatusFailed {
+		t.Fatalf("Status = %q, want %q", state.Status, StatusFailed)
+	}
+	if !strings.Contains(state.Error, "exit 1") || !strings.Contains(state.Error, "boom output") {
+		t.Fatalf("Error = %q, want the cause and the command output", state.Error)
+	}
+	if state.LogPath != LogPath {
+		t.Fatalf("LogPath = %q, want %q", state.LogPath, LogPath)
+	}
+}
+
+func TestStatusFallsBackToTheContainerMarkers(t *testing.T) {
+	catalog := testCatalog(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		marker   bool
+		failure  bool
+		want     Status
+		template string
+	}{
+		{name: "pending", template: "stack", want: StatusPending},
+		{name: "done", template: "stack", marker: true, want: StatusDone},
+		{name: "failed", template: "stack", failure: true, want: StatusFailed},
+		{name: "none", template: "blank", want: StatusNone},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtime := newFakeRuntime()
+			runtime.setFile(MarkerPath, tt.marker)
+			runtime.setFile(FailurePath, tt.failure)
+			// A fresh service has no in-memory state, exactly like the first
+			// status request after a backend restart.
+			service := NewService(catalog, runtime)
+			if got := service.Status(ctx, "project-1", tt.template); got.Status != tt.want {
+				t.Fatalf("Status = %q, want %q", got.Status, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatusReportsPendingWhenTheRuntimeIsUnavailable(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.available = false
+	service := NewService(testCatalog(t), runtime)
+
+	state := service.Status(context.Background(), "project-1", "stack")
+	if state.Status != StatusPending {
+		t.Fatalf("Status = %q, want %q", state.Status, StatusPending)
+	}
+	if calls := runtime.recorded(); len(calls) != 0 {
+		t.Fatalf("an unavailable runtime was called: %v", calls)
+	}
+}
+
+func TestStatusUsesTheProjectsOwnTemplate(t *testing.T) {
+	// Cached state belongs to a container/template pair: a project recreated
+	// under a different template must not inherit the old answer.
+	runtime := newFakeRuntime()
+	service := NewService(testCatalog(t), runtime)
+	<-service.Ensure(context.Background(), "project-1", "stack")
+
+	state := service.Status(context.Background(), "project-1", "blank")
+	if state.Status != StatusNone || state.Template != "blank" {
+		t.Fatalf("Status = %+v, want the blank template's own answer", state)
+	}
+}
+
+func TestImageForPrefersAPublishedTemplateImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		template  string
+		published bool
+		want      string
+	}{
+		{name: "published", template: "stack", published: true, want: "futrx-remote-stack-base"},
+		{name: "not published", template: "stack", want: ""},
+		{name: "template declares none", template: "blank", published: true, want: ""},
+		{name: "unknown template falls back", template: "gone", published: true, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtime := newFakeRuntime()
+			if tt.published {
+				runtime.images["futrx-remote-stack-base"] = true
+			}
+			service := NewService(testCatalog(t), runtime)
+			if got := service.ImageFor(context.Background(), tt.template); got != tt.want {
+				t.Fatalf("ImageFor(%q) = %q, want %q", tt.template, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListAnnotatesPrebuiltImageAvailability(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.images["futrx-remote-stack-base"] = true
+	service := NewService(testCatalog(t), runtime)
+
+	descriptors := service.List(context.Background())
+	if len(descriptors) != 2 {
+		t.Fatalf("List() = %d entries, want 2", len(descriptors))
+	}
+	byName := map[string]Descriptor{}
+	for _, descriptor := range descriptors {
+		byName[descriptor.Name] = descriptor
+	}
+	if !byName["blank"].Default || byName["blank"].Provisions {
+		t.Fatalf("blank descriptor = %+v", byName["blank"])
+	}
+	if byName["blank"].PrebuiltImage != "" || byName["blank"].PrebuiltImageAvailable {
+		t.Fatalf("blank must not advertise a template image: %+v", byName["blank"])
+	}
+	stack := byName["stack"]
+	if stack.PrebuiltImage != "futrx-remote-stack-base" || !stack.PrebuiltImageAvailable {
+		t.Fatalf("stack descriptor = %+v", stack)
+	}
+	if !stack.Provisions || stack.Default {
+		t.Fatalf("stack descriptor = %+v", stack)
+	}
+}
+
+func TestTemplateStatusAdaptsToTheProjectPayload(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(testCatalog(t), runtime)
+	ctx := context.Background()
+	<-service.Ensure(ctx, "project-1", "stack")
+
+	status := service.TemplateStatus(ctx, "project-1", "stack")
+	if status.Name != "stack" || status.Title != "Stack" || status.Status != string(StatusDone) {
+		t.Fatalf("TemplateStatus() = %+v", status)
+	}
+	if status.StartedAt == 0 || status.FinishedAt == 0 {
+		t.Fatalf("TemplateStatus() should carry timestamps: %+v", status)
+	}
+}
+
+func TestForgetTemplateStateDropsCachedState(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(testCatalog(t), runtime)
+	ctx := context.Background()
+	<-service.Ensure(ctx, "project-1", "stack")
+
+	service.ForgetTemplateState("project-1")
+	if _, ok := service.state("project-1"); ok {
+		t.Fatal("ForgetTemplateState() left cached state behind")
+	}
+}

--- a/backend/internal/service/container/templates/wordpress/AGENTS.md
+++ b/backend/internal/service/container/templates/wordpress/AGENTS.md
@@ -1,0 +1,53 @@
+# Stack: WordPress
+
+This workspace was provisioned from the `wordpress` project template.
+
+## What is installed
+
+| Piece | Detail |
+| --- | --- |
+| PHP | 8.3 CLI (`php`) with `mysql`, `curl`, `gd`, `mbstring`, `xml`, `zip`, `intl`, `bcmath`, `soap` |
+| Database | MariaDB, local only, started by systemd (`systemctl status mariadb`) |
+| DB auth | root over the unix socket, **no password** — `mysql -u root` just works |
+| Database name | `wordpress` (already created) |
+| WP-CLI | `/usr/local/bin/wp`; use `wp --allow-root` or the `wp-root` wrapper |
+| Composer | `/usr/local/bin/composer` |
+| Site root | `/workspace/public` (WordPress core downloaded, `wp-config.php` written) |
+| Preview server | `remote-wordpress.service`, PHP built-in server on **port 8080** |
+
+## Rules that matter here
+
+- Everything you want to keep must live under `/workspace`. The rest of the
+  container filesystem is replaced whenever the workspace is upgraded — this
+  provisioning re-runs automatically after that happens.
+- Run WP-CLI as `wp --allow-root ...` from `/workspace/public`, or use
+  `wp-root`, which adds the flag for you.
+- The database connection is `--dbhost=localhost` so PHP uses the unix socket.
+  Do not switch it to `127.0.0.1`.
+- The preview server is a systemd unit. After changing PHP files nothing needs
+  restarting; after changing the unit, run
+  `systemctl restart remote-wordpress`.
+- Do not start a second server on 8080 — check with `ss -ltnp` first.
+
+## Common tasks
+
+```bash
+cd /workspace/public
+
+# Finish the install non-interactively
+wp --allow-root core install \
+  --url=http://localhost:8080 --title="Dev site" \
+  --admin_user=admin --admin_password=admin --admin_email=dev@example.com
+
+# WooCommerce is not preinstalled; add it when the project needs a store
+wp --allow-root plugin install woocommerce --activate
+
+# Database access
+mysql -u root wordpress
+wp --allow-root db query "SELECT option_value FROM wp_options WHERE option_name='siteurl'"
+```
+
+## Previews
+
+Port 8080 is published as a preview URL by the platform. Bind any additional
+server to `0.0.0.0`, never `127.0.0.1`, or it will not be reachable.

--- a/backend/internal/service/container/templates/wordpress/provision.sh
+++ b/backend/internal/service/container/templates/wordpress/provision.sh
@@ -1,0 +1,96 @@
+# Ubuntu 24.04 ships PHP 8.3 in its own repositories, so no third-party PPA
+# is needed. Keep the extension list to what WordPress and WooCommerce
+# actually require; each one costs disk on a small host.
+echo "--- installing PHP 8.3 and MariaDB ---"
+apt_retry update -qq
+apt_retry install -y -qq \
+    php8.3-cli php8.3-mysql php8.3-curl php8.3-gd php8.3-mbstring \
+    php8.3-xml php8.3-zip php8.3-intl php8.3-bcmath php8.3-soap \
+    mariadb-server mariadb-client \
+    unzip less
+
+# MariaDB must come back on its own after a container reboot. The Debian
+# package ships the unit; enabling it is what makes it a boot service.
+echo "--- enabling MariaDB ---"
+systemctl enable mariadb
+systemctl start mariadb || service mariadb start
+
+# Wait for the socket rather than sleeping a fixed amount: a cold first start
+# on a 1 vCPU host can take a while.
+for _ in $(seq 1 60); do
+    if mariadb-admin ping --silent 2>/dev/null || mysqladmin ping --silent 2>/dev/null; then
+        break
+    fi
+    sleep 2
+done
+
+# Container-local database. Root authenticates over the unix socket, so there
+# is no password to manage; nothing outside the container can reach it.
+echo "--- creating the wordpress database ---"
+mysql -u root -e "CREATE DATABASE IF NOT EXISTS wordpress DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+
+echo "--- installing Composer ---"
+curl -fsSL https://getcomposer.org/installer -o /tmp/composer-setup.php
+php /tmp/composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
+rm -f /tmp/composer-setup.php
+
+echo "--- installing WP-CLI ---"
+curl -fsSL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+    -o /usr/local/bin/wp
+chmod 0755 /usr/local/bin/wp
+
+# WP-CLI refuses to run as root without this flag. The container IS root-only,
+# so make it the default instead of teaching every caller to pass it.
+cat > /usr/local/bin/wp-root <<'WRAPPER'
+#!/bin/sh
+exec /usr/local/bin/wp --allow-root "$@"
+WRAPPER
+chmod 0755 /usr/local/bin/wp-root
+
+# WordPress core lands in the durable workspace, so it survives container
+# replacement. Never clobber an existing installation.
+mkdir -p /workspace/public
+if [ ! -f /workspace/public/wp-load.php ]; then
+    echo "--- downloading WordPress core ---"
+    wp --allow-root --path=/workspace/public core download
+else
+    echo "WordPress core already present in /workspace/public - skipping download"
+fi
+
+if [ ! -f /workspace/public/wp-config.php ]; then
+    echo "--- writing wp-config.php ---"
+    wp --allow-root --path=/workspace/public config create \
+        --dbname=wordpress --dbuser=root --dbhost=localhost --skip-check
+fi
+
+# php -S is enough for a single-developer preview and costs far less memory
+# than nginx + php-fpm on a 4 GB box. PHP_CLI_SERVER_WORKERS keeps wp-admin
+# usable: WordPress makes loopback requests to itself, which deadlock a
+# single-worker built-in server.
+echo "--- installing the preview web server unit ---"
+cat > /etc/systemd/system/remote-wordpress.service <<'UNIT'
+[Unit]
+Description=WordPress preview server (PHP built-in, port 8080)
+After=network.target mariadb.service
+Wants=mariadb.service
+
+[Service]
+Type=simple
+Environment=PHP_CLI_SERVER_WORKERS=4
+WorkingDirectory=/workspace/public
+ExecStart=/usr/bin/php -S 0.0.0.0:8080 -t /workspace/public
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+systemctl enable remote-wordpress.service
+systemctl restart remote-wordpress.service || true
+
+echo "--- versions ---"
+php --version | head -1
+composer --version
+wp --allow-root --version
+mysql --version

--- a/backend/internal/service/container/templates/wordpress/template.json
+++ b/backend/internal/service/container/templates/wordpress/template.json
@@ -1,0 +1,10 @@
+{
+  "name": "wordpress",
+  "title": "WordPress",
+  "description": "PHP 8.3 with the WordPress extension set, a local MariaDB (root over the unix socket, no password), WP-CLI, Composer, and WordPress core downloaded into /workspace/public and served on port 8080.",
+  "icon": "wordpress",
+  "provisionScript": "provision.sh",
+  "agentInstructions": "AGENTS.md",
+  "defaultPorts": [8080],
+  "prebuiltImage": true
+}

--- a/backend/internal/service/project/errors.go
+++ b/backend/internal/service/project/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrInvalidSecretKey   = errors.New("invalid secret key (must match [A-Za-z_][A-Za-z0-9_]*)")
 	ErrInvalidLimits      = errors.New("invalid container resource limits")
 	ErrSecretsUnavailable = errors.New("secrets store is not configured")
+	ErrUnknownTemplate    = errors.New("unknown project template")
 )

--- a/backend/internal/service/project/model.go
+++ b/backend/internal/service/project/model.go
@@ -30,13 +30,26 @@ const (
 	AgentBrowserStatusStopped   AgentBrowserStatus = "stopped"
 )
 
+// DefaultTemplate is the stack preset assigned to a project that requests
+// none, and the value assumed for metadata written before templates existed.
+const DefaultTemplate = "blank"
+
 type Meta struct {
-	ID             ID               `json:"id"`
-	Name           string           `json:"name"`
-	Slug           string           `json:"slug"`
-	Cwd            string           `json:"cwd"`
-	ContainerName  string           `json:"containerName"`
-	Status         Status           `json:"status"`
+	ID            ID     `json:"id"`
+	Name          string `json:"name"`
+	Slug          string `json:"slug"`
+	Cwd           string `json:"cwd"`
+	ContainerName string `json:"containerName"`
+	Status        Status `json:"status"`
+	// Template is the stack preset the container was created from. It is set
+	// once at creation and never changes: the provisioning it drives is
+	// applied to the container rootfs and to /workspace, and neither can be
+	// rolled back to another stack without destroying the project. Recreate
+	// the project to change stacks.
+	//
+	// Empty means "written before templates existed"; read it through
+	// TemplateName, which maps that to DefaultTemplate.
+	Template       string           `json:"template,omitempty"`
 	ResourceLimits *ContainerLimits `json:"resourceLimits,omitempty"`
 	Order          int64            `json:"order,omitempty"`
 	ErrorMsg       string           `json:"errorMsg,omitempty"`
@@ -44,10 +57,24 @@ type Meta struct {
 	UpdatedAt      int64            `json:"updatedAt"`
 }
 
-type CreateInput struct {
-	Name string `json:"name"`
+// TemplateName is the backward-compatible accessor for Meta.Template: project
+// metadata written before templates existed has no field at all, and those
+// projects behave exactly like the default template.
+func (m Meta) TemplateName() string {
+	if m.Template == "" {
+		return DefaultTemplate
+	}
+	return m.Template
 }
 
+type CreateInput struct {
+	Name string `json:"name"`
+	// Template selects the stack preset. Empty means the default.
+	Template string `json:"template,omitempty"`
+}
+
+// UpdateInput deliberately has no Template field: the template is immutable
+// after creation (see Meta.Template).
 type UpdateInput struct {
 	Name *string `json:"name,omitempty"`
 }
@@ -89,6 +116,25 @@ type ContainerInspect struct {
 	Claude         ClaudeContainerStatus `json:"claude"`
 	Codex          CodexContainerStatus  `json:"codex"`
 	AuthBundles    []AuthBundleStatus    `json:"authBundles"`
+	// Template reports the project's stack preset and how far its one-time
+	// in-container provisioning has got.
+	Template *TemplateStatus `json:"template,omitempty"`
+}
+
+// TemplateProvisioningNone is the status reported when a project's template
+// installs nothing, so its container is ready as soon as it boots.
+const TemplateProvisioningNone = "none"
+
+// TemplateStatus is the project-facing view of template provisioning.
+// Status is one of "none", "pending", "running", "done", or "failed".
+type TemplateStatus struct {
+	Name       string `json:"name"`
+	Title      string `json:"title,omitempty"`
+	Status     string `json:"status"`
+	Error      string `json:"error,omitempty"`
+	LogPath    string `json:"logPath,omitempty"`
+	StartedAt  int64  `json:"startedAt,omitempty"`
+	FinishedAt int64  `json:"finishedAt,omitempty"`
 }
 
 type WorkspaceInfo struct {

--- a/backend/internal/service/project/ports.go
+++ b/backend/internal/service/project/ports.go
@@ -65,6 +65,20 @@ type ContainerBrowser interface {
 	Port() int
 }
 
+// ContainerTemplates is the project service's stack-preset port. It answers
+// which templates exist (create-time validation) and how far one project's
+// one-time provisioning has got (status payload).
+type ContainerTemplates interface {
+	// Has reports whether name is a known template.
+	Has(name string) bool
+	// DefaultName is the template assigned when a caller requests none.
+	DefaultName() string
+	// TemplateStatus reports the provisioning state of one container.
+	TemplateStatus(ctx context.Context, containerName, template string) TemplateStatus
+	// ForgetTemplateState drops any cached state for a deleted container.
+	ForgetTemplateState(containerName string)
+}
+
 // ContainerDependencies groups the independently replaceable container
 // capabilities used by Service. A nil capability preserves the behavior of a
 // nil container manager for the operations that consume it.
@@ -75,4 +89,5 @@ type ContainerDependencies struct {
 	Network     ContainerNetwork
 	Listeners   ContainerListeners
 	Browser     ContainerBrowser
+	Templates   ContainerTemplates
 }

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -19,6 +19,7 @@ type Service struct {
 	containerNetwork     ContainerNetwork
 	containerListeners   ContainerListeners
 	containerBrowser     ContainerBrowser
+	containerTemplates   ContainerTemplates
 	secrets              SecretsRepository
 	access               AccessRepository
 
@@ -51,6 +52,7 @@ func New(
 		containerNetwork:     containers.Network,
 		containerListeners:   containers.Listeners,
 		containerBrowser:     containers.Browser,
+		containerTemplates:   containers.Templates,
 		secrets:              secrets,
 		access:               access,
 		agentBrowserInfo:     make(map[ID]AgentBrowserInfo),
@@ -196,11 +198,16 @@ func (s *Service) Create(ctx context.Context, in CreateInput, callerEmail string
 	if name == "" {
 		return Meta{}, ErrNameRequired
 	}
+	template, err := s.resolveTemplate(in.Template)
+	if err != nil {
+		return Meta{}, err
+	}
 
 	m, err := s.repo.Create(ctx, Meta{
-		Name:   name,
-		Slug:   Slugify(name),
-		Status: StatusProvisioning,
+		Name:     name,
+		Slug:     Slugify(name),
+		Status:   StatusProvisioning,
+		Template: template,
 	})
 	if err != nil {
 		return Meta{}, err
@@ -228,6 +235,27 @@ func (s *Service) Create(ctx context.Context, in CreateInput, callerEmail string
 		}
 	}
 	return s.repo.SetStatus(ctx, m.ID, StatusRunning, "")
+}
+
+// resolveTemplate validates a requested template name against the catalog.
+// The template is fixed at creation, so this is the only place it is chosen.
+func (s *Service) resolveTemplate(requested string) (string, error) {
+	requested = strings.ToLower(strings.TrimSpace(requested))
+	if s.containerTemplates == nil {
+		// No catalog wired (tests, and any build without container support):
+		// only the default template exists, and it installs nothing.
+		if requested == "" || requested == DefaultTemplate {
+			return DefaultTemplate, nil
+		}
+		return "", ErrUnknownTemplate
+	}
+	if requested == "" {
+		return s.containerTemplates.DefaultName(), nil
+	}
+	if !s.containerTemplates.Has(requested) {
+		return "", ErrUnknownTemplate
+	}
+	return requested, nil
 }
 
 func (s *Service) Update(ctx context.Context, id ID, in UpdateInput) (Meta, error) {
@@ -357,6 +385,9 @@ func (s *Service) Delete(ctx context.Context, id ID) error {
 		return err
 	}
 	s.clearAgentBrowserState(id)
+	if s.containerTemplates != nil && m.ContainerName != "" {
+		s.containerTemplates.ForgetTemplateState(m.ContainerName)
+	}
 	if s.containerLifecycle != nil && m.ContainerName != "" {
 		if err := s.containerLifecycle.Delete(ctx, m.ContainerName); err != nil {
 			log.Printf("projects: delete container %s: %v", m.ContainerName, err)
@@ -569,7 +600,23 @@ func (s *Service) InspectContainer(ctx context.Context, id ID) (ContainerInspect
 		return ContainerInspect{}, err
 	}
 	info.LimitOverrides = m.ResourceLimits
+	s.describeTemplate(ctx, m, &info)
 	return info, nil
+}
+
+// describeTemplate annotates an inspection with the project's stack preset and
+// its provisioning progress. Best-effort: a project must remain inspectable
+// when the template catalog is unavailable.
+func (s *Service) describeTemplate(ctx context.Context, m Meta, info *ContainerInspect) {
+	if s.containerTemplates == nil {
+		info.Template = &TemplateStatus{
+			Name:   m.TemplateName(),
+			Status: TemplateProvisioningNone,
+		}
+		return
+	}
+	status := s.containerTemplates.TemplateStatus(ctx, m.ContainerName, m.TemplateName())
+	info.Template = &status
 }
 
 // RepairNetwork re-runs eth0 configuration inside the project's container

--- a/backend/internal/service/project/service_template_test.go
+++ b/backend/internal/service/project/service_template_test.go
@@ -1,0 +1,223 @@
+package project
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type templateCatalogStub struct {
+	known       map[string]bool
+	defaultName string
+	status      TemplateStatus
+	statusCalls []string
+	forgotten   []string
+}
+
+func newTemplateCatalogStub(names ...string) *templateCatalogStub {
+	known := make(map[string]bool, len(names))
+	for _, name := range names {
+		known[name] = true
+	}
+	return &templateCatalogStub{
+		known:       known,
+		defaultName: DefaultTemplate,
+		status:      TemplateStatus{Name: "wordpress", Title: "WordPress", Status: "running"},
+	}
+}
+
+func (s *templateCatalogStub) Has(name string) bool { return s.known[name] }
+
+func (s *templateCatalogStub) DefaultName() string { return s.defaultName }
+
+func (s *templateCatalogStub) TemplateStatus(_ context.Context, container, template string) TemplateStatus {
+	s.statusCalls = append(s.statusCalls, container+" "+template)
+	return s.status
+}
+
+func (s *templateCatalogStub) ForgetTemplateState(containerName string) {
+	s.forgotten = append(s.forgotten, containerName)
+}
+
+func TestCreateResolvesTheRequestedTemplate(t *testing.T) {
+	tests := []struct {
+		name       string
+		catalog    ContainerTemplates
+		requested  string
+		want       string
+		wantErr    error
+		wantStored string
+	}{
+		{
+			name:    "an empty request takes the catalog default",
+			catalog: newTemplateCatalogStub("blank", "wordpress"),
+			want:    DefaultTemplate,
+		},
+		{
+			name:      "a known template is stored verbatim",
+			catalog:   newTemplateCatalogStub("blank", "wordpress"),
+			requested: "wordpress",
+			want:      "wordpress",
+		},
+		{
+			name:      "the request is normalized before lookup",
+			catalog:   newTemplateCatalogStub("blank", "wordpress"),
+			requested: "  WordPress ",
+			want:      "wordpress",
+		},
+		{
+			name:      "an unknown template is rejected",
+			catalog:   newTemplateCatalogStub("blank", "wordpress"),
+			requested: "cobol",
+			wantErr:   ErrUnknownTemplate,
+		},
+		{
+			name: "without a catalog only the default is accepted",
+			want: DefaultTemplate,
+		},
+		{
+			name:      "without a catalog a named template is rejected",
+			requested: "wordpress",
+			wantErr:   ErrUnknownTemplate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &startTestRepository{}
+			service := New(repo, ContainerDependencies{Templates: tt.catalog}, nil, nil)
+
+			meta, err := service.Create(
+				context.Background(),
+				CreateInput{Name: "My Project", Template: tt.requested},
+				"",
+			)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("Create() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Create() = %v", err)
+			}
+			if meta.Template != tt.want {
+				t.Fatalf("Template = %q, want %q", meta.Template, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateRejectsAnUnknownTemplateBeforeWritingAnything(t *testing.T) {
+	repo := &startTestRepository{}
+	catalog := newTemplateCatalogStub("blank")
+	service := New(repo, ContainerDependencies{Templates: catalog}, nil, nil)
+
+	if _, err := service.Create(
+		context.Background(), CreateInput{Name: "P", Template: "cobol"}, "",
+	); !errors.Is(err, ErrUnknownTemplate) {
+		t.Fatalf("Create() error = %v, want %v", err, ErrUnknownTemplate)
+	}
+	if repo.meta.Name != "" {
+		t.Fatalf("a rejected create still persisted %#v", repo.meta)
+	}
+}
+
+func TestTemplateNameDefaultsForMetadataWrittenBeforeTemplatesExisted(t *testing.T) {
+	tests := []struct {
+		name string
+		meta Meta
+		want string
+	}{
+		{name: "absent field", meta: Meta{}, want: DefaultTemplate},
+		{name: "explicit blank", meta: Meta{Template: "blank"}, want: "blank"},
+		{name: "explicit stack", meta: Meta{Template: "wordpress"}, want: "wordpress"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.meta.TemplateName(); got != tt.want {
+				t.Fatalf("TemplateName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateCannotChangeTheTemplate(t *testing.T) {
+	repo := &startTestRepository{meta: Meta{
+		ID: ID("abcd"), Name: "project", ContainerName: "project", Template: "wordpress",
+	}}
+	service := New(repo, ContainerDependencies{Templates: newTemplateCatalogStub("blank", "wordpress")}, nil, nil)
+
+	renamed := "renamed"
+	meta, err := service.Update(context.Background(), ID("abcd"), UpdateInput{Name: &renamed})
+	if err != nil {
+		t.Fatalf("Update() = %v", err)
+	}
+	if meta.Template != "wordpress" {
+		t.Fatalf("Template = %q, want it unchanged", meta.Template)
+	}
+}
+
+type templateInspector struct{ info ContainerInspect }
+
+func (i templateInspector) Inspect(context.Context, string) (ContainerInspect, error) {
+	return i.info, nil
+}
+
+func TestInspectContainerReportsTheTemplateStatus(t *testing.T) {
+	repo := &startTestRepository{meta: Meta{
+		ID: ID("abcd"), Name: "project", ContainerName: "project", Template: "wordpress",
+	}}
+	catalog := newTemplateCatalogStub("blank", "wordpress")
+	service := New(repo, ContainerDependencies{
+		Inspector: templateInspector{info: ContainerInspect{Name: "project"}},
+		Templates: catalog,
+	}, nil, nil)
+
+	info, err := service.InspectContainer(context.Background(), ID("abcd"))
+	if err != nil {
+		t.Fatalf("InspectContainer() = %v", err)
+	}
+	if info.Template == nil || info.Template.Name != "wordpress" || info.Template.Status != "running" {
+		t.Fatalf("Template = %+v", info.Template)
+	}
+	if len(catalog.statusCalls) != 1 || catalog.statusCalls[0] != "project wordpress" {
+		t.Fatalf("statusCalls = %q", catalog.statusCalls)
+	}
+}
+
+func TestDeleteForgetsCachedTemplateState(t *testing.T) {
+	repo := &startTestRepository{meta: Meta{
+		ID: ID("abcd"), Name: "project", ContainerName: "project", Template: "wordpress",
+	}}
+	catalog := newTemplateCatalogStub("blank", "wordpress")
+	service := New(repo, ContainerDependencies{Templates: catalog}, nil, nil)
+
+	if err := service.Delete(context.Background(), ID("abcd")); err != nil {
+		t.Fatalf("Delete() = %v", err)
+	}
+	if len(catalog.forgotten) != 1 || catalog.forgotten[0] != "project" {
+		t.Fatalf("forgotten = %q, want the deleted container", catalog.forgotten)
+	}
+}
+
+func TestInspectContainerReportsTheDefaultTemplateWithoutACatalog(t *testing.T) {
+	repo := &startTestRepository{meta: Meta{
+		ID: ID("abcd"), Name: "project", ContainerName: "project",
+	}}
+	service := New(repo, ContainerDependencies{
+		Inspector: templateInspector{info: ContainerInspect{Name: "project"}},
+	}, nil, nil)
+
+	info, err := service.InspectContainer(context.Background(), ID("abcd"))
+	if err != nil {
+		t.Fatalf("InspectContainer() = %v", err)
+	}
+	if info.Template == nil || info.Template.Name != DefaultTemplate {
+		t.Fatalf("Template = %+v, want the default", info.Template)
+	}
+	if info.Template.Status != TemplateProvisioningNone {
+		t.Fatalf("Status = %q, want %q", info.Template.Status, TemplateProvisioningNone)
+	}
+}

--- a/backend/internal/stores/fileproject/template_test.go
+++ b/backend/internal/stores/fileproject/template_test.go
@@ -1,0 +1,121 @@
+package fileproject
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
+)
+
+// writeLegacyMeta drops a meta.json with an explicit field set, bypassing the
+// store so the fixture is exactly what an older release wrote.
+func writeLegacyMeta(t *testing.T, dataDir, id, body string) {
+	t.Helper()
+	dir := filepath.Join(dataDir, "projects", id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReadsProjectMetadataWrittenBeforeTemplatesExisted(t *testing.T) {
+	dataDir := t.TempDir()
+	writeLegacyMeta(t, dataDir, "abcdef123456", `{
+  "id": "abcdef123456",
+  "name": "Legacy Project",
+  "slug": "legacy-project",
+  "cwd": "/var/lib/remote/projects/legacy-project/workspace",
+  "containerName": "legacy-project",
+  "status": "running",
+  "createdAt": 1700000000000,
+  "updatedAt": 1700000000000
+}`)
+
+	store, err := NewWithWorkspaceRoot(dataDir, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	meta, err := store.Get(context.Background(), serviceproject.ID("abcdef123456"))
+	if err != nil {
+		t.Fatalf("Get() = %v", err)
+	}
+	if meta.Template != "" {
+		t.Fatalf("Template = %q, want it absent for legacy metadata", meta.Template)
+	}
+	if got := meta.TemplateName(); got != serviceproject.DefaultTemplate {
+		t.Fatalf("TemplateName() = %q, want %q", got, serviceproject.DefaultTemplate)
+	}
+	if meta.Slug != "legacy-project" || meta.Status != serviceproject.StatusRunning {
+		t.Fatalf("legacy metadata was not read faithfully: %#v", meta)
+	}
+
+	// The slug index must have picked the legacy project up as well.
+	if _, err := store.GetBySlug(context.Background(), "legacy-project"); err != nil {
+		t.Fatalf("GetBySlug() = %v", err)
+	}
+}
+
+func TestTemplateSurvivesUpdatesAndIsOmittedWhenEmpty(t *testing.T) {
+	dataDir := t.TempDir()
+	store, err := NewWithWorkspaceRoot(dataDir, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	templated, err := store.Create(ctx, serviceproject.Meta{
+		Name:     "Shop",
+		Slug:     serviceproject.Slugify("Shop"),
+		Status:   serviceproject.StatusProvisioning,
+		Template: "wordpress",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plain, err := store.Create(ctx, serviceproject.Meta{
+		Name:   "Plain",
+		Slug:   serviceproject.Slugify("Plain"),
+		Status: serviceproject.StatusProvisioning,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	renamed, err := store.Update(ctx, templated.ID, func(m *serviceproject.Meta) {
+		m.Name = "Shop v2"
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if renamed.Template != "wordpress" {
+		t.Fatalf("Template = %q, want it preserved across an update", renamed.Template)
+	}
+
+	statused, err := store.SetStatus(ctx, templated.ID, serviceproject.StatusRunning, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statused.Template != "wordpress" {
+		t.Fatalf("Template = %q, want it preserved across a status change", statused.Template)
+	}
+
+	// A project on the default template writes no field at all, so metadata
+	// stays byte-compatible with what older releases produced.
+	raw, err := os.ReadFile(filepath.Join(dataDir, "projects", string(plain.ID), "meta.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := decoded["template"]; present {
+		t.Fatalf("meta.json for a default-template project carries %q: %s", "template", raw)
+	}
+}

--- a/backend/internal/transport/http/handlers/project_handler.go
+++ b/backend/internal/transport/http/handlers/project_handler.go
@@ -640,7 +640,8 @@ func sendProjectError(w http.ResponseWriter, err error) {
 	case errors.Is(err, serviceproject.ErrNameRequired),
 		errors.Is(err, serviceproject.ErrInvalidID),
 		errors.Is(err, serviceproject.ErrInvalidSecretKey),
-		errors.Is(err, serviceproject.ErrInvalidLimits):
+		errors.Is(err, serviceproject.ErrInvalidLimits),
+		errors.Is(err, serviceproject.ErrUnknownTemplate):
 		httptransport.SendErr(w, http.StatusBadRequest, err.Error())
 	case errors.Is(err, serviceproject.ErrSecretsUnavailable):
 		httptransport.SendErr(w, http.StatusServiceUnavailable, err.Error())

--- a/backend/internal/transport/http/handlers/project_template_test.go
+++ b/backend/internal/transport/http/handlers/project_template_test.go
@@ -1,0 +1,127 @@
+package httphandlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
+	"github.com/futrx-com/remote.futrx.com/internal/stores/fileproject"
+)
+
+// stubTemplateCatalog stands in for the template service in transport tests.
+type stubTemplateCatalog struct{ known map[string]bool }
+
+func (s stubTemplateCatalog) Has(name string) bool { return s.known[name] }
+
+func (s stubTemplateCatalog) DefaultName() string { return serviceproject.DefaultTemplate }
+
+func (s stubTemplateCatalog) TemplateStatus(
+	_ context.Context,
+	_, template string,
+) serviceproject.TemplateStatus {
+	return serviceproject.TemplateStatus{Name: template, Status: "pending"}
+}
+
+func (s stubTemplateCatalog) ForgetTemplateState(string) {}
+
+func newTemplateProjectHandler(t *testing.T) *ProjectHandler {
+	t.Helper()
+	repo, err := fileproject.NewWithWorkspaceRoot(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	containers := newFakeProjectContainers()
+	projects := serviceproject.New(repo, serviceproject.ContainerDependencies{
+		Lifecycle: containers,
+		Inspector: containers,
+		Templates: stubTemplateCatalog{known: map[string]bool{"blank": true, "wordpress": true}},
+	}, nil, nil)
+	return NewProjectHandler(projects, nil, nil, "remote.futrx.com")
+}
+
+func TestProjectCreateAcceptsATemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantCode int
+		want     string
+	}{
+		{
+			name:     "explicit template",
+			body:     `{"name":"Shop","template":"wordpress"}`,
+			wantCode: http.StatusCreated,
+			want:     "wordpress",
+		},
+		{
+			name:     "omitted template takes the default",
+			body:     `{"name":"Plain"}`,
+			wantCode: http.StatusCreated,
+			want:     serviceproject.DefaultTemplate,
+		},
+		{
+			name:     "unknown template is a client error",
+			body:     `{"name":"Nope","template":"cobol"}`,
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := newTemplateProjectHandler(t)
+			request := httptest.NewRequest(http.MethodPost, "/api/projects", strings.NewReader(tt.body))
+			response := httptest.NewRecorder()
+
+			handler.HandleCollection(response, request)
+
+			if response.Code != tt.wantCode {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, tt.wantCode, response.Body)
+			}
+			if tt.wantCode != http.StatusCreated {
+				return
+			}
+			var meta serviceproject.Meta
+			if err := json.NewDecoder(response.Body).Decode(&meta); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if meta.Template != tt.want {
+				t.Fatalf("template = %q, want %q", meta.Template, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectContainerRouteReportsTemplateProvisioning(t *testing.T) {
+	handler := newTemplateProjectHandler(t)
+	request := httptest.NewRequest(
+		http.MethodPost, "/api/projects", strings.NewReader(`{"name":"Shop","template":"wordpress"}`),
+	)
+	response := httptest.NewRecorder()
+	handler.HandleCollection(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body = %s", response.Code, response.Body)
+	}
+	var created serviceproject.Meta
+	if err := json.NewDecoder(response.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+
+	inspect := httptest.NewRequest(
+		http.MethodGet, "/api/projects/"+string(created.ID)+"/container", nil,
+	)
+	inspectResponse := httptest.NewRecorder()
+	handler.HandleResource(inspectResponse, inspect)
+	if inspectResponse.Code != http.StatusOK {
+		t.Fatalf("container status = %d body = %s", inspectResponse.Code, inspectResponse.Body)
+	}
+	var info serviceproject.ContainerInspect
+	if err := json.NewDecoder(inspectResponse.Body).Decode(&info); err != nil {
+		t.Fatal(err)
+	}
+	if info.Template == nil || info.Template.Name != "wordpress" || info.Template.Status != "pending" {
+		t.Fatalf("template status = %+v", info.Template)
+	}
+}

--- a/backend/internal/transport/http/handlers/template_handler.go
+++ b/backend/internal/transport/http/handlers/template_handler.go
@@ -1,0 +1,39 @@
+package httphandlers
+
+import (
+	"net/http"
+
+	servicetemplates "github.com/futrx-com/remote.futrx.com/internal/service/container/templates"
+	httptransport "github.com/futrx-com/remote.futrx.com/internal/transport/http"
+)
+
+// TemplateHandler serves the project-template catalog used by the
+// new-project dialog. The list is static per build; only the "is a pre-built
+// image published on this host" flag is resolved per request.
+type TemplateHandler struct {
+	templates *servicetemplates.Service
+}
+
+func NewTemplateHandler(templates *servicetemplates.Service) *TemplateHandler {
+	return &TemplateHandler{templates: templates}
+}
+
+func (h *TemplateHandler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/templates", h.HandleCollection)
+}
+
+func (h *TemplateHandler) HandleCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		httptransport.SendErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if h.templates == nil {
+		httptransport.SendErr(w, http.StatusServiceUnavailable, "templates unavailable")
+		return
+	}
+	items := h.templates.List(r.Context())
+	if items == nil {
+		items = []servicetemplates.Descriptor{}
+	}
+	httptransport.SendJSON(w, http.StatusOK, items)
+}

--- a/backend/internal/transport/http/handlers/template_handler_test.go
+++ b/backend/internal/transport/http/handlers/template_handler_test.go
@@ -1,0 +1,166 @@
+package httphandlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	servicetemplates "github.com/futrx-com/remote.futrx.com/internal/service/container/templates"
+)
+
+// templateRuntimeStub answers the two probes the template service makes when
+// listing: it never runs anything, so the handler test stays hermetic.
+type templateRuntimeStub struct {
+	available bool
+	images    map[string]bool
+	imageErr  error
+}
+
+func (s templateRuntimeStub) Available() bool { return s.available }
+
+func (s templateRuntimeStub) FileExists(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func (s templateRuntimeStub) EnsureDirectory(context.Context, string, string) error { return nil }
+
+func (s templateRuntimeStub) PushFile(context.Context, string, []byte, string, string) error {
+	return nil
+}
+
+func (s templateRuntimeStub) RunScript(context.Context, string, string) (string, error) {
+	return "", nil
+}
+
+func (s templateRuntimeStub) ImageExists(_ context.Context, alias string) (bool, error) {
+	if s.imageErr != nil {
+		return false, s.imageErr
+	}
+	return s.images[alias], nil
+}
+
+func newTemplateTestHandler(runtime servicetemplates.Runtime) *TemplateHandler {
+	return NewTemplateHandler(servicetemplates.NewService(servicetemplates.MustLoad(), runtime))
+}
+
+func TestTemplateHandlerListsTheShippedCatalog(t *testing.T) {
+	handler := newTemplateTestHandler(templateRuntimeStub{
+		available: true,
+		images:    map[string]bool{"futrx-remote-wordpress-base": true},
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/api/templates", nil)
+	response := httptest.NewRecorder()
+	handler.HandleCollection(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	var body []servicetemplates.Descriptor
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("empty catalog")
+	}
+	if body[0].Name != "blank" || !body[0].Default {
+		t.Fatalf("first entry = %+v, want the default template first", body[0])
+	}
+	byName := map[string]servicetemplates.Descriptor{}
+	for _, descriptor := range body {
+		byName[descriptor.Name] = descriptor
+		if descriptor.Title == "" || descriptor.Description == "" || descriptor.Icon == "" {
+			t.Fatalf("descriptor %+v is missing presentation metadata", descriptor)
+		}
+	}
+	wordpress, ok := byName["wordpress"]
+	if !ok {
+		t.Fatalf("wordpress missing from %+v", body)
+	}
+	if wordpress.PrebuiltImage != "futrx-remote-wordpress-base" || !wordpress.PrebuiltImageAvailable {
+		t.Fatalf("wordpress = %+v, want the published image reported", wordpress)
+	}
+	laravel := byName["laravel"]
+	if laravel.PrebuiltImage != "futrx-remote-laravel-base" || laravel.PrebuiltImageAvailable {
+		t.Fatalf("laravel = %+v, want its unpublished image reported as unavailable", laravel)
+	}
+	if byName["node"].PrebuiltImage != "" {
+		t.Fatalf("node = %+v, want no dedicated image", byName["node"])
+	}
+}
+
+func TestTemplateHandlerReportsNoPrebuiltImagesWithoutARuntime(t *testing.T) {
+	handler := newTemplateTestHandler(templateRuntimeStub{available: false})
+
+	request := httptest.NewRequest(http.MethodGet, "/api/templates", nil)
+	response := httptest.NewRecorder()
+	handler.HandleCollection(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	var body []servicetemplates.Descriptor
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	for _, descriptor := range body {
+		if descriptor.PrebuiltImageAvailable {
+			t.Fatalf("%q reported an available image without a runtime", descriptor.Name)
+		}
+	}
+}
+
+func TestTemplateHandlerTreatsAnImageProbeFailureAsUnavailable(t *testing.T) {
+	handler := newTemplateTestHandler(templateRuntimeStub{
+		available: true,
+		imageErr:  errors.New("lxd is down"),
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/api/templates", nil)
+	response := httptest.NewRecorder()
+	handler.HandleCollection(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; a failing probe must not fail the list", response.Code, http.StatusOK)
+	}
+}
+
+func TestTemplateHandlerRejectsNonGET(t *testing.T) {
+	handler := newTemplateTestHandler(templateRuntimeStub{available: true})
+	request := httptest.NewRequest(http.MethodPost, "/api/templates", nil)
+	response := httptest.NewRecorder()
+
+	handler.HandleCollection(response, request)
+
+	if response.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestTemplateHandlerWithoutAService(t *testing.T) {
+	handler := NewTemplateHandler(nil)
+	request := httptest.NewRequest(http.MethodGet, "/api/templates", nil)
+	response := httptest.NewRecorder()
+
+	handler.HandleCollection(response, request)
+
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestTemplateHandlerRegistersItsRoute(t *testing.T) {
+	mux := http.NewServeMux()
+	newTemplateTestHandler(templateRuntimeStub{available: true}).RegisterRoutes(mux)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/templates", nil)
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+}

--- a/backend/internal/transport/http/server.go
+++ b/backend/internal/transport/http/server.go
@@ -29,6 +29,7 @@ type Handlers struct {
 	ServerInfo       RouteRegistrar
 	SelfUpdate       RouteRegistrar
 	Skills           RouteRegistrar
+	Templates        RouteRegistrar
 	BrowserInspector RouteRegistrar
 	Schedules        RouteRegistrar
 	Uploads          RouteRegistrar
@@ -60,6 +61,7 @@ func NewHandler(handlers Handlers) http.Handler {
 	register(handlers.ServerInfo)
 	register(handlers.SelfUpdate)
 	register(handlers.Skills)
+	register(handlers.Templates)
 	register(handlers.BrowserInspector)
 	register(handlers.Schedules)
 	register(handlers.Uploads)

--- a/backend/internal/transport/transport.go
+++ b/backend/internal/transport/transport.go
@@ -8,6 +8,7 @@ import (
 	service "github.com/futrx-com/remote.futrx.com/internal/service"
 	serviceauth "github.com/futrx-com/remote.futrx.com/internal/service/auth"
 	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+	servicetemplates "github.com/futrx-com/remote.futrx.com/internal/service/container/templates"
 	servicegithistory "github.com/futrx-com/remote.futrx.com/internal/service/githistory"
 	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
 	serviceselfupdate "github.com/futrx-com/remote.futrx.com/internal/service/selfupdate"
@@ -35,6 +36,7 @@ type Dependencies struct {
 	Files          *serviceworkspacefiles.Service
 	GitHistory     *servicegithistory.Service
 	IDE            *serviceworkspaceide.Service
+	Templates      *servicetemplates.Service
 }
 
 func NewHTTPHandler(deps Dependencies) (http.Handler, error) {
@@ -113,6 +115,7 @@ func NewHTTPHandler(deps Dependencies) (http.Handler, error) {
 		ServerInfo:       httphandlers.NewServerInfoHandler(deps.ServerInfo),
 		SelfUpdate:       httphandlers.NewSelfUpdateHandler(deps.SelfUpdate, deps.Services.Auth),
 		Skills:           httphandlers.NewSkillHandler(deps.Services.Skills),
+		Templates:        httphandlers.NewTemplateHandler(deps.Templates),
 		BrowserInspector: httphandlers.NewBrowserInspectorHandler(),
 		Schedules:        scheduleHandler,
 		Uploads:          uploads,

--- a/docs/01-overview/README.md
+++ b/docs/01-overview/README.md
@@ -25,6 +25,7 @@ This documentation maps the complete `remote.futrx` application: how to use ever
 | [04-chat-and-agents.md](../02-workspaces/04-chat-and-agents.md) | Chats, prompt execution, providers, modes, skills, streaming, fork, and rewind |
 | [05-workspace-tools.md](../02-workspaces/05-workspace-tools.md) | Attachments, files, terminal, Git history, and browser IDE |
 | [06-scheduled-tasks.md](../02-workspaces/06-scheduled-tasks.md) | Host scheduler, task state, capability-scoped agent tools, overlap, guardrails, and recovery |
+| [08-project-templates.md](../02-workspaces/08-project-templates.md) | Stack presets, in-container provisioning, pre-built template images, and adding a template |
 | [06-previews-and-browser.md](../03-platform/06-previews-and-browser.md) | App discovery, HTTPS preview URLs, element inspection, and Agent Browser |
 | [07-data-and-frontend-state.md](../03-platform/07-data-and-frontend-state.md) | File-backed persistence, workspace files, entities, and UI state |
 | [08-api-and-realtime.md](../03-platform/08-api-and-realtime.md) | HTTP endpoints, WebSockets, events, and access gates |

--- a/docs/02-workspaces/03-projects-and-containers.md
+++ b/docs/02-workspaces/03-projects-and-containers.md
@@ -16,18 +16,26 @@ sequenceDiagram
     participant LXD
     participant Provision as Launch provisioners
 
-    User->>API: Create project with a name
-    API->>Store: Create ID, unique slug, metadata
+    User->>API: Create project with a name and a template
+    API->>Store: Create ID, unique slug, metadata (including the template)
     API->>Access: Add creator as a member
     API->>Files: Prepare durable workspace and agent-home directories
-    API->>LXD: Launch from futrx-remote-dev-base
+    API->>LXD: Launch from the template image if published, else futrx-remote-dev-base
     LXD->>LXD: Attach workspace and provider homes
     API->>Provision: Credentials, skills, browser assets, code-server
+    API->>Provision: Template stack (background, marker-gated)
     API->>Store: Mark running or error
     Store-->>User: Workspace WebSocket project update
 ```
 
 The slug becomes the container name and is used in IDE and preview hostnames. Duplicate names receive a unique slug.
+
+The template is chosen at creation and never changes. It selects the image the
+container is created from and a one-time provisioning step that installs a
+stack (WordPress, Laravel, Node, Python) inside it. Projects created before
+templates existed, and projects created without choosing one, use `blank` — the
+plain base image, which is the pre-template behaviour. See
+[Project templates](08-project-templates.md).
 
 ## Durable and replaceable parts
 

--- a/docs/02-workspaces/08-project-templates.md
+++ b/docs/02-workspaces/08-project-templates.md
@@ -1,0 +1,253 @@
+# Project templates
+
+A **template** (stack preset) decides what is installed inside a project's
+container. It is chosen once, in the new-project dialog, and cannot be changed
+afterwards.
+
+Templates are a **layer**, not a fleet of images. The target deployment is a
+single small server, so building one complete image per stack would be
+expensive in build time and disk. A template is therefore:
+
+1. the shared base image `futrx-remote-dev-base`, plus
+2. a post-provision script run once inside the new container, plus
+3. optional seed files written into the durable `/workspace` mount, plus
+4. an optional agent-instructions snippet seeded as `/workspace/AGENTS.md`.
+
+A template may *additionally* declare a dedicated pre-built image alias. When
+that image is published on the host, the container launches straight from it
+and the provisioning is already baked in.
+
+```mermaid
+flowchart TD
+    Create["Create project with template T"] --> Resolve{"futrx-remote-T-base published?"}
+    Resolve -- yes --> Fast["lxc init futrx-remote-T-base<br/>(fast path: stack already installed)"]
+    Resolve -- no --> Slow["lxc init futrx-remote-dev-base<br/>(slow path)"]
+    Fast --> Marker{"/var/lib/remote-template.done present?"}
+    Slow --> Marker
+    Marker -- yes --> Ready["Nothing to do"]
+    Marker -- no --> Provision["Seed /workspace files, then run the provision script<br/>logging to /var/log/remote-template.log"]
+    Provision --> Done["Write the marker; report done"]
+```
+
+## What each template installs
+
+| Template | Installs | Ports | Pre-built image |
+| --- | --- | --- | --- |
+| `blank` (default) | Nothing beyond the base image: Ubuntu 24.04, Node 22, Python 3, git, gh, jq, the agent CLIs, code-server, Chromium | — | not applicable |
+| `wordpress` | PHP 8.3 CLI + `mysql`, `curl`, `gd`, `mbstring`, `xml`, `zip`, `intl`, `bcmath`, `soap`; MariaDB (enabled as a boot service, root over the unix socket, no password, database `wordpress`); Composer; WP-CLI at `/usr/local/bin/wp` plus a `wp-root` wrapper; WordPress core downloaded to `/workspace/public` with a generated `wp-config.php`; `remote-wordpress.service` serving `/workspace/public` on port 8080 with PHP's built-in server | 8080 | `futrx-remote-wordpress-base` |
+| `laravel` | PHP 8.3 CLI + `mysql`, `sqlite3`, `curl`, `mbstring`, `xml`, `zip`, `intl`, `bcmath`, `gd`; MariaDB (boot service, database `laravel`); Composer; a `laravel/laravel` skeleton in `/workspace/app` with `.env` pointed at the local database. Node 22 for Vite comes from the base image | 8000, 5173 | `futrx-remote-laravel-base` |
+| `node` | `pnpm` and `yarn` enabled through corepack, plus a `/workspace/README.md`. Nothing is downloaded from apt | 3000, 5173 | none |
+| `python` | `python3.12-venv`, `python3-dev`, `pipx`, `uv` at `/usr/local/bin/uv`, and a project virtualenv at `/workspace/.venv`, plus a `/workspace/README.md`. Poetry is deliberately not installed | 8000 | none |
+
+WooCommerce is **not** preinstalled on the WordPress template. Install it in a
+project when it is needed:
+
+```bash
+wp --allow-root --path=/workspace/public plugin install woocommerce --activate
+```
+
+The port column is informational. Previews are discovered by scanning the
+container for listening sockets, so any port bound to `0.0.0.0` becomes a
+preview URL regardless of what the template declares.
+
+## Provisioning contract
+
+Every template's provision script runs inside a shared harness
+(`ProvisionProgram` in
+[`backend/internal/service/container/templates/provisioning.go`](../../backend/internal/service/container/templates/provisioning.go)),
+which supplies:
+
+- `set -eu`, `DEBIAN_FRONTEND=noninteractive`, `NEEDRESTART_MODE=a`, and
+  `APT_LISTCHANGES_FRONTEND=none`, so no install can prompt;
+- an `apt_retry` helper that runs `apt-get`, then refreshes the index and
+  retries **once** — the templates must use it instead of bare `apt-get`;
+- output teed to `/var/log/remote-template.log` inside the container;
+- the marker protocol below.
+
+| Path (inside the container) | Meaning |
+| --- | --- |
+| `/var/log/remote-template.log` | Append-only log of every provisioning run |
+| `/var/lib/remote-template.done` | Written only after the script completes. Its presence makes every later run a no-op |
+| `/var/lib/remote-template.failed` | Written when a run starts, removed on success. Its presence after a backend restart is what distinguishes "failed" from "pending" |
+
+All three live in the **disposable** container root filesystem, on purpose.
+`upgrade-workspaces` re-clones every container from the image, which discards
+them — and that is exactly the intent: a replaced container must be
+re-provisioned. The lifecycle offers provisioning on **every** convergence
+([`lifecycle/service.go`](../../backend/internal/service/container/lifecycle/service.go)),
+and the marker file is what makes that offer cheap: one `test -e` per project
+start.
+
+Seeding never overwrites. `/workspace` is durable and may already hold the
+user's own version of a path, so a seed whose target exists is skipped.
+
+## Provisioning status
+
+Provisioning runs in the background — a WordPress stack on a 1 vCPU host takes
+minutes — so project creation returns immediately and the status is polled.
+
+| Status | Meaning |
+| --- | --- |
+| `none` | The template installs nothing (`blank`); the container was ready on first boot |
+| `pending` | Provisioning is required and has not started, or the backend restarted before it could |
+| `running` | The provision script is executing |
+| `done` | The marker file is present |
+| `failed` | The last attempt exited non-zero |
+
+The status is part of the project status payload:
+
+```bash
+curl -s -b cookies.txt https://<host>/api/projects/<id>/container | jq .template
+```
+
+```json
+{
+  "name": "wordpress",
+  "title": "WordPress",
+  "status": "running",
+  "logPath": "/var/log/remote-template.log",
+  "startedAt": 1755400000000
+}
+```
+
+The project settings page shows the same thing as a badge next to the project
+name and as a **Template** panel on the Info tab.
+
+A failed run is retried on the next convergence, so **restarting the project**
+retries provisioning. Read `/var/log/remote-template.log` inside the container
+for the cause.
+
+## Building a pre-built template image on a beefier server
+
+The slow path costs every new project the full install. Publishing a dedicated
+image moves that cost to build time, once per host:
+
+```bash
+cd /opt/remote.futrx/backend
+
+# Which templates can be baked into an image
+go run ./cmd/build-template-image -list
+
+# Build. The builder starts from futrx-remote-dev-base, so the base image
+# must already be published (infra/steps/05-base-image.sh does that).
+go run ./cmd/build-template-image -template wordpress
+
+# Replace an existing one
+go run ./cmd/build-template-image -template wordpress -overwrite
+```
+
+Publishing compresses the whole root filesystem and regularly exceeds the
+default 5-minute budget on a 1 vCPU box. Both budgets are overridable, by flag
+or environment variable:
+
+```bash
+go run ./cmd/build-template-image -template wordpress \
+  -build-timeout 60m -publish-timeout 30m
+
+FUTRX_IMAGE_BUILD_TIMEOUT=60m FUTRX_IMAGE_PUBLISH_TIMEOUT=30m \
+  go run ./cmd/build-template-image -template wordpress
+```
+
+The image is a plain LXD image, so it can be built on a bigger machine and
+moved:
+
+```bash
+# On the build host
+lxc image export futrx-remote-wordpress-base wordpress-base
+scp wordpress-base.tar.gz root@server:/tmp/
+
+# On the small server
+lxc image import /tmp/wordpress-base.tar.gz --alias futrx-remote-wordpress-base
+```
+
+`GET /api/templates` reports `prebuiltImageAvailable` per template, and the
+new-project dialog shows a **prebuilt image** tag on those cards, so you can
+confirm the fast path is live without touching the host.
+
+### Keeping template images current
+
+`infra/upgrade-workspaces.sh` rebakes `futrx-remote-dev-base` and recycles
+containers onto it. Projects whose template has a published image launch from
+**that** image, not from the base, so the base rebake alone leaves them on the
+old layer. The script detects published `futrx-remote-*-base` aliases and warns
+about it; pass `--rebake-templates` to rebuild each of them on top of the fresh
+base:
+
+```bash
+sudo bash /opt/remote.futrx/infra/upgrade-workspaces.sh --rebake-templates
+```
+
+The rest of the script's behaviour is unchanged: containers with an active
+agent process are still skipped unless `--include-busy` is given, and
+`/workspace` plus the provider homes still survive.
+
+Deleting a template image is always safe. The next project on that template
+falls back to base + provision script.
+
+## Adding a custom template
+
+Templates are data files embedded into the binary. Adding one is a code change,
+not a runtime configuration:
+
+1. Create `backend/internal/service/container/templates/<name>/` — the
+   directory name **is** the template name and must match `[a-z][a-z0-9-]{0,31}`.
+2. Write `template.json`:
+
+   ```json
+   {
+     "name": "rails",
+     "title": "Ruby on Rails",
+     "description": "Shown on the picker card. One or two sentences.",
+     "icon": "blank",
+     "provisionScript": "provision.sh",
+     "agentInstructions": "AGENTS.md",
+     "seedFiles": [
+       { "source": "README.md", "target": "/workspace/README.md", "mode": "644" }
+     ],
+     "defaultPorts": [3000],
+     "prebuiltImage": true
+   }
+   ```
+
+   Every field except `name`, `title`, `description`, and `icon` is optional.
+   Unknown fields are rejected at load time. `seedFiles[].target` must be a
+   clean absolute path under `/workspace/`. `prebuiltImage: true` only means
+   the runtime will *look* for `futrx-remote-<name>-base`; it does not create
+   it.
+
+3. Write `provision.sh` as a **payload**, not a standalone script: no shebang,
+   no `set -e`, no `DEBIAN_FRONTEND`, no marker handling — the harness owns all
+   of those. Use `apt_retry` for apt calls. A test enforces this.
+
+4. Write `AGENTS.md` describing the stack for agents: what is installed, where,
+   which commands to use, and the preview rules. It is seeded to
+   `/workspace/AGENTS.md` and never overwrites an existing file.
+
+5. Add the directory to the `//go:embed` line in
+   [`catalog.go`](../../backend/internal/service/container/templates/catalog.go)
+   and give it a position in the `order` map (unlisted templates sort
+   alphabetically after the listed ones).
+
+6. Optionally map the `icon` key to a glyph in
+   [`frontend/src/ui/projects/templateIcons.tsx`](../../frontend/src/ui/projects/templateIcons.tsx).
+   An unmapped key falls back to a generic icon rather than failing.
+
+7. Run `go test ./internal/service/container/templates/...`. Catalog
+   validation, the harness contract, and the shipped-template properties are
+   all covered there.
+
+## Backward compatibility
+
+Project metadata (`DATA_DIR/projects/<id>/meta.json`) gained a `template`
+field. It is omitted when the project uses the default, so metadata for a
+`blank` project is byte-compatible with what earlier releases wrote, and a
+`meta.json` without the field reads as `blank`.
+
+## Why the template is immutable
+
+The template is applied to the container root filesystem *and* to `/workspace`:
+packages, systemd units, a database, a downloaded application skeleton, and
+seeded files. Switching a live project to another stack would mean uninstalling
+all of that from a workspace the user has since edited, which cannot be done
+safely. Create a new project instead; `/workspace` can be copied across with
+the file manager or git.

--- a/docs/03-platform/08-api-and-realtime.md
+++ b/docs/03-platform/08-api-and-realtime.md
@@ -51,6 +51,7 @@ All `/api/*` and `/ws*` requests require a signed session for a registered user.
 | POST | `/api/codex/login/device` | Start Codex device login; admin only |
 | POST | `/api/kimi/login/device` | Start Kimi device login; admin only |
 | GET | `/api/skills?provider=...&projectId=...` | List accessible provider and project skills |
+| GET | `/api/templates` | List project templates and whether each has a pre-built image on this host |
 
 `{provider}` can also be `antigravity` for the generic status binding, but
 Antigravity has no host login route. Its status is unavailable by design
@@ -60,13 +61,13 @@ because users authenticate `agy` inside each project.
 
 | Method | Route | Purpose |
 | --- | --- | --- |
-| GET, POST | `/api/projects` | List visible projects or create a project |
+| GET, POST | `/api/projects` | List visible projects or create a project (`{"name","template"}`; an unknown template is a 400) |
 | POST | `/api/projects/reorder` | Update project ordering |
 | GET, PATCH, DELETE | `/api/projects/{id}` | Read, rename, or admin-delete a project |
 | POST | `/api/projects/{id}/start` | Start or relaunch a project |
 | POST | `/api/projects/{id}/stop` | Stop a project |
 | POST | `/api/projects/{id}/restart` | Force restart or relaunch a project |
-| GET | `/api/projects/{id}/container` | Detailed container inspection |
+| GET | `/api/projects/{id}/container` | Detailed container inspection, including `template` provisioning status |
 | PUT | `/api/projects/{id}/limits` | Set CPU, memory, and disk overrides; admin only |
 | POST | `/api/projects/{id}/repair-network` | Reconfigure container networking and reinspect |
 | GET | `/api/projects/{id}/apps` | List externally reachable container listeners |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "node --experimental-strip-types --test src/shared/projectPreviewUrls.test.ts src/state/auth/returnUrlPolicy.test.ts src/state/chat/chatAttachmentState.test.ts src/state/chat/chatBrowserState.test.ts src/state/chat/chatEventStateProjector.test.ts src/state/chat/chatPreferenceState.test.ts src/state/chat/composerSessionStore.test.ts src/state/chat/promptQueueState.test.ts src/state/chat/workspaceFileBrowserState.test.ts src/state/workspace/workspaceState.test.ts src/ui/chat/files/fileMeta.test.ts src/ui/chat/ideLinks.test.ts src/ui/chat/history/diffModel.test.ts src/ui/chat/schedules/scheduledTaskView.test.ts",
+    "test": "node --experimental-strip-types --test src/shared/projectPreviewUrls.test.ts src/state/auth/returnUrlPolicy.test.ts src/state/chat/chatAttachmentState.test.ts src/state/chat/chatBrowserState.test.ts src/state/chat/chatEventStateProjector.test.ts src/state/chat/chatPreferenceState.test.ts src/state/chat/composerSessionStore.test.ts src/state/chat/promptQueueState.test.ts src/state/chat/workspaceFileBrowserState.test.ts src/state/projects/newProjectState.test.ts src/state/workspace/workspaceState.test.ts src/ui/chat/files/fileMeta.test.ts src/ui/chat/ideLinks.test.ts src/ui/chat/history/diffModel.test.ts src/ui/chat/schedules/scheduledTaskView.test.ts",
     "test:project-preview-urls": "node --experimental-strip-types --test src/shared/projectPreviewUrls.test.ts"
   },
   "dependencies": {

--- a/frontend/src/api/projectApi.ts
+++ b/frontend/src/api/projectApi.ts
@@ -8,8 +8,11 @@ import { API_ROUTES } from "../config/routes";
 
 export const projectApi = {
   list: () => requestJson<ProjectMeta[]>("GET", API_ROUTES.projects.collection),
-  create: (name: string) =>
-    requestJson<ProjectMeta>("POST", API_ROUTES.projects.collection, { name }),
+  create: (name: string, template?: string) =>
+    requestJson<ProjectMeta>("POST", API_ROUTES.projects.collection, {
+      name,
+      ...(template ? { template } : {}),
+    }),
   fetch: (id: string) =>
     requestJson<ProjectMeta>("GET", API_ROUTES.projects.item(id)),
   update: (id: string, body: { name?: string }) =>

--- a/frontend/src/api/templateApi.ts
+++ b/frontend/src/api/templateApi.ts
@@ -1,0 +1,7 @@
+import { requestJson } from "./apiRequest";
+import type { ProjectTemplate } from "../models/template";
+import { API_ROUTES } from "../config/routes";
+
+export const templateApi = {
+  list: () => requestJson<ProjectTemplate[]>("GET", API_ROUTES.templates),
+};

--- a/frontend/src/app/containers/WorkspaceContainer.tsx
+++ b/frontend/src/app/containers/WorkspaceContainer.tsx
@@ -1,5 +1,6 @@
 import { AppShell } from "../../ui/layout/AppShell";
 import { NoChatSelected } from "../../ui/layout/NoChatSelected";
+import { NewProjectDialog } from "../../ui/projects/NewProjectDialog";
 import { useWorkspaceContext } from "../../state/context/WorkspaceContext";
 import { useWorkspaceCommands } from "../../state/hooks/workspace/useWorkspaceCommands";
 import { ChatContainer } from "./ChatContainer";
@@ -12,35 +13,44 @@ export function WorkspaceContainer() {
   const commands = useWorkspaceCommands();
 
   return (
-    <AppShell sidebar={<SidebarContainer />}>
-      {workspace.ui.view === "settings" ? (
-        <SettingsContainer
-          onBack={workspace.showChat}
-          onHamburger={workspace.openSidebar}
-        />
-      ) : workspace.ui.view === "project-containers" ? (
-        <ProjectContainersContainer
-          projects={workspace.projects}
-          selectedProjectId={workspace.ui.containerProjectId}
-          onBack={workspace.showChat}
-          onHamburger={workspace.openSidebar}
-          onDeleteProject={workspace.deleteProject}
-        />
-      ) : workspace.activeChat ? (
-        <ChatContainer
-          key={workspace.activeChat.id}
-          chat={workspace.activeChat}
-          projects={workspace.projects}
-          onHamburger={workspace.openSidebar}
-        />
-      ) : (
-        <NoChatSelected
-          hasProjects={workspace.projects.length > 0}
-          onNewProject={commands.newProject}
-          onNewChat={() => commands.newChatInProject(undefined)}
-          onHamburger={workspace.openSidebar}
-        />
-      )}
-    </AppShell>
+    <>
+      <AppShell sidebar={<SidebarContainer />}>
+        {workspace.ui.view === "settings" ? (
+          <SettingsContainer
+            onBack={workspace.showChat}
+            onHamburger={workspace.openSidebar}
+          />
+        ) : workspace.ui.view === "project-containers" ? (
+          <ProjectContainersContainer
+            projects={workspace.projects}
+            selectedProjectId={workspace.ui.containerProjectId}
+            onBack={workspace.showChat}
+            onHamburger={workspace.openSidebar}
+            onDeleteProject={workspace.deleteProject}
+          />
+        ) : workspace.activeChat ? (
+          <ChatContainer
+            key={workspace.activeChat.id}
+            chat={workspace.activeChat}
+            projects={workspace.projects}
+            onHamburger={workspace.openSidebar}
+          />
+        ) : (
+          <NoChatSelected
+            hasProjects={workspace.projects.length > 0}
+            onNewProject={commands.newProject}
+            onNewChat={() => commands.newChatInProject(undefined)}
+            onHamburger={workspace.openSidebar}
+          />
+        )}
+      </AppShell>
+      <NewProjectDialog
+        state={workspace.newProject}
+        onNameChange={workspace.setNewProjectName}
+        onSelectTemplate={workspace.selectNewProjectTemplate}
+        onSubmit={workspace.submitNewProject}
+        onClose={workspace.closeNewProject}
+      />
+    </>
   );
 }

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -91,6 +91,7 @@ export const API_ROUTES = {
     apply: "/api/admin/update/apply",
   },
   skills: (query: string) => `/api/skills?${query}`,
+  templates: "/api/templates",
   uploads: "/api/uploads",
   users: {
     collection: "/api/admin/users",

--- a/frontend/src/models/project.ts
+++ b/frontend/src/models/project.ts
@@ -1,3 +1,5 @@
+import type { ProjectTemplateStatus } from "./template";
+
 export type ProjectStatus =
   | ""
   | "provisioning"
@@ -20,11 +22,22 @@ export interface ProjectMeta {
   cwd: string;
   containerName: string;
   status: ProjectStatus;
+  /**
+   * Stack preset the container was created from. Absent on projects created
+   * before templates existed, which behave like "blank"; read it through
+   * projectTemplateName().
+   */
+  template?: string;
   order?: number;
   errorMsg?: string;
   resourceLimits?: ContainerLimits;
   createdAt: number;
   updatedAt: number;
+}
+
+/** Backward-compatible read of ProjectMeta.template. */
+export function projectTemplateName(project: Pick<ProjectMeta, "template">): string {
+  return project.template || "blank";
 }
 
 export interface WorkspaceInfo {
@@ -124,6 +137,7 @@ export interface ProjectContainerInfo {
   claude: ClaudeContainerStatus;
   codex: CodexContainerStatus;
   authBundles: AuthBundleStatus[];
+  template?: ProjectTemplateStatus;
 }
 
 export interface ProjectSecret {

--- a/frontend/src/models/template.ts
+++ b/frontend/src/models/template.ts
@@ -1,0 +1,40 @@
+/**
+ * Project templates ("stack presets"). A template is the shared base image
+ * plus a one-time in-container provisioning step, so choosing one at project
+ * creation is the only place the stack is decided — it cannot be changed
+ * afterwards.
+ */
+export interface ProjectTemplate {
+  name: string;
+  title: string;
+  description: string;
+  /** Stable key mapped to a glyph by the UI; unknown keys fall back. */
+  icon: string;
+  defaultPorts?: number[];
+  /** True for the template assigned when none is requested. */
+  default: boolean;
+  /** False when the template installs nothing (the container starts at once). */
+  provisions: boolean;
+  /** Alias of the dedicated pre-built image, when the template declares one. */
+  prebuiltImage?: string;
+  /** True when that image is published on this host (fast first start). */
+  prebuiltImageAvailable: boolean;
+}
+
+/** How far a project's one-time template provisioning has got. */
+export type TemplateProvisionStatus =
+  | "none"
+  | "pending"
+  | "running"
+  | "done"
+  | "failed";
+
+export interface ProjectTemplateStatus {
+  name: string;
+  title?: string;
+  status: TemplateProvisionStatus;
+  error?: string;
+  logPath?: string;
+  startedAt?: number;
+  finishedAt?: number;
+}

--- a/frontend/src/state/context/WorkspaceContext.tsx
+++ b/frontend/src/state/context/WorkspaceContext.tsx
@@ -5,6 +5,7 @@ import type { ChatMeta, CreateChatInput } from "../../models/chat";
 import type { ProjectMeta } from "../../models/project";
 import { chatApi } from "../../api/chatApi";
 import { projectApi } from "../../api/projectApi";
+import { templateApi } from "../../api/templateApi";
 import { useWorkspaceData } from "../hooks/workspace/useWorkspaceData";
 import { useUserSettingsContext } from "./UserSettingsContext";
 import {
@@ -12,6 +13,10 @@ import {
   type WorkspaceUiState,
 } from "../workspace/workspaceUiState";
 import { workspaceSidebarState } from "../workspace/workspaceSidebarState";
+import {
+  newProjectState,
+  type NewProjectState,
+} from "../projects/newProjectState";
 
 interface WorkspaceContextValue {
   chats: ChatMeta[];
@@ -24,7 +29,12 @@ interface WorkspaceContextValue {
   showChat: () => void;
   showSettings: () => void;
   showProjectContainers: (projectId: string | null) => void;
-  createProject: (name: string) => Promise<ProjectMeta>;
+  newProject: NewProjectState;
+  openNewProject: () => void;
+  closeNewProject: () => void;
+  setNewProjectName: (name: string) => void;
+  selectNewProjectTemplate: (template: string) => void;
+  submitNewProject: () => Promise<void>;
   createChat: (projectId?: string) => Promise<ChatMeta>;
   deleteChat: (chatId: string) => Promise<void>;
   forkChat: (chatId: string) => Promise<ChatMeta>;
@@ -46,6 +56,10 @@ export function WorkspaceProvider({
   const data = useWorkspaceData(enabled);
   const { settings } = useUserSettingsContext();
   const [ui, dispatch] = useReducer(workspaceUiState.reduce, workspaceUiState.createInitial());
+  const [newProject, dispatchNewProject] = useReducer(
+    newProjectState.reduce,
+    newProjectState.createInitial()
+  );
   const activeChat = workspaceSidebarState.activeChat(data.chats, ui.activeChatId);
 
   useEffect(() => {
@@ -59,9 +73,30 @@ export function WorkspaceProvider({
     }
   }, [data.chats, ui.activeChatId]);
 
-  async function createProject(name: string): Promise<ProjectMeta> {
-    const project = await projectApi.create(name);
-    return project;
+  // The template catalog is fetched once the dialog is first opened, not on
+  // mount: it is a static list only this dialog needs.
+  function openNewProject() {
+    dispatchNewProject({ type: "open" });
+    if (newProject.templates.length > 0 || newProject.templatesLoading) return;
+    dispatchNewProject({ type: "templates-loading" });
+    templateApi
+      .list()
+      .then((templates) => dispatchNewProject({ type: "templates-loaded", templates }))
+      .catch((error: Error) =>
+        dispatchNewProject({ type: "templates-failed", error: error.message })
+      );
+  }
+
+  async function submitNewProject(): Promise<void> {
+    const name = newProjectState.submittedName(newProject);
+    if (!name) return;
+    dispatchNewProject({ type: "submit" });
+    try {
+      await projectApi.create(name, newProject.template);
+      dispatchNewProject({ type: "close" });
+    } catch (error) {
+      dispatchNewProject({ type: "submit-failed", error: (error as Error).message });
+    }
   }
 
   async function createChat(projectId?: string): Promise<ChatMeta> {
@@ -118,7 +153,13 @@ export function WorkspaceProvider({
         showSettings: () => dispatch({ type: "show-settings" }),
         showProjectContainers: (projectId) =>
           dispatch({ type: "show-project-containers", projectId }),
-        createProject,
+        newProject,
+        openNewProject,
+        closeNewProject: () => dispatchNewProject({ type: "close" }),
+        setNewProjectName: (name) => dispatchNewProject({ type: "set-name", name }),
+        selectNewProjectTemplate: (template) =>
+          dispatchNewProject({ type: "select-template", template }),
+        submitNewProject,
         createChat,
         deleteChat,
         forkChat,

--- a/frontend/src/state/hooks/workspace/useWorkspaceCommands.ts
+++ b/frontend/src/state/hooks/workspace/useWorkspaceCommands.ts
@@ -6,14 +6,10 @@ import { chatApi } from "../../../api/chatApi";
 export function useWorkspaceCommands() {
   const workspace = useWorkspaceContext();
 
-  async function newProject() {
-    const name = prompt("Project name?", "");
-    if (!name || !name.trim()) return;
-    try {
-      await workspace.createProject(name.trim());
-    } catch (error) {
-      alert("create project failed: " + (error as Error).message);
-    }
+  // Opens the new-project dialog, which owns the name field and the template
+  // picker. Errors surface inside the dialog rather than in an alert().
+  function newProject() {
+    workspace.openNewProject();
   }
 
   async function newChatInProject(projectId?: string) {

--- a/frontend/src/state/projects/newProjectState.test.ts
+++ b/frontend/src/state/projects/newProjectState.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ProjectTemplate } from "../../models/template.ts";
+import { newProjectState, type NewProjectState } from "./newProjectState.ts";
+
+const catalog: ProjectTemplate[] = [
+  {
+    name: "blank",
+    title: "Blank",
+    description: "Nothing extra.",
+    icon: "blank",
+    default: true,
+    provisions: false,
+    prebuiltImageAvailable: false,
+  },
+  {
+    name: "wordpress",
+    title: "WordPress",
+    description: "PHP + MariaDB + WP-CLI.",
+    icon: "wordpress",
+    defaultPorts: [8080],
+    default: false,
+    provisions: true,
+    prebuiltImage: "futrx-remote-wordpress-base",
+    prebuiltImageAvailable: false,
+  },
+  {
+    name: "laravel",
+    title: "Laravel",
+    description: "PHP + Composer + MariaDB.",
+    icon: "laravel",
+    default: false,
+    provisions: true,
+    prebuiltImage: "futrx-remote-laravel-base",
+    prebuiltImageAvailable: true,
+  },
+];
+
+function loaded(): NewProjectState {
+  const opened = newProjectState.reduce(newProjectState.createInitial(), { type: "open" });
+  return newProjectState.reduce(opened, { type: "templates-loaded", templates: catalog });
+}
+
+test("starts closed on the default template", () => {
+  const initial = newProjectState.createInitial();
+  assert.equal(initial.open, false);
+  assert.equal(initial.template, "blank");
+  assert.equal(newProjectState.canSubmit(initial), false);
+});
+
+test("loading the catalog keeps the catalog's own default", () => {
+  const state = loaded();
+  assert.equal(state.template, "blank");
+  assert.equal(state.templates.length, 3);
+  assert.equal(state.templatesLoading, false);
+});
+
+test("a selection that survives a catalog reload is kept", () => {
+  const selected = newProjectState.reduce(loaded(), {
+    type: "select-template",
+    template: "wordpress",
+  });
+  const reloaded = newProjectState.reduce(selected, {
+    type: "templates-loaded",
+    templates: catalog,
+  });
+  assert.equal(reloaded.template, "wordpress");
+});
+
+test("a selection the catalog no longer offers falls back to the default", () => {
+  const selected = newProjectState.reduce(loaded(), {
+    type: "select-template",
+    template: "wordpress",
+  });
+  const reloaded = newProjectState.reduce(selected, {
+    type: "templates-loaded",
+    templates: [catalog[0]],
+  });
+  assert.equal(reloaded.template, "blank");
+});
+
+test("a failed catalog still allows creating a default project", () => {
+  const failed = newProjectState.reduce(loaded(), {
+    type: "templates-failed",
+    error: "503",
+  });
+  assert.equal(failed.template, "blank");
+  assert.equal(failed.templatesError, "503");
+  assert.equal(failed.templates.length, 0);
+
+  const named = newProjectState.reduce(failed, { type: "set-name", name: "Site" });
+  assert.equal(newProjectState.canSubmit(named), true);
+});
+
+test("reopening clears the form but keeps the loaded catalog", () => {
+  const dirty = newProjectState.reduce(
+    newProjectState.reduce(loaded(), { type: "set-name", name: "Draft" }),
+    { type: "select-template", template: "laravel" }
+  );
+  const failed = newProjectState.reduce(dirty, { type: "submit-failed", error: "boom" });
+  const reopened = newProjectState.reduce(failed, { type: "open" });
+
+  assert.equal(reopened.name, "");
+  assert.equal(reopened.error, "");
+  assert.equal(reopened.submitting, false);
+  assert.equal(reopened.template, "blank");
+  assert.equal(reopened.templates.length, 3);
+});
+
+test("submission requires a non-blank name and blocks double submits", () => {
+  const blank = newProjectState.reduce(loaded(), { type: "set-name", name: "   " });
+  assert.equal(newProjectState.canSubmit(blank), false);
+
+  const named = newProjectState.reduce(loaded(), { type: "set-name", name: "  Site  " });
+  assert.equal(newProjectState.submittedName(named), "Site");
+  assert.equal(newProjectState.canSubmit(named), true);
+
+  const submitting = newProjectState.reduce(named, { type: "submit" });
+  assert.equal(newProjectState.canSubmit(submitting), false);
+
+  const failed = newProjectState.reduce(submitting, { type: "submit-failed", error: "409" });
+  assert.equal(failed.error, "409");
+  assert.equal(newProjectState.canSubmit(failed), true);
+});
+
+test("the first-start notice reflects whether a prebuilt image is published", () => {
+  const blank = loaded();
+  assert.equal(newProjectState.firstStartNotice(blank), "");
+
+  const slow = newProjectState.reduce(blank, { type: "select-template", template: "wordpress" });
+  assert.match(newProjectState.firstStartNotice(slow), /several minutes/);
+
+  const fast = newProjectState.reduce(blank, { type: "select-template", template: "laravel" });
+  assert.match(newProjectState.firstStartNotice(fast), /starts immediately/);
+});
+
+test("closing leaves no in-flight submission behind", () => {
+  const submitting = newProjectState.reduce(
+    newProjectState.reduce(loaded(), { type: "set-name", name: "Site" }),
+    { type: "submit" }
+  );
+  const closed = newProjectState.reduce(submitting, { type: "close" });
+  assert.equal(closed.open, false);
+  assert.equal(closed.submitting, false);
+});

--- a/frontend/src/state/projects/newProjectState.ts
+++ b/frontend/src/state/projects/newProjectState.ts
@@ -1,0 +1,136 @@
+import type { ProjectTemplate } from "../../models/template";
+
+/**
+ * State of the new-project dialog. The template is chosen here and nowhere
+ * else: a project's stack preset is immutable once its container exists, so
+ * this dialog is the whole decision surface.
+ */
+export interface NewProjectState {
+  open: boolean;
+  name: string;
+  /** Selected template name; "" until the catalog loads. */
+  template: string;
+  templates: ProjectTemplate[];
+  templatesLoading: boolean;
+  templatesError: string;
+  submitting: boolean;
+  error: string;
+}
+
+export type NewProjectAction =
+  | { type: "open" }
+  | { type: "close" }
+  | { type: "set-name"; name: string }
+  | { type: "select-template"; template: string }
+  | { type: "templates-loading" }
+  | { type: "templates-loaded"; templates: ProjectTemplate[] }
+  | { type: "templates-failed"; error: string }
+  | { type: "submit" }
+  | { type: "submit-failed"; error: string };
+
+/** The template assumed before the catalog answers, and if it omits a default. */
+export const DEFAULT_TEMPLATE = "blank";
+
+class NewProjectStateTransitions {
+  createInitial(): NewProjectState {
+    return {
+      open: false,
+      name: "",
+      template: DEFAULT_TEMPLATE,
+      templates: [],
+      templatesLoading: false,
+      templatesError: "",
+      submitting: false,
+      error: "",
+    };
+  }
+
+  readonly reduce = (
+    state: NewProjectState,
+    action: NewProjectAction
+  ): NewProjectState => {
+    switch (action.type) {
+      case "open":
+        // Reopening starts from a clean form but keeps the already-loaded
+        // catalog, so the picker does not flash on every open.
+        return {
+          ...state,
+          open: true,
+          name: "",
+          error: "",
+          submitting: false,
+          template: this.defaultTemplate(state.templates),
+        };
+      case "close":
+        return { ...state, open: false, submitting: false, error: "" };
+      case "set-name":
+        return { ...state, name: action.name, error: "" };
+      case "select-template":
+        return { ...state, template: action.template, error: "" };
+      case "templates-loading":
+        return { ...state, templatesLoading: true, templatesError: "" };
+      case "templates-loaded":
+        return {
+          ...state,
+          templatesLoading: false,
+          templatesError: "",
+          templates: action.templates,
+          template: this.selectedOrDefault(state.template, action.templates),
+        };
+      case "templates-failed":
+        // A failed catalog must not block project creation: the form falls
+        // back to the default template, which is what every project got
+        // before templates existed.
+        return {
+          ...state,
+          templatesLoading: false,
+          templatesError: action.error,
+          templates: [],
+          template: DEFAULT_TEMPLATE,
+        };
+      case "submit":
+        return { ...state, submitting: true, error: "" };
+      case "submit-failed":
+        return { ...state, submitting: false, error: action.error };
+    }
+  };
+
+  /** The template a freshly opened dialog starts on. */
+  defaultTemplate(templates: ProjectTemplate[]): string {
+    return templates.find((template) => template.default)?.name ?? DEFAULT_TEMPLATE;
+  }
+
+  /** Keeps a still-valid selection, otherwise falls back to the default. */
+  selectedOrDefault(selected: string, templates: ProjectTemplate[]): string {
+    if (templates.some((template) => template.name === selected)) return selected;
+    return this.defaultTemplate(templates);
+  }
+
+  /** Trimmed project name, which is what gets submitted. */
+  submittedName(state: NewProjectState): string {
+    return state.name.trim();
+  }
+
+  canSubmit(state: NewProjectState): boolean {
+    return !state.submitting && this.submittedName(state).length > 0;
+  }
+
+  selectedTemplate(state: NewProjectState): ProjectTemplate | undefined {
+    return state.templates.find((template) => template.name === state.template);
+  }
+
+  /**
+   * One-line warning about how long the first start will take. Only a
+   * provisioning template without a published image pays the slow path.
+   */
+  firstStartNotice(state: NewProjectState): string {
+    const template = this.selectedTemplate(state);
+    if (!template || !template.provisions) return "";
+    if (template.prebuiltImageAvailable) {
+      return "This host has a prebuilt image for this template, so the container starts immediately.";
+    }
+    return "The stack is installed inside the container on first start, which can take several minutes.";
+  }
+}
+
+export const newProjectState = new NewProjectStateTransitions();

--- a/frontend/src/ui/primitives/icons.tsx
+++ b/frontend/src/ui/primitives/icons.tsx
@@ -62,3 +62,6 @@ export const Cpu = (p: P) => (<svg {...base} {...p}><rect x="6" y="6" width="12"
 export const MemoryStick = (p: P) => (<svg {...base} {...p}><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M6 10h2v4H6zM11 10h2v4h-2zM16 10h2v4h-2zM6 18v2M10 18v2M14 18v2M18 18v2"/></svg>);
 export const HardDrive = (p: P) => (<svg {...base} {...p}><path d="M22 12H2l3-7h14l3 7Z"/><rect x="2" y="12" width="20" height="7" rx="1"/><path d="M6 15.5h.01M10 15.5h.01"/></svg>);
 export const Network = (p: P) => (<svg {...base} {...p}><rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4M5 16v-4h14v4"/></svg>);
+export const Globe = (p: P) => (<svg {...base} {...p}><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10Z"/></svg>);
+export const Layers = (p: P) => (<svg {...base} {...p}><path d="m12 2 9 5-9 5-9-5 9-5Z"/><path d="m3 12 9 5 9-5M3 17l9 5 9-5"/></svg>);
+export const Package = (p: P) => (<svg {...base} {...p}><path d="m12 2 9 5v10l-9 5-9-5V7l9-5Z"/><path d="m3 7 9 5 9-5M12 12v10"/></svg>);

--- a/frontend/src/ui/projects/NewProjectDialog.tsx
+++ b/frontend/src/ui/projects/NewProjectDialog.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useRef } from "preact/hooks";
+import type { ProjectTemplate } from "../../models/template";
+import {
+  newProjectState,
+  type NewProjectState,
+} from "../../state/projects/newProjectState";
+import { AlertCircle, Check, Loader, X } from "../primitives/icons";
+import { templateIcon } from "./templateIcons";
+
+export function NewProjectDialog({
+  state,
+  onNameChange,
+  onSelectTemplate,
+  onSubmit,
+  onClose,
+}: {
+  state: NewProjectState;
+  onNameChange: (name: string) => void;
+  onSelectTemplate: (template: string) => void;
+  onSubmit: () => void;
+  onClose: () => void;
+}) {
+  const nameInput = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (state.open) nameInput.current?.focus();
+  }, [state.open]);
+
+  useEffect(() => {
+    if (!state.open) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [state.open, onClose]);
+
+  if (!state.open) return null;
+
+  const canSubmit = newProjectState.canSubmit(state);
+  const notice = newProjectState.firstStartNotice(state);
+
+  return (
+    <div
+      class="fixed inset-0 z-50 flex items-end md:items-center justify-center bg-black/60 p-0 md:p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="new-project-title"
+        class="w-full md:max-w-2xl max-h-[92vh] flex flex-col rounded-t-xl md:rounded-xl
+               border border-white/10 bg-[#101318] shadow-2xl overflow-hidden"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header class="flex-none flex items-start gap-3 px-4 py-3 border-b border-white/[0.08]">
+          <div class="flex-1 min-w-0">
+            <h2 id="new-project-title" class="text-[15px] font-semibold text-ink-50">
+              New project
+            </h2>
+            <p class="text-[12.5px] text-ink-300 mt-0.5 leading-snug">
+              Each project gets its own container. The template decides what is
+              installed inside it and cannot be changed later.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            class="h-8 w-8 rounded-md text-ink-300 hover:text-ink-50 hover:bg-white/[0.08] grid place-items-center"
+            aria-label="Close"
+          >
+            <X class="w-4 h-4" />
+          </button>
+        </header>
+
+        <form
+          class="flex-1 min-h-0 flex flex-col"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (canSubmit) onSubmit();
+          }}
+        >
+          <div class="flex-1 min-h-0 overflow-y-auto touch-scroll px-4 py-4 space-y-4">
+            <label class="block">
+              <span class="text-[12.5px] font-medium text-ink-200">Project name</span>
+              <input
+                ref={nameInput}
+                type="text"
+                value={state.name}
+                onInput={(event) => onNameChange((event.target as HTMLInputElement).value)}
+                placeholder="My project"
+                class="mt-1.5 w-full h-10 px-3 rounded-md bg-white/[0.04] border border-white/10
+                       text-[14px] text-ink-50 placeholder:text-ink-400
+                       focus:outline-none focus:border-accent-blue/60"
+              />
+            </label>
+
+            <div>
+              <div class="text-[12.5px] font-medium text-ink-200">Template</div>
+              <TemplatePicker
+                templates={state.templates}
+                loading={state.templatesLoading}
+                error={state.templatesError}
+                selected={state.template}
+                onSelect={onSelectTemplate}
+              />
+              {notice && (
+                <p class="mt-2 text-[12px] text-ink-300 leading-snug">{notice}</p>
+              )}
+            </div>
+
+            {state.error && (
+              <div class="flex items-start gap-2.5 rounded-md border border-accent-red/30
+                          bg-accent-red/[0.08] px-3 py-2 text-[12.5px]">
+                <AlertCircle class="w-4 h-4 mt-0.5 flex-none text-accent-red" />
+                <span class="text-ink-100 break-words">{state.error}</span>
+              </div>
+            )}
+          </div>
+
+          <footer class="flex-none flex justify-end gap-2 px-4 py-3 border-t border-white/[0.08]">
+            <button
+              type="button"
+              onClick={onClose}
+              class="h-10 px-3 rounded-md text-[13.5px] text-ink-200 hover:text-ink-50 hover:bg-white/[0.08]"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              class="h-10 px-4 rounded-md text-[13.5px] font-medium text-white
+                     bg-accent-blue hover:bg-accent-blue/90 disabled:opacity-50
+                     disabled:cursor-not-allowed inline-flex items-center gap-2"
+            >
+              {state.submitting && <Loader class="w-4 h-4 animate-spin" />}
+              Create project
+            </button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function TemplatePicker({
+  templates,
+  loading,
+  error,
+  selected,
+  onSelect,
+}: {
+  templates: ProjectTemplate[];
+  loading: boolean;
+  error: string;
+  selected: string;
+  onSelect: (template: string) => void;
+}) {
+  if (loading && templates.length === 0) {
+    return (
+      <div class="mt-1.5 flex items-center gap-2 text-[12.5px] text-ink-300">
+        <Loader class="w-4 h-4 animate-spin" /> Loading templates…
+      </div>
+    );
+  }
+  if (error && templates.length === 0) {
+    return (
+      <div class="mt-1.5 text-[12.5px] text-ink-300">
+        Templates could not be loaded ({error}). The project will be created
+        from the blank template.
+      </div>
+    );
+  }
+
+  return (
+    <div class="mt-1.5 grid grid-cols-1 sm:grid-cols-2 gap-2" role="radiogroup" aria-label="Template">
+      {templates.map((template) => {
+        const active = template.name === selected;
+        const Icon = templateIcon(template.icon);
+        return (
+          <button
+            key={template.name}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onSelect(template.name)}
+            class={`text-left rounded-lg border p-3 transition-colors ${
+              active
+                ? "border-accent-blue/60 bg-accent-blue/[0.08]"
+                : "border-white/10 bg-white/[0.03] hover:bg-white/[0.06]"
+            }`}
+          >
+            <div class="flex items-center gap-2">
+              <Icon class={`w-4 h-4 flex-none ${active ? "text-accent-blue" : "text-ink-300"}`} />
+              <span class="text-[13.5px] font-medium text-ink-50 truncate">{template.title}</span>
+              {active && <Check class="w-4 h-4 ml-auto flex-none text-accent-blue" />}
+            </div>
+            <p class="mt-1 text-[12px] text-ink-300 leading-snug">{template.description}</p>
+            <div class="mt-1.5 flex flex-wrap gap-1">
+              {template.default && <TemplateTag label="default" />}
+              {template.prebuiltImageAvailable && <TemplateTag label="prebuilt image" />}
+              {template.defaultPorts?.map((port) => (
+                <TemplateTag key={port} label={`:${port}`} mono />
+              ))}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function TemplateTag({ label, mono = false }: { label: string; mono?: boolean }) {
+  return (
+    <span
+      class={`inline-flex items-center h-5 px-1.5 rounded bg-white/[0.06] text-[10.5px] text-ink-300 ${
+        mono ? "font-mono" : ""
+      }`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/ui/projects/ProjectContainersPage.tsx
+++ b/frontend/src/ui/projects/ProjectContainersPage.tsx
@@ -13,8 +13,17 @@ import {
 import { ProjectSecretsSection } from "./project-containers/ProjectSecretsSection";
 import { ProjectSharingSection } from "./project-containers/ProjectSharingSection";
 import { ProjectResourceLimits } from "./project-containers/ProjectResourceLimits";
+import {
+  TemplateBadge,
+  TemplateStatusBadge,
+} from "./project-containers/ProjectTemplateSection";
 import { formatRelativeTime as fmtRelative } from "./project-containers/projectContainerFormat";
-import type { ContainerLimits, ProjectContainerInfo, ProjectMeta } from "../../models/project";
+import {
+  projectTemplateName,
+  type ContainerLimits,
+  type ProjectContainerInfo,
+  type ProjectMeta,
+} from "../../models/project";
 import { ChevronLeft, Info, Key, Loader, Menu, RotateCcw, Settings, Users } from "../primitives/icons";
 
 export type ProjectSettingsTab = "info" | "settings" | "secrets" | "sharing";
@@ -349,9 +358,16 @@ function ProjectHeader({
         <Settings class="w-4 h-4 text-ink-200" />
       </div>
       <div class="flex-1 min-w-0">
-        <div class="flex items-center gap-2 min-w-0">
+        <div class="flex items-center gap-2 flex-wrap min-w-0">
           <span class="text-[14.5px] font-semibold text-ink-50 truncate">{project.name}</span>
           {info && <ContainerStateBadge state={info.state ?? "UNKNOWN"} />}
+          {/* The container payload carries the title and provisioning
+              status; project metadata alone is enough for the name, so the
+              badge appears before the inspection request resolves. */}
+          <TemplateBadge
+            template={info?.template ?? { name: projectTemplateName(project), status: "none" }}
+          />
+          {info?.template && <TemplateStatusBadge status={info.template.status} />}
         </div>
         <div class="text-[12.5px] text-ink-300 mt-0.5 leading-snug font-mono truncate">
           {project.containerName || project.slug}

--- a/frontend/src/ui/projects/project-containers/ProjectInfoSection.tsx
+++ b/frontend/src/ui/projects/project-containers/ProjectInfoSection.tsx
@@ -14,6 +14,7 @@ import type {
 import type { ProjectContainerRecord } from "../../../state/projects/projectContainerRecords";
 import { AlertCircle } from "../../primitives/icons";
 import { Field, Grid, Loading, Panel } from "./ProjectContainerPrimitives";
+import { TemplatePanel } from "./ProjectTemplateSection";
 import {
   formatBytes,
   formatDate,
@@ -64,6 +65,7 @@ export function ProjectInfoSection({
           <Field label="Last used" value={formatDate(info.lastUsedAt)} mono />
         </Grid>
       </Panel>
+      {info.template && <TemplatePanel template={info.template} />}
       {info.os && <OSPanel os={info.os} />}
       {info.resources && <ResourcesPanel res={info.resources} />}
       {info.disks && info.disks.length > 0 && <DisksPanel disks={info.disks} />}

--- a/frontend/src/ui/projects/project-containers/ProjectTemplateSection.tsx
+++ b/frontend/src/ui/projects/project-containers/ProjectTemplateSection.tsx
@@ -1,0 +1,91 @@
+import type { JSX } from "preact";
+import type { ProjectTemplateStatus } from "../../../models/template";
+import { Field, Grid, Panel } from "./ProjectContainerPrimitives";
+import { formatEpochMillis } from "./projectContainerFormat";
+
+/**
+ * Small badge shown next to the project name. Templates that install nothing
+ * ("blank") still get a badge so the field is never mysteriously absent.
+ */
+export function TemplateBadge({ template }: { template: ProjectTemplateStatus }) {
+  return (
+    <span
+      class="inline-flex items-center h-5 px-1.5 rounded bg-white/[0.06] text-[11px] font-medium text-ink-200"
+      title={`Project template: ${template.title || template.name}`}
+    >
+      {template.title || template.name}
+    </span>
+  );
+}
+
+/**
+ * Provisioning progress badge. Only rendered for templates that actually
+ * install something — "none" means the container was ready on first boot.
+ */
+export function TemplateStatusBadge({ status }: { status: ProjectTemplateStatus["status"] }) {
+  if (status === "none") return null;
+  const tone =
+    status === "done"
+      ? "text-accent-green bg-accent-green/[0.12]"
+      : status === "failed"
+      ? "text-accent-red bg-accent-red/[0.12]"
+      : status === "running"
+      ? "text-accent-blue bg-accent-blue/[0.12]"
+      : "text-ink-300 bg-white/[0.06]";
+  return (
+    <span class={`inline-flex items-center h-5 px-1.5 rounded text-[11px] font-medium ${tone}`}>
+      {statusLabel(status)}
+    </span>
+  );
+}
+
+export function statusLabel(status: ProjectTemplateStatus["status"]): string {
+  switch (status) {
+    case "pending":
+      return "setup pending";
+    case "running":
+      return "setting up";
+    case "done":
+      return "setup done";
+    case "failed":
+      return "setup failed";
+    default:
+      return "";
+  }
+}
+
+export function TemplatePanel({ template }: { template: ProjectTemplateStatus }) {
+  const fields: JSX.Element[] = [
+    <Field key="template" label="Template" value={template.title || template.name} />,
+    <Field
+      key="provisioning"
+      label="Provisioning"
+      value={template.status === "none" ? "not required" : statusLabel(template.status)}
+      tone={template.status === "failed" ? "warn" : undefined}
+    />,
+    <Field key="started" label="Started" value={formatEpochMillis(template.startedAt)} mono />,
+    <Field key="finished" label="Finished" value={formatEpochMillis(template.finishedAt)} mono />,
+  ];
+  if (template.logPath) {
+    fields.push(
+      <Field key="log" label="Log (in container)" value={template.logPath} mono />
+    );
+  }
+
+  return (
+    <Panel title="Template">
+      <div>
+        <Grid>{fields}</Grid>
+        {template.error && (
+          <p class="mt-2 text-[12px] text-accent-red break-words">{template.error}</p>
+        )}
+        {template.status === "failed" && (
+          <p class="mt-2 text-[12px] text-ink-300 leading-snug">
+            Restart the project to retry: provisioning re-runs on every container
+            convergence until it succeeds.
+          </p>
+        )}
+      </div>
+    </Panel>
+  );
+}

--- a/frontend/src/ui/projects/project-containers/projectContainerFormat.ts
+++ b/frontend/src/ui/projects/project-containers/projectContainerFormat.ts
@@ -29,6 +29,15 @@ export function formatUnixTime(unix?: number): string {
   }
 }
 
+export function formatEpochMillis(millis?: number): string {
+  if (!millis) return "—";
+  try {
+    return new Date(millis).toLocaleString();
+  } catch {
+    return String(millis);
+  }
+}
+
 export function formatDuration(seconds: number): string {
   if (!seconds || seconds < 0) return "—";
   const days = Math.floor(seconds / 86400);

--- a/frontend/src/ui/projects/templateIcons.tsx
+++ b/frontend/src/ui/projects/templateIcons.tsx
@@ -1,0 +1,19 @@
+import type { ComponentType } from "preact";
+import { Code, File, Globe, Layers, Package } from "../primitives/icons";
+
+/**
+ * Maps a template's `icon` key to a glyph. The key is data shipped by the
+ * backend, so an unknown one (a template added by a newer backend, or a
+ * custom template) must render rather than crash — hence the fallback.
+ */
+const glyphs: Record<string, ComponentType<{ class?: string }>> = {
+  blank: File,
+  wordpress: Globe,
+  laravel: Layers,
+  node: Package,
+  python: Code,
+};
+
+export function templateIcon(icon: string): ComponentType<{ class?: string }> {
+  return glyphs[icon] ?? File;
+}

--- a/infra/upgrade-workspaces.sh
+++ b/infra/upgrade-workspaces.sh
@@ -5,6 +5,9 @@
 # Flow:
 #   1. Rebake futrx-remote-dev-base from the recipe (skip with --no-rebake,
 #      e.g. when you just rebaked by hand).
+#   1b. Optionally rebake every published project-template image
+#      (futrx-remote-<template>-base) on top of the fresh base. Off by
+#      default because each one costs another full build.
 #   2. Delegate replacement to the Go lifecycle. It migrates agent homes,
 #      replaces each idle container, attaches every durable mount, and
 #      validates the result before reporting success.
@@ -20,9 +23,10 @@
 #   sudo bash /opt/remote.futrx/infra/upgrade-workspaces.sh [flags]
 #
 # Flags:
-#   --dry-run        show what would happen, change nothing
-#   --no-rebake      skip step 1, only recycle containers
-#   --include-busy   also replace containers with an active agent process
+#   --dry-run           show what would happen, change nothing
+#   --no-rebake         skip step 1, only recycle containers
+#   --rebake-templates  also rebuild every published template image
+#   --include-busy      also replace containers with an active agent process
 set -euo pipefail
 
 INFRA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -36,12 +40,14 @@ err()  { printf "\n\033[1;31m✗ %s\033[0m\n" "$*" >&2; }
 
 DRY_RUN=0
 REBAKE=1
+REBAKE_TEMPLATES=0
 INCLUDE_BUSY=0
 for a in "$@"; do
     case "$a" in
-        --dry-run)      DRY_RUN=1 ;;
-        --no-rebake)    REBAKE=0 ;;
-        --include-busy) INCLUDE_BUSY=1 ;;
+        --dry-run)           DRY_RUN=1 ;;
+        --no-rebake)         REBAKE=0 ;;
+        --rebake-templates)  REBAKE_TEMPLATES=1 ;;
+        --include-busy)      INCLUDE_BUSY=1 ;;
         *) err "unknown flag: $a"; exit 1 ;;
     esac
 done
@@ -65,6 +71,37 @@ if [ "$REBAKE" -eq 1 ]; then
     fi
 else
     log "Skipping rebake (--no-rebake) — recycling containers onto the existing image"
+fi
+
+# ───────── 1b. project-template images ─────────
+# Projects created from a template that has a published image launch from that
+# image, NOT from futrx-remote-dev-base. Rebaking the base alone therefore
+# leaves them on the old base layer.
+TEMPLATE_ALIASES="$(lxc image list --format csv --columns l 2>/dev/null \
+    | tr ',' '\n' \
+    | grep -E '^futrx-remote-.+-base$' \
+    | grep -v '^futrx-remote-dev-base$' \
+    | sort -u || true)"
+if [ -n "$TEMPLATE_ALIASES" ]; then
+    if [ "$REBAKE_TEMPLATES" -eq 1 ] && [ "$REBAKE" -eq 1 ]; then
+        log "Rebaking published project-template images"
+        for ALIAS in $TEMPLATE_ALIASES; do
+            TEMPLATE="${ALIAS#futrx-remote-}"
+            TEMPLATE="${TEMPLATE%-base}"
+            if [ "$DRY_RUN" -eq 1 ]; then
+                log "[dry-run] would rebuild $ALIAS (template $TEMPLATE)"
+                continue
+            fi
+            (
+                cd "$INFRA_DIR/../backend"
+                go run ./cmd/build-template-image -template "$TEMPLATE" -overwrite
+            )
+            ok "$ALIAS rebaked"
+        done
+    else
+        warn "published template images are NOT rebaked: $(echo $TEMPLATE_ALIASES)"
+        warn "projects on those templates keep the old base layer until you rerun with --rebake-templates"
+    fi
 fi
 
 # ───────────────── 2. migrate + replace through Go ─────────────────


### PR DESCRIPTION
## Summary
Project templates: create a container from a stack preset instead of only the bare base image.

- A template = the shared `futrx-remote-dev-base` image + a marker-gated post-provision script run once inside the new container + optional `/workspace` seed files + an `AGENTS.md` snippet (never overwriting). Optionally a template declares a prebuilt alias `futrx-remote-<name>-base`; if present it is used (fast path), else base + script (slow path). New `cmd/build-template-image -template <name>` builds the alias reusing the image builder (with `-publish-timeout`/`-build-timeout` overrides for slow hosts).
- Ships `blank` (default, unchanged behaviour), `wordpress` (PHP 8.3 + MariaDB + WP-CLI + Composer, WordPress core in `/workspace/public`, preview on :8080), `laravel`, `node`, `python`. Provisioning is non-interactive, idempotent (`/var/lib/remote-template.done`), logs to `/var/log/remote-template.log`, runs in the background, and re-runs automatically after a container is replaced (`upgrade-workspaces` re-clones the rootfs) since the marker lives in the disposable rootfs. `infra/upgrade-workspaces.sh` gains `--rebake-templates`.
- Project meta gains `template` (omitted for `blank` → backward compatible). `GET /api/templates`; project create accepts `template`. New-project dialog replaces the old `prompt()` with a template picker; project page shows template + provisioning status badges and a Template panel.

## Testing
Unit tests for catalog/validation, provisioning decision logic, meta compat, handlers, lifecycle wiring. Verified live on a 1-vCPU host: WordPress template provisioned in ~70 s, MariaDB + WP-CLI active, preview serves the WordPress installer; Node template idempotent across restarts. Docs: `docs/02-workspaces/08-project-templates.md`.
