### PR TITLE
fix(infra): detect LXD install via snap, not the lxd-installer shim

### DIFF
--- a/infra/steps/01-host-deps.sh
+++ b/infra/steps/01-host-deps.sh
@@ -127,7 +127,15 @@ ensure_agent_cli "Codex" codex @openai/codex "$CODEX_CLI_VERSION"
 ensure_agent_cli "Kimi Code" kimi @moonshot-ai/kimi-code "$KIMI_CODE_VERSION"
 
 # ───────────────── LXD (one container per project) ─────────────────
-if ! command -v lxc >/dev/null; then
+# Checked via `snap list lxd`, not `command -v lxc`: Ubuntu 24.04 ships the
+# `lxd-installer` transitional package, which pre-populates /usr/bin/lxc and
+# /usr/sbin/lxd as shims that lazily install the snap on first invocation.
+# `command -v lxc` finds those shims on a completely fresh box, so this step
+# would silently skip the real install — and the first real LXD command
+# later in this script (or `lxd init --auto` below) would trigger the
+# shim's own uncontrolled auto-install instead, outside our retry/wait
+# logic and prone to leaving the host half-installed on any hiccup.
+if ! snap list lxd >/dev/null 2>&1; then
     log "Installing LXD via snap"
     if ! command -v snap >/dev/null; then
         apt-get install -y -qq snapd
@@ -135,8 +143,8 @@ if ! command -v lxc >/dev/null; then
         for _ in 1 2 3 4 5; do snap wait system seed.loaded && break; sleep 1; done
     fi
     snap install lxd
-    export PATH="/snap/bin:$PATH"
 fi
+export PATH="/snap/bin:$PATH"
 
 # Initialize storage + bridge on fresh installs. `lxc network show lxdbr0`
 # is our "initialized" probe.


### PR DESCRIPTION
## Summary
- The LXD install step in `infra/steps/01-host-deps.sh` gated its own `snap install lxd` on `command -v lxc`, which Ubuntu 24.04's transitional `lxd-installer` package pre-satisfies with shims (`/usr/bin/lxc`, `/usr/sbin/lxd`) that lazily install the real snap on first use.
- On a fresh noble host this makes the script skip its own controlled install; the first real LXD invocation later in the script (`lxd init --auto`) then hits the shim's own uncontrolled auto-install path instead — outside our `snap wait system seed.loaded` retry logic — and can leave the host half-installed if that hits any transient hiccup (as it did in #54).
- Swapped the guard to `snap list lxd` (checks the actual snap install state, immune to the OS-provided shims) and made the `PATH="/snap/bin:$PATH"` export unconditional so re-runs are still correct when LXD was already installed by a previous run.

Fixes #54.

## Test plan
- [x] `bash -n infra/steps/01-host-deps.sh` — syntax OK
- [x] Re-run the installer end-to-end on a fresh Ubuntu 24.04 host with stock `lxd-installer` present, confirm `snap install lxd` actually runs and `lxd init --auto` succeeds without the shim's lazy-install path ever firing
