### PR TITLE
0.4.0

### DIFF
--- a/.github/scripts/classify-release-test.sh
+++ b/.github/scripts/classify-release-test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+CLASSIFIER="$SCRIPT_DIR/classify-release.sh"
+TEST_REPO="$(mktemp -d)"
+trap 'rm -rf "$TEST_REPO"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+commit_file() {
+    local path="$1" contents="$2" message="$3"
+    mkdir -p "$TEST_REPO/$(dirname "$path")"
+    printf '%s\n' "$contents" > "$TEST_REPO/$path"
+    git -C "$TEST_REPO" add "$path"
+    git -C "$TEST_REPO" commit -q -m "$message"
+}
+
+assert_output() {
+    local output="$1" expected="$2"
+    grep -Fxq "$expected" <<<"$output" || fail "missing output: $expected"
+}
+
+git -C "$TEST_REPO" init -q
+git -C "$TEST_REPO" config user.name "Release Test"
+git -C "$TEST_REPO" config user.email "release-test@example.invalid"
+
+commit_file README.md initial initial
+git -C "$TEST_REPO" tag 0.3.1
+output="$(cd "$TEST_REPO" && "$CLASSIFIER" 0.3.1)"
+assert_output "$output" "kind=infrastructure"
+assert_output "$output" "label=Infrastructure"
+assert_output "$output" "previous="
+
+commit_file frontend/app.ts patch application
+git -C "$TEST_REPO" tag 0.3.2
+output="$(cd "$TEST_REPO" && "$CLASSIFIER" 0.3.2)"
+assert_output "$output" "kind=application"
+assert_output "$output" "label=Application"
+assert_output "$output" "previous=0.3.1"
+
+commit_file infra/versions.env protected infrastructure
+git -C "$TEST_REPO" tag 0.3.3
+if error="$(cd "$TEST_REPO" && "$CLASSIFIER" 0.3.3 2>&1)"; then
+    fail "protected infrastructure change was accepted as an application release"
+fi
+grep -Fq "patch release 0.3.3 changes infrastructure-managed paths:" <<<"$error" \
+    || fail "protected-path rejection did not explain the failure"
+
+commit_file README.md next-minor minor
+git -C "$TEST_REPO" tag 0.4.0
+output="$(cd "$TEST_REPO" && "$CLASSIFIER" 0.4.0)"
+assert_output "$output" "kind=infrastructure"
+assert_output "$output" "label=Infrastructure"
+assert_output "$output" "previous=0.3.3"
+
+if error="$(cd "$TEST_REPO" && "$CLASSIFIER" 0.4 2>&1)"; then
+    fail "malformed release tag was accepted"
+fi
+grep -Fq "release tags must use MAJOR.MINOR.PATCH (got: 0.4)" <<<"$error" \
+    || fail "malformed-tag rejection did not explain the failure"
+
+echo "Release classification tests passed"

--- a/.github/scripts/classify-release.sh
+++ b/.github/scripts/classify-release.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Classify a release tag and reject unsafe application-only releases.
+#
+# Usage: classify-release.sh MAJOR.MINOR.PATCH
+#
+# Run this from a Git checkout containing the target tag and its history. The
+# script writes GitHub Actions-compatible key=value outputs to stdout. Errors
+# and validation details are written to stderr.
+
+set -euo pipefail
+
+tag="${1:-}"
+if ! [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "release tags must use MAJOR.MINOR.PATCH (got: $tag)" >&2
+    exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+current_train="${tag%.*}"
+previous=""
+while IFS= read -r candidate; do
+    if [[ "$candidate" != "$tag" && "$candidate" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        previous="$candidate"
+        break
+    fi
+done < <(git -C "$repo_root" tag --merged "$tag" --list '[0-9]*' --sort=-v:refname)
+
+kind="infrastructure"
+label="Infrastructure"
+if [ -n "$previous" ] && [ "${previous%.*}" = "$current_train" ]; then
+    kind="application"
+    label="Application"
+
+    # These paths affect host convergence, provider toolchains, or workspace
+    # images. They cannot ship as a patch release because patch updates
+    # deliberately skip the infrastructure updater.
+    protected_changes="$(git -C "$repo_root" diff --name-only "$previous" "$tag" -- \
+        infra/install.sh \
+        infra/update.sh \
+        infra/deploy-app.sh \
+        infra/upgrade-workspaces.sh \
+        infra/steps \
+        infra/lib \
+        infra/templates \
+        infra/launcher \
+        infra/versions.env \
+        backend/internal/agent/provisioning \
+        backend/internal/agent/antigravity/profile.go \
+        backend/internal/agent/claude/assets \
+        backend/internal/agent/claude/profile.go \
+        backend/internal/agent/codex/provisioning.go \
+        backend/internal/agent/kimi/profile.go \
+        backend/internal/service/container/image)"
+    if [ -n "$protected_changes" ]; then
+        echo "patch release $tag changes infrastructure-managed paths:" >&2
+        echo "$protected_changes" >&2
+        echo "bump the minor (or major) version so installations run the full updater" >&2
+        exit 1
+    fi
+fi
+
+printf 'kind=%s\n' "$kind"
+printf 'label=%s\n' "$label"
+printf 'previous=%s\n' "$previous"

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,6 +1,7 @@
-# Creates a GitHub Release for every version tag (0.2.4, 0.2.4.1, ...) so
-# the Releases page tracks product releases. Notes come from the tag
-# commit's changelog-style body — our release commits are the changelog.
+# Creates a GitHub Release for every MAJOR.MINOR.PATCH tag. Major/minor bumps
+# are infrastructure releases; patch bumps are application releases. Notes
+# come from the tag commit's changelog-style body — our release commits are
+# the changelog.
 # Vendor asset releases (vendors-*) are separate pre-releases published by
 # vendor-playwright.yml and are not matched by the tag pattern below.
 name: Release on tag
@@ -17,18 +18,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Classify and validate release
+        id: release
+        env:
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: .github/scripts/classify-release.sh "$TAG" >> "$GITHUB_OUTPUT"
       - name: Create GitHub Release from tag
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
+          RELEASE_LABEL: ${{ steps.release.outputs.label }}
         run: |
+          set -euo pipefail
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "release $TAG already exists"
             exit 0
           fi
           notes="$(git log -1 --format=%b HEAD)"
+          heading="**Release type:** ${RELEASE_LABEL}"
+          generate_args=()
           if [ -n "$notes" ]; then
-            gh release create "$TAG" --title "$TAG" --notes "$notes" --verify-tag
+            notes="${heading}
+
+          ${notes}"
           else
-            gh release create "$TAG" --title "$TAG" --generate-notes --verify-tag
+            notes="$heading"
+            generate_args+=(--generate-notes)
           fi
+          gh release create "$TAG" \
+            --title "$TAG · $RELEASE_LABEL" \
+            --notes "$notes" \
+            "${generate_args[@]}" \
+            --verify-tag

--- a/.qa.env.example
+++ b/.qa.env.example
@@ -1,5 +1,5 @@
 # Copy this file to .qa.env and fill in the QA host details used by
-# infra/qa/install.sh and infra/qa/update.sh.
+# infra/qa/install.sh, update.sh, deploy-app.sh, and deploy-local.sh.
 # Never place the SSH private key itself inside this repository.
 
 QA_SSH_HOST=209.0.113.10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,5 +54,6 @@ not a substitute for testing the complete updater.
 1. Commit and push the candidate.
 2. Iterate with `deploy-app.sh`.
 3. Test `install.sh` on a rebuilt VM if installer behavior changed.
-4. Run `update.sh` against an existing installation before release.
-5. Release only the verified commit.
+4. For a patch release, finish with `deploy-app.sh` against an existing installation.
+5. For a major/minor release, run `update.sh` against an existing installation.
+6. Release only the verified commit. Tags use `MAJOR.MINOR.PATCH`; infrastructure changes require a major/minor bump.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,9 @@ bash infra/tests/health-check-test.sh
 bash infra/tests/go-toolchain-test.sh
 bash infra/tests/dns-resolve-test.sh
 bash infra/tests/container-forwarding-test.sh
+bash infra/tests/release-version-test.sh
+bash infra/tests/deploy-app-script-test.sh
+bash .github/scripts/classify-release-test.sh
 ```
 
 There is no CI that exercises the installer against a server. `infra/` changes reach a box only when its operator runs `sudo bash infra/update.sh` over SSH or applies a release tag from the in-app updater (both re-detect the box's hostname from the installed unit). Treat changes to `infra/` with extra care since they modify hosts in place.
@@ -98,6 +101,25 @@ test(state): pin chat event projection behavior
 ```
 
 Keep commits small and focused — one logical change per commit.
+
+## Releases
+
+Release tags use exactly `MAJOR.MINOR.PATCH`, without a `v` prefix. The version
+determines what an installed server runs:
+
+- Bump `PATCH` for frontend/backend-only releases.
+- Bump `MINOR` or `MAJOR` when the release changes host dependencies, Caddy or
+  systemd configuration, provider toolchains, workspace provisioning, or the
+  reusable base image.
+
+The tag workflow rejects patch releases that changed protected
+infrastructure-managed paths since the previous release. This guard is a
+minimum safety net, not a substitute for judgment: changes outside those paths
+that require a newer host toolchain must also use a minor or major release.
+
+The first release containing a change to the update machinery itself must be a
+minor or major release so existing installations receive the new scripts via
+full infrastructure convergence.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,21 @@ bash infra/tests/qa-scripts-test.sh
 bash .github/scripts/classify-release-test.sh
 ```
 
+The root package exposes every QA deployment path. Commands that take a ref
+require a clean checkout whose `HEAD` matches the pushed branch, tag, or commit:
+
+```bash
+npm run qa:install                         # public install on a fresh server
+npm run qa:install -- <ref>                # candidate install on a fresh server
+npm run qa:update -- <ref>                 # full infrastructure update
+npm run qa:deploy-app -- <ref>             # app-only deploy from a pushed ref
+npm run qa:deploy-local                    # app-only deploy of the working tree
+npm run qa:test                            # QA wrapper contract tests
+```
+
+All deployment commands read `.qa.env`; set `QA_ENV_FILE=/path/to/.qa.env` to
+reuse configuration stored in another worktree.
+
 There is no CI that exercises the installer against a server. `infra/` changes reach a box only when its operator runs `sudo bash infra/update.sh` over SSH or applies a release tag from the in-app updater (both re-detect the box's hostname from the installed unit). Treat changes to `infra/` with extra care since they modify hosts in place.
 
 ## Making changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ bash infra/tests/dns-resolve-test.sh
 bash infra/tests/container-forwarding-test.sh
 bash infra/tests/release-version-test.sh
 bash infra/tests/deploy-app-script-test.sh
+bash infra/tests/qa-scripts-test.sh
 bash .github/scripts/classify-release-test.sh
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,10 @@ npm run qa:deploy-local                    # app-only deploy of the working tree
 npm run qa:test                            # QA wrapper contract tests
 ```
 
-All deployment commands read `.qa.env`; set `QA_ENV_FILE=/path/to/.qa.env` to
-reuse configuration stored in another worktree.
+The npm deployment aliases default to `/workspace/remote.futrx/.qa.env`, where
+the shared QA configuration currently lives. Set
+`QA_ENV_FILE=/path/to/.qa.env` to override it. Calling an `infra/qa/*.sh`
+script directly still defaults to `.qa.env` in that script's worktree.
 
 There is no CI that exercises the installer against a server. `infra/` changes reach a box only when its operator runs `sudo bash infra/update.sh` over SSH or applies a release tag from the in-app updater (both re-detect the box's hostname from the installed unit). Treat changes to `infra/` with extra care since they modify hosts in place.
 

--- a/README.md
+++ b/README.md
@@ -168,13 +168,18 @@ Before using Remote with valuable code or credentials, read the [threat model](d
 
 ## Updating
 
-Run on the Remote server:
+The in-app updater selects the deployment path from the release version:
+patch releases rebuild and restart only the frontend/backend application,
+while major or minor releases also converge host infrastructure, rebuild the
+workspace image, and recycle idle containers.
+
+To force a full infrastructure convergence from the server, run:
 
 ```bash
 sudo bash /opt/remote.futrx/infra/update.sh
 ```
 
-The updater rebuilds the app and project image while preserving project files and provider homes. Coordinate a maintenance window, or use `--skip-workspaces`, when agents are actively running. See [Deployment and operations](docs/04-operations/09-deployment-and-operations.md#update-flow) for details.
+The full updater preserves project files and provider homes. Coordinate a maintenance window, or use `--skip-workspaces`, when agents are actively running. See [Deployment and operations](docs/04-operations/09-deployment-and-operations.md#update-flow) for details.
 
 ## Learn more
 

--- a/backend/internal/integration/updatecli/client.go
+++ b/backend/internal/integration/updatecli/client.go
@@ -52,13 +52,16 @@ func (Client) ListRemoteTags(ctx context.Context, installDir string) ([]string, 
 	return tags, nil
 }
 
-// StartUpdater launches infra/update.sh --ref=<tag> in its own session so
-// that the systemd restart the updater itself performs cannot kill it (the
-// unit runs with KillMode=process). Output streams to logPath; when the run
-// finishes, its exit code is written to donePath — that file, not the
-// process, is the durable record of the outcome, because the backend that
-// spawned the run is usually replaced before the run ends.
-func (Client) StartUpdater(installDir, tag, logPath, donePath string) (int, error) {
+// StartUpdater launches the selected release script in its own session so
+// that the systemd restart cannot kill it (the unit runs with
+// KillMode=process). Output streams to logPath; when the run finishes, its
+// exit code is written to donePath — that file, not the process, is the
+// durable record of the outcome, because the backend that spawned the run is
+// usually replaced before the run ends.
+func (Client) StartUpdater(installDir, tag, kind, logPath, donePath string) (int, error) {
+	if kind != "application" && kind != "infrastructure" {
+		return 0, fmt.Errorf("unknown update kind: %s", kind)
+	}
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return 0, err
@@ -67,11 +70,15 @@ func (Client) StartUpdater(installDir, tag, logPath, donePath string) (int, erro
 
 	// Values reach the script as positional parameters, never by string
 	// interpolation.
-	const script = `bash "$1/infra/update.sh" "--ref=$2"
+	const script = `case "$4" in
+application) FUTRX_INSTALL_DIR="$1" bash "$1/infra/deploy-app.sh" "--ref=$2" ;;
+infrastructure) FUTRX_INSTALL_DIR="$1" bash "$1/infra/update.sh" "--ref=$2" ;;
+*) echo "unknown update kind: $4" >&2; exit 2 ;;
+esac
 status=$?
 printf '{"exitCode":%d,"finishedAt":%d}\n' "$status" "$(date +%s)" > "$3.tmp" && mv "$3.tmp" "$3"
 exit "$status"`
-	cmd := exec.Command("bash", "-c", script, "self-update", installDir, tag, donePath)
+	cmd := exec.Command("bash", "-c", script, "self-update", installDir, tag, donePath, kind)
 	cmd.Dir = installDir
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile

--- a/backend/internal/integration/updatecli/client_test.go
+++ b/backend/internal/integration/updatecli/client_test.go
@@ -1,0 +1,79 @@
+package updatecli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStartUpdaterSelectsReleaseScript(t *testing.T) {
+	for _, test := range []struct {
+		kind       string
+		wantScript string
+	}{
+		{"application", "deploy-app"},
+		{"infrastructure", "update"},
+	} {
+		t.Run(test.kind, func(t *testing.T) {
+			installDir := t.TempDir()
+			infraDir := filepath.Join(installDir, "infra")
+			if err := os.Mkdir(infraDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			markerPath := filepath.Join(installDir, "selected")
+			for _, script := range []string{"deploy-app", "update"} {
+				contents := "#!/usr/bin/env bash\nprintf '%s:%s' '" + script + "' \"$1\" > \"$MARKER_PATH\"\n"
+				if err := os.WriteFile(filepath.Join(infraDir, script+".sh"), []byte(contents), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			t.Setenv("MARKER_PATH", markerPath)
+
+			logPath := filepath.Join(installDir, "run.log")
+			donePath := filepath.Join(installDir, "done.json")
+			if _, err := (Client{}).StartUpdater(installDir, "0.4.2", test.kind, logPath, donePath); err != nil {
+				t.Fatal(err)
+			}
+			waitForDone(t, donePath)
+
+			selected, err := os.ReadFile(markerPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := string(selected), test.wantScript+":--ref=0.4.2"; got != want {
+				t.Fatalf("selected script = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestStartUpdaterRejectsUnknownKind(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := (Client{}).StartUpdater(dir, "0.4.2", "surprise", filepath.Join(dir, "log"), filepath.Join(dir, "done")); err == nil {
+		t.Fatal("StartUpdater accepted an unknown update kind")
+	}
+}
+
+func waitForDone(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			var done struct {
+				ExitCode int `json:"exitCode"`
+			}
+			if err := json.Unmarshal(data, &done); err != nil {
+				t.Fatal(err)
+			}
+			if done.ExitCode != 0 {
+				t.Fatalf("updater exited with %d", done.ExitCode)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}

--- a/backend/internal/service/selfupdate/service.go
+++ b/backend/internal/service/selfupdate/service.go
@@ -1,7 +1,8 @@
 // Package selfupdate checks the installed checkout's origin for newer
-// release tags and applies updates by running infra/update.sh detached from
-// the service unit. Run state lives on disk under DATA_DIR/self-update/ so
-// it survives the backend restart that every successful update performs.
+// release tags and applies them with either application deployment or full
+// infrastructure convergence detached from the service unit. Run state lives
+// on disk under DATA_DIR/self-update/ so it survives the backend restart that
+// every successful update performs.
 package selfupdate
 
 import (
@@ -21,7 +22,7 @@ import (
 // HostClient is implemented by integration/updatecli.
 type HostClient interface {
 	ListRemoteTags(ctx context.Context, installDir string) ([]string, error)
-	StartUpdater(installDir, tag, logPath, donePath string) (int, error)
+	StartUpdater(installDir, tag, kind, logPath, donePath string) (int, error)
 	ProcessAlive(pid int) bool
 }
 
@@ -35,6 +36,16 @@ const (
 	stateDirName = "self-update"
 	logTailBytes = 16 * 1024
 	runFileMode  = 0o600
+)
+
+// UpdateKind selects the smallest safe deployment path for a release.
+// Application updates stay within the installed major/minor release line;
+// crossing either boundary requires full infrastructure convergence.
+type UpdateKind string
+
+const (
+	UpdateKindApplication    UpdateKind = "application"
+	UpdateKindInfrastructure UpdateKind = "infrastructure"
 )
 
 type Service struct {
@@ -58,22 +69,24 @@ func New(currentVersion, installDir, dataDir string, host HostClient) *Service {
 
 // CheckResult is the outcome of one tag lookup against origin.
 type CheckResult struct {
-	CheckedAt       int64  `json:"checkedAt"`
-	LatestTag       string `json:"latestTag,omitempty"`
-	UpdateAvailable bool   `json:"updateAvailable"`
-	Error           string `json:"error,omitempty"`
+	CheckedAt       int64      `json:"checkedAt"`
+	LatestTag       string     `json:"latestTag,omitempty"`
+	UpdateAvailable bool       `json:"updateAvailable"`
+	UpdateKind      UpdateKind `json:"updateKind,omitempty"`
+	Error           string     `json:"error,omitempty"`
 }
 
 // RunStatus describes the most recent apply run, reconstructed from disk so
 // it stays accurate across the restart the update itself triggers.
 type RunStatus struct {
-	State      string `json:"state"` // running | succeeded | failed
-	Target     string `json:"target"`
-	StartedAt  int64  `json:"startedAt"`
-	StartedBy  string `json:"startedBy,omitempty"`
-	FinishedAt int64  `json:"finishedAt,omitempty"`
-	ExitCode   *int   `json:"exitCode,omitempty"`
-	Log        string `json:"log,omitempty"`
+	State      string     `json:"state"` // running | succeeded | failed
+	Target     string     `json:"target"`
+	UpdateKind UpdateKind `json:"updateKind,omitempty"`
+	StartedAt  int64      `json:"startedAt"`
+	StartedBy  string     `json:"startedBy,omitempty"`
+	FinishedAt int64      `json:"finishedAt,omitempty"`
+	ExitCode   *int       `json:"exitCode,omitempty"`
+	Log        string     `json:"log,omitempty"`
 }
 
 type Status struct {
@@ -83,10 +96,11 @@ type Status struct {
 }
 
 type runRecord struct {
-	Target    string `json:"target"`
-	StartedAt int64  `json:"startedAt"`
-	StartedBy string `json:"startedBy"`
-	PID       int    `json:"pid"`
+	Target     string     `json:"target"`
+	UpdateKind UpdateKind `json:"updateKind,omitempty"`
+	StartedAt  int64      `json:"startedAt"`
+	StartedBy  string     `json:"startedBy"`
+	PID        int        `json:"pid"`
 }
 
 type doneRecord struct {
@@ -119,6 +133,9 @@ func (s *Service) Check(ctx context.Context) Status {
 		result.LatestTag = latest
 		if current, ok := parseReleaseTag(describeBase(s.currentVersion)); ok && latest != "" {
 			result.UpdateAvailable = compareVersions(latestSegments, current) > 0
+			if result.UpdateAvailable {
+				result.UpdateKind = classifyUpdate(s.currentVersion, latest)
+			}
 		}
 	}
 	s.mu.Lock()
@@ -127,9 +144,9 @@ func (s *Service) Check(ctx context.Context) Status {
 	return s.Status(ctx)
 }
 
-// Apply starts infra/update.sh toward the given tag (or the newest release
-// tag when tag is empty). Single-flight: a second call while a run is alive
-// returns ErrUpdateInProgress.
+// Apply starts the safe deployment path toward the given tag (or the newest
+// release tag when tag is empty). Single-flight: a second call while a run is
+// alive returns ErrUpdateInProgress.
 func (s *Service) Apply(ctx context.Context, startedBy, tag string) (Status, error) {
 	tags, err := s.host.ListRemoteTags(ctx, s.installDir)
 	if err != nil {
@@ -158,11 +175,14 @@ func (s *Service) Apply(ctx context.Context, startedBy, tag string) (Status, err
 	if err := os.WriteFile(s.logPath(), nil, runFileMode); err != nil {
 		return s.statusLocked(), err
 	}
-	pid, err := s.host.StartUpdater(s.installDir, tag, s.logPath(), s.donePath())
+	kind := classifyUpdate(s.currentVersion, tag)
+	pid, err := s.host.StartUpdater(s.installDir, tag, string(kind), s.logPath(), s.donePath())
 	if err != nil {
 		return s.statusLocked(), fmt.Errorf("start updater: %w", err)
 	}
-	record := runRecord{Target: tag, StartedAt: time.Now().Unix(), StartedBy: startedBy, PID: pid}
+	record := runRecord{
+		Target: tag, UpdateKind: kind, StartedAt: time.Now().Unix(), StartedBy: startedBy, PID: pid,
+	}
 	if err := writeJSONFile(s.runPath(), record); err != nil {
 		return s.statusLocked(), err
 	}
@@ -190,11 +210,12 @@ func (s *Service) runStatus() *RunStatus {
 		return nil
 	}
 	status := &RunStatus{
-		State:     "running",
-		Target:    record.Target,
-		StartedAt: record.StartedAt,
-		StartedBy: record.StartedBy,
-		Log:       tailFile(s.logPath(), logTailBytes),
+		State:      "running",
+		Target:     record.Target,
+		UpdateKind: record.UpdateKind,
+		StartedAt:  record.StartedAt,
+		StartedBy:  record.StartedBy,
+		Log:        tailFile(s.logPath(), logTailBytes),
 	}
 	var done doneRecord
 	switch err := readJSONFile(s.donePath(), &done); {
@@ -257,6 +278,21 @@ func compareVersions(a, b []int) int {
 		}
 	}
 	return 0
+}
+
+// classifyUpdate is conservative for legacy or malformed versions. Only
+// releases with a major, minor, and patch component in the same release line
+// can use the application-only deployment path.
+func classifyUpdate(currentVersion, targetTag string) UpdateKind {
+	current, currentOK := parseReleaseTag(describeBase(currentVersion))
+	target, targetOK := parseReleaseTag(targetTag)
+	if !currentOK || !targetOK || len(current) < 3 || len(target) < 3 {
+		return UpdateKindInfrastructure
+	}
+	if current[0] == target[0] && current[1] == target[1] {
+		return UpdateKindApplication
+	}
+	return UpdateKindInfrastructure
 }
 
 // latestReleaseTag picks the highest version-shaped tag.

--- a/backend/internal/service/selfupdate/service_test.go
+++ b/backend/internal/service/selfupdate/service_test.go
@@ -10,6 +10,7 @@ type fakeHost struct {
 	tags     []string
 	tagsErr  error
 	started  []string
+	kinds    []string
 	pid      int
 	alive    bool
 	startErr error
@@ -19,11 +20,12 @@ func (f *fakeHost) ListRemoteTags(context.Context, string) ([]string, error) {
 	return f.tags, f.tagsErr
 }
 
-func (f *fakeHost) StartUpdater(_ string, tag string, logPath, donePath string) (int, error) {
+func (f *fakeHost) StartUpdater(_ string, tag, kind, logPath, donePath string) (int, error) {
 	if f.startErr != nil {
 		return 0, f.startErr
 	}
 	f.started = append(f.started, tag)
+	f.kinds = append(f.kinds, kind)
 	return f.pid, nil
 }
 
@@ -81,6 +83,32 @@ func TestCompareVersions(t *testing.T) {
 	}
 }
 
+func TestClassifyUpdate(t *testing.T) {
+	cases := []struct {
+		name    string
+		current string
+		target  string
+		want    UpdateKind
+	}{
+		{"patch release", "0.3.1", "0.3.2", UpdateKindApplication},
+		{"commit after patch release", "0.3.1-12-gdb01776", "0.3.2", UpdateKindApplication},
+		{"legacy fourth segment", "0.3.1", "0.3.1.1", UpdateKindApplication},
+		{"minor release", "0.3.1", "0.4.0", UpdateKindInfrastructure},
+		{"skips minor baseline", "0.3.1", "0.4.2", UpdateKindInfrastructure},
+		{"already on minor baseline", "0.4.0", "0.4.2", UpdateKindApplication},
+		{"major release", "1.9.5", "2.0.0", UpdateKindInfrastructure},
+		{"legacy two-part version", "0.3", "0.3.1", UpdateKindInfrastructure},
+		{"unstamped build", "dev", "0.3.2", UpdateKindInfrastructure},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := classifyUpdate(c.current, c.target); got != c.want {
+				t.Fatalf("classifyUpdate(%q, %q) = %q, want %q", c.current, c.target, got, c.want)
+			}
+		})
+	}
+}
+
 func TestLatestReleaseTag(t *testing.T) {
 	tag, _ := latestReleaseTag([]string{"0.1", "v0.10", "0.9", "nightly", "db01776"})
 	if tag != "v0.10" {
@@ -117,6 +145,17 @@ func TestCheckComparesAgainstDescribeOutput(t *testing.T) {
 		if status.LastCheck.LatestTag != "0.2" {
 			t.Errorf("current=%q: latestTag = %q, want 0.2", c.current, status.LastCheck.LatestTag)
 		}
+		if status.LastCheck.UpdateAvailable && status.LastCheck.UpdateKind != UpdateKindInfrastructure {
+			t.Errorf("current=%q: updateKind = %q, want infrastructure for legacy two-part tag", c.current, status.LastCheck.UpdateKind)
+		}
+	}
+}
+
+func TestCheckReportsApplicationUpdateWithinReleaseLine(t *testing.T) {
+	host := &fakeHost{tags: []string{"0.3.1", "0.3.2"}}
+	status := New("0.3.1", "/opt/x", t.TempDir(), host).Check(context.Background())
+	if status.LastCheck == nil || status.LastCheck.UpdateKind != UpdateKindApplication {
+		t.Fatalf("last check = %+v, want application update", status.LastCheck)
 	}
 }
 
@@ -130,6 +169,9 @@ func TestApplyLifecycle(t *testing.T) {
 	}
 	if len(host.started) != 1 || host.started[0] != "0.2" {
 		t.Fatalf("started = %v, want [0.2]", host.started)
+	}
+	if len(host.kinds) != 1 || host.kinds[0] != string(UpdateKindInfrastructure) {
+		t.Fatalf("update kinds = %v, want [infrastructure]", host.kinds)
 	}
 	if status.Run == nil || status.Run.State != "running" || status.Run.Target != "0.2" {
 		t.Fatalf("run status = %+v, want running 0.2", status.Run)
@@ -152,6 +194,21 @@ func TestApplyLifecycle(t *testing.T) {
 	}
 	if run := svc.Status(context.Background()).Run; run == nil || run.State != "succeeded" {
 		t.Fatalf("run after done marker = %+v, want succeeded", run)
+	}
+}
+
+func TestApplyStartsApplicationDeploymentWithinReleaseLine(t *testing.T) {
+	host := &fakeHost{tags: []string{"0.3.1", "0.3.2"}, pid: 4242, alive: true}
+	svc := New("0.3.1", "/opt/x", t.TempDir(), host)
+	status, err := svc.Apply(context.Background(), "admin@example.com", "0.3.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(host.kinds) != 1 || host.kinds[0] != string(UpdateKindApplication) {
+		t.Fatalf("update kinds = %v, want [application]", host.kinds)
+	}
+	if status.Run == nil || status.Run.UpdateKind != UpdateKindApplication {
+		t.Fatalf("run = %+v, want application update", status.Run)
 	}
 }
 

--- a/backend/internal/transport/http/handlers/self_update_handler.go
+++ b/backend/internal/transport/http/handlers/self_update_handler.go
@@ -9,9 +9,9 @@ import (
 	httptransport "github.com/futrx-com/remote.futrx.com/internal/transport/http"
 )
 
-// SelfUpdateHandler exposes the admin-only application update flow: read
-// the current status, check origin for newer release tags, and start
-// infra/update.sh toward one.
+// SelfUpdateHandler exposes the admin-only release update flow: read the
+// current status, check origin for newer release tags, and start the safe
+// application or infrastructure path toward one.
 type SelfUpdateHandler struct {
 	updates *serviceselfupdate.Service
 	auth    *serviceauth.Service

--- a/docs/04-operations/09-deployment-and-operations.md
+++ b/docs/04-operations/09-deployment-and-operations.md
@@ -92,7 +92,13 @@ The recipe is generated from the same provider profiles used by runtime CLI repa
 
 ```mermaid
 flowchart TD
-    Update["Run infra/update.sh"] --> Pull["Fetch and reset installed checkout to origin/main"]
+    Check["In-app updater finds newest release tag"] --> Line{"Installed and target major/minor match?"}
+    Line -->|"Yes: patch release"| App["Run infra/deploy-app.sh"]
+    App --> AppBuild["Build frontend/backend into a staged binary"]
+    AppBuild --> AppRestart["Replace binary, restart, and health-check"]
+    AppRestart --> AppDone["Keep host, base image, and containers unchanged"]
+    Line -->|"No: major/minor release"| Update["Run infra/update.sh"]
+    Update --> Pull["Fetch and reset installed checkout to release tag"]
     Pull --> Reexec["Re-execute the new updater"]
     Reexec --> Install["Converge dependencies, rebuild, restart, and health-check"]
     Install --> Rebuild["Rebuild base image"]
@@ -104,6 +110,22 @@ flowchart TD
     Relaunch --> Mount["Reattach persistent workspace and provider homes"]
     Mount --> Provision["Reprovision tools and compatibility links"]
 ```
+
+Release tags use `MAJOR.MINOR.PATCH`. Crossing a major or minor boundary runs
+the full infrastructure updater; movement within one major/minor line runs the
+application-only deployer. The decision is relative to the installed version:
+
+| Upgrade | Deployment path |
+| --- | --- |
+| `0.3.1` → `0.3.2` | Application only |
+| `0.3.1` → `0.4.0` | Infrastructure |
+| `0.3.1` → `0.4.2` | Infrastructure, because the host missed the `0.4` baseline |
+| `0.4.0` → `0.4.2` | Application only |
+
+The application deployer stages the new binary, restores the previous checkout
+and binary when restart or health verification fails, and refuses to cross a
+major/minor boundary. Unknown and legacy two-component installed versions take
+the conservative infrastructure path.
 
 `--include-busy` forces busy workspace recycling. `--skip-workspaces` updates only the host and application. `upgrade-workspaces.sh --dry-run` shows the workspace plan without changing it.
 
@@ -198,12 +220,14 @@ systemctl status remote.futrx
 systemctl status caddy
 journalctl -u remote.futrx -f
 sudo bash /opt/remote.futrx/infra/update.sh
+sudo bash /opt/remote.futrx/infra/deploy-app.sh --ref=0.4.2
 sudo bash /opt/remote.futrx/infra/upgrade-workspaces.sh --dry-run
 ```
 
 ## Code map
 
 - Installer: [`infra/install.sh`](../../infra/install.sh)
+- Application deployer: [`infra/deploy-app.sh`](../../infra/deploy-app.sh)
 - Updater: [`infra/update.sh`](../../infra/update.sh)
 - Workspace upgrade: [`infra/upgrade-workspaces.sh`](../../infra/upgrade-workspaces.sh)
 - Systemd template: [`infra/templates/remote.futrx.service.tmpl`](../../infra/templates/remote.futrx.service.tmpl)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "remote.futrx-web",
+  "name": "@remote.futrx-web/frontend",
   "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "remote.futrx-web",
+      "name": "@remote.futrx-web/frontend",
       "version": "0.3.0",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "remote.futrx-web",
+  "name": "@remote.futrx-web/frontend",
   "private": true,
   "version": "0.3.0",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@remote.futrx-web/frontend",
+  "name": "@remote.futrx/frontend",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/models/selfUpdate.ts
+++ b/frontend/src/models/selfUpdate.ts
@@ -1,13 +1,17 @@
+export type SelfUpdateKind = "application" | "infrastructure";
+
 export interface SelfUpdateCheck {
   checkedAt: number;
   latestTag?: string;
   updateAvailable: boolean;
+  updateKind?: SelfUpdateKind;
   error?: string;
 }
 
 export interface SelfUpdateRun {
   state: "running" | "succeeded" | "failed";
   target: string;
+  updateKind?: SelfUpdateKind;
   startedAt: number;
   startedBy?: string;
   finishedAt?: number;

--- a/frontend/src/ui/settings/UpdatesSettings.tsx
+++ b/frontend/src/ui/settings/UpdatesSettings.tsx
@@ -33,6 +33,8 @@ export function UpdatesSettings({
   const runActive = run?.state === "running";
   const latestTag = lastCheck?.latestTag ?? "";
   const updateAvailable = !runActive && lastCheck?.updateAvailable === true && latestTag !== "";
+  const updateKind = lastCheck?.updateKind ?? "infrastructure";
+  const infrastructureUpdate = updateKind === "infrastructure";
 
   return (
     <div class="space-y-4">
@@ -81,12 +83,23 @@ export function UpdatesSettings({
       {updateAvailable && (
         <section class="rounded-lg border border-accent-blue/25 bg-accent-blue/[0.06] p-4">
           <div class="text-[13.5px] font-semibold text-ink-50">
-            Release {latestTag} is ready to install
+            {infrastructureUpdate ? "Infrastructure" : "Application"} release {latestTag} is ready
           </div>
           <p class="mt-1 text-[12.5px] leading-relaxed text-ink-300">
-            Updating pulls the release onto the server, rebuilds the application, restarts it,
-            and recycles idle project containers onto the fresh base image. Containers with a
-            running agent are skipped. Expect a few minutes where the app is unreachable.
+            {infrastructureUpdate ? (
+              <>
+                This release crosses a major or minor version boundary. It converges the host,
+                rebuilds the application and base image, and recycles idle project containers.
+                Containers with a running agent are skipped. Expect a few minutes where the app
+                is unreachable.
+              </>
+            ) : (
+              <>
+                This patch release rebuilds and restarts the frontend/backend application only.
+                Host configuration, the base image, and project containers remain unchanged.
+                Expect a brief reconnect while the service restarts.
+              </>
+            )}
           </p>
           <button
             type="button"
@@ -94,7 +107,13 @@ export function UpdatesSettings({
             disabled={applying}
             class="mt-3 h-10 px-3 rounded bg-accent-blue/80 hover:bg-accent-blue text-white text-[13px] font-medium disabled:opacity-50"
           >
-            {applying ? "Starting update…" : `Update to ${latestTag}`}
+            {applying
+              ? infrastructureUpdate
+                ? "Starting infrastructure update…"
+                : "Starting application deploy…"
+              : infrastructureUpdate
+                ? `Update infrastructure to ${latestTag}`
+                : `Deploy ${latestTag}`}
           </button>
         </section>
       )}
@@ -105,18 +124,20 @@ export function UpdatesSettings({
             {run.state === "running" && (
               <div class="flex items-center gap-2 text-[13.5px] font-semibold text-ink-50">
                 <Loader class="w-4 h-4 animate-spin text-accent-blue" />
-                Updating to {run.target}…
+                {run.updateKind === "application"
+                  ? `Deploying application release ${run.target}…`
+                  : `Updating infrastructure to ${run.target}…`}
               </div>
             )}
             {run.state === "succeeded" && (
               <div class="text-[13.5px] font-semibold text-accent-green">
-                Updated to {run.target}
+                {run.updateKind === "application" ? "Deployed" : "Updated to"} {run.target}
               </div>
             )}
             {run.state === "failed" && (
               <div class="flex items-center gap-2 text-[13.5px] font-semibold text-accent-red">
                 <AlertCircle class="w-4 h-4 flex-none" />
-                Update to {run.target} failed
+                {run.updateKind === "application" ? "Deployment of" : "Update to"} {run.target} failed
                 {typeof run.exitCode === "number" ? ` (exit ${run.exitCode})` : ""}
               </div>
             )}
@@ -127,8 +148,9 @@ export function UpdatesSettings({
             </div>
             {run.state === "running" && restarting && (
               <div class="mt-2 text-[12px] text-accent-yellow">
-                The server is restarting as part of the update — reconnecting… This can take a
-                few minutes while containers are recycled.
+                {run.updateKind === "application"
+                  ? "The application is restarting — reconnecting…"
+                  : "The server is restarting as part of the update — reconnecting… This can take a few minutes while containers are recycled."}
               </div>
             )}
             {run.state === "succeeded" && (

--- a/infra/deploy-app.sh
+++ b/infra/deploy-app.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# remote.futrx — production application-only release deployer.
+#
+# Use this to deploy frontend/backend code when the installed and target
+# releases have the same MAJOR.MINOR version (for example, 0.4.1 -> 0.4.2).
+# The in-app updater selects this script automatically for that case; the
+# command below is the manual operator equivalent.
+#
+# The target must resolve as a release tag after the script fetches tags from
+# the installed checkout's origin. It builds the frontend and a staged backend
+# binary, replaces the live binary, restarts remote.futrx.service, and verifies
+# the local HTTP endpoint. If the build, restart, or health check fails, it
+# restores the previous checkout and, if replaced, the previous binary.
+#
+# This script does NOT converge host dependencies, Caddy, systemd units, LXD,
+# the workspace base image, or project containers. It rejects major/minor
+# crossings, unknown installed versions, and legacy two-component versions;
+# use infra/update.sh for those infrastructure updates.
+#
+# Requirements: an existing installed service, root privileges, and the Git,
+# Node/npm, and Go toolchains previously installed by infra/install.sh.
+#
+# Usage:
+#   sudo bash /opt/remote.futrx/infra/deploy-app.sh --ref=<release-tag>
+#
+# Test-only overrides: FUTRX_INSTALL_DIR, FUTRX_SERVICE_NAME, FUTRX_SERVICE_PORT.
+set -euo pipefail
+
+usage() {
+    sed -n '2,/^set -euo pipefail$/ { /^set -euo pipefail$/d; s/^# \{0,1\}//p; }' "$0"
+}
+
+TARGET_REF=""
+for argument in "$@"; do
+    case "$argument" in
+        --ref=*)  TARGET_REF="${argument#*=}" ;;
+        -h|--help) usage; exit 0 ;;
+        --*)      echo "unknown flag: $argument" >&2; exit 2 ;;
+        *)        echo "unexpected argument: $argument" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$TARGET_REF" ]; then
+    echo "--ref=<release-tag> is required" >&2
+    exit 2
+fi
+if [ "$EUID" -ne 0 ]; then
+    echo "this application deployer needs root; rerun with sudo" >&2
+    exit 1
+fi
+
+DEFAULT_INSTALL_DIR="${INSTALL_DIR:-/opt/remote.futrx}"
+INSTALL_DIR="${FUTRX_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+SERVICE_NAME="${FUTRX_SERVICE_NAME:-remote.futrx.service}"
+DEFAULT_SERVICE_PORT="${PORT:-7682}"
+SERVICE_PORT="${FUTRX_SERVICE_PORT:-$DEFAULT_SERVICE_PORT}"
+BINARY="$INSTALL_DIR/backend/remote"
+
+if [ ! -d "$INSTALL_DIR/.git" ]; then
+    echo "$INSTALL_DIR is not an installed git checkout; run infra/install.sh first" >&2
+    exit 1
+fi
+if ! systemctl cat "$SERVICE_NAME" >/dev/null 2>&1; then
+    echo "$SERVICE_NAME is not installed; run infra/install.sh first" >&2
+    exit 1
+fi
+if [ ! -x "$BINARY" ]; then
+    echo "installed application binary is missing or not executable: $BINARY" >&2
+    exit 1
+fi
+for command_name in git npm go systemctl; do
+    command -v "$command_name" >/dev/null 2>&1 || {
+        echo "missing required command: $command_name" >&2
+        echo "run infra/update.sh to converge host dependencies" >&2
+        exit 1
+    }
+done
+
+SCRIPT_INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=lib/release-version.sh
+. "$SCRIPT_INFRA_DIR/lib/release-version.sh"
+
+cd "$INSTALL_DIR"
+PREVIOUS_SHA="$(git rev-parse --verify 'HEAD^{commit}')"
+git fetch --quiet --tags origin
+CURRENT_VERSION="$(git describe --tags --abbrev=0 --match '[0-9]*' --match 'v[0-9]*' HEAD 2>/dev/null || true)"
+TARGET_COMMIT="$(git rev-parse --verify --quiet "refs/tags/${TARGET_REF}^{commit}" || true)"
+if [ -z "$TARGET_COMMIT" ]; then
+    echo "release tag is unavailable after fetching origin: $TARGET_REF" >&2
+    exit 1
+fi
+
+UPDATE_KIND="$(release_update_kind "$CURRENT_VERSION" "$TARGET_REF")"
+if [ "$UPDATE_KIND" != "application" ]; then
+    echo "refusing application-only deployment from ${CURRENT_VERSION:-unknown} to $TARGET_REF" >&2
+    echo "major/minor changes require: sudo bash $INSTALL_DIR/infra/update.sh --ref=$TARGET_REF" >&2
+    exit 1
+fi
+
+STAGE_DIR="$(mktemp -d "$INSTALL_DIR/backend/.app-deploy.XXXXXX")"
+PREVIOUS_BINARY="$STAGE_DIR/previous"
+STAGED_BINARY="$STAGE_DIR/remote"
+cp -p "$BINARY" "$PREVIOUS_BINARY"
+BINARY_REPLACED=0
+DEPLOYMENT_SUCCEEDED=0
+
+finish() {
+    local status="$1"
+    trap - EXIT
+    if [ "$DEPLOYMENT_SUCCEEDED" -ne 1 ]; then
+        echo "Application deployment failed; restoring the previous release" >&2
+        git reset --hard "$PREVIOUS_SHA" >/dev/null 2>&1 || true
+        if [ "$BINARY_REPLACED" -eq 1 ]; then
+            install -m 0755 "$PREVIOUS_BINARY" "$BINARY" || true
+            systemctl restart "$SERVICE_NAME" || true
+        fi
+    fi
+    rm -f "$PREVIOUS_BINARY" "$STAGED_BINARY"
+    rmdir "$STAGE_DIR" 2>/dev/null || true
+    exit "$status"
+}
+trap 'finish $?' EXIT
+
+echo "==> Deploying application release $TARGET_REF ($TARGET_COMMIT)"
+echo "    infrastructure, base image, and project containers will be unchanged"
+git reset --hard "$TARGET_COMMIT"
+
+echo "==> Building frontend"
+(
+    cd frontend
+    npm install --silent --no-audit --no-fund 2>&1 | tail -3
+    npm run build
+)
+
+echo "==> Building backend"
+APP_VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"
+(
+    cd backend
+    go build -trimpath \
+        -ldflags="-s -w -X github.com/futrx-com/remote.futrx.com/internal/version.Version=${APP_VERSION}" \
+        -o "$STAGED_BINARY" ./cmd/remote
+)
+
+install -m 0755 "$STAGED_BINARY" "$BINARY"
+BINARY_REPLACED=1
+systemctl restart "$SERVICE_NAME"
+
+# shellcheck source=lib/health-check.sh
+. "$INSTALL_DIR/infra/lib/health-check.sh"
+wait_for_http_health "http://127.0.0.1:${SERVICE_PORT}/" 30
+systemctl is-active --quiet "$SERVICE_NAME"
+
+DEPLOYED_SHA="$(git rev-parse --verify 'HEAD^{commit}')"
+if [ "$DEPLOYED_SHA" != "$TARGET_COMMIT" ]; then
+    echo "deployed $DEPLOYED_SHA, expected $TARGET_COMMIT" >&2
+    exit 1
+fi
+
+DEPLOYMENT_SUCCEEDED=1
+echo
+echo "✓ application release $TARGET_REF deployed"

--- a/infra/install.sh
+++ b/infra/install.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 #
-# remote.futrx — main installer / deployer.
-# Walks through infra/steps/*.sh in order. Idempotent: safe to re-run on
-# every CI deploy as well as the initial bootstrap.
+# remote.futrx — fresh installer and full host-convergence entry point.
+#
+# Use this for a first installation or an intentional repair/re-convergence of
+# an existing host. It runs infra/steps/*.sh in order to converge host packages
+# and pinned toolchains, select and build the application checkout, render
+# Caddy and systemd configuration, ensure the LXD base image exists, harden
+# SSH, and install the container-network repair timer.
+#
+# The steps are designed to be idempotent, but a re-run is not an
+# application-only deployment: it can change host configuration and restart
+# the backend. For normal releases, prefer Settings -> Updates. Manually use
+# infra/deploy-app.sh for a same-major/minor application release or
+# infra/update.sh for a major/minor infrastructure release.
 #
 # Usage (from a clone):
 #   sudo bash infra/install.sh <hostname> [flags]
@@ -17,12 +27,15 @@
 #                                               A record is set but propagation isn't done.
 #   --ref=<40-character commit SHA>             install an immutable candidate commit instead
 #                                               of origin/main (used by QA branch installs).
-#   --github-token=ghp_xxx                      private-repo PAT.
+#   --github-token=ghp_xxx                      private-repo PAT; prefer the
+#                                               GITHUB_TOKEN environment variable
+#                                               to avoid placing it in shell history.
 #   --google-client-id=...                      optional; can be added in Settings later.
 #   --google-client-secret=...                  optional; can be added in Settings later.
 #
 # Environment:
-#   GITHUB_TOKEN                                same as --github-token=.
+#   GITHUB_TOKEN                                same as --github-token.
+#   FUTRX_INSTALL_DIR                           override /opt/remote.futrx (QA/tests).
 
 set -euo pipefail
 
@@ -307,7 +320,9 @@ cat <<EOF
    systemctl status   caddy
    journalctl -u      remote.futrx -f
 
- Re-run this installer any time to pull latest + rebuild + restart.
+ For future releases, use Settings → Updates so Remote selects the safe
+ application or infrastructure path. Re-run this installer only for an
+ intentional full host repair/re-convergence.
 ═══════════════════════════════════════════════════════════════
 
 EOF

--- a/infra/lib/release-version.sh
+++ b/infra/lib/release-version.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Helpers for choosing a release deployment path from numeric version tags.
+# This file is sourced by deploy/update scripts; do not enable shell options.
+
+# release_version_train VERSION
+# Prints MAJOR.MINOR for a version with at least major, minor, and patch
+# components. A leading "v" and legacy fourth components are accepted.
+release_version_train() {
+    local version="${1#v}"
+    if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)*$'; then
+        return 1
+    fi
+    local major minor remainder
+    IFS=. read -r major minor remainder <<EOF
+$version
+EOF
+    printf '%s.%s\n' "$major" "$minor"
+}
+
+# release_update_kind CURRENT TARGET
+# Prints "application" only when both versions are complete numeric releases
+# in the same major/minor line. Unknown and legacy two-component versions take
+# the conservative infrastructure path.
+release_update_kind() {
+    local current_train target_train
+    current_train="$(release_version_train "$1")" || {
+        printf 'infrastructure\n'
+        return 0
+    }
+    target_train="$(release_version_train "$2")" || {
+        printf 'infrastructure\n'
+        return 0
+    }
+    if [ "$current_train" = "$target_train" ]; then
+        printf 'application\n'
+    else
+        printf 'infrastructure\n'
+    fi
+}

--- a/infra/qa/common.sh
+++ b/infra/qa/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Shared local safeguards for the explicit QA install and update commands.
+# Shared connection, ref-validation, and public-health helpers for QA deploys.
 
 set -euo pipefail
 

--- a/infra/qa/deploy-app.sh
+++ b/infra/qa/deploy-app.sh
@@ -3,9 +3,10 @@
 #
 # Unlike the production deployer, this accepts a pushed branch, tag, or commit
 # and intentionally does not enforce a semantic-version release boundary. Use
-# it only when the candidate needs frontend/backend deployment alone; use
-# infra/qa/update.sh when the candidate changes host or workspace
-# infrastructure. Connection settings come from .qa.env (see .qa.env.example).
+# it when an immutable, shareable candidate needs frontend/backend deployment
+# alone. Use deploy-local.sh for an uncommitted working tree, or update.sh when
+# the candidate changes host or workspace infrastructure. Connection settings
+# come from .qa.env (see .qa.env.example).
 
 set -euo pipefail
 
@@ -21,6 +22,7 @@ Deploys application code only from one exact pushed commit: it builds the
 frontend and backend on the existing QA server, restarts remote.futrx.service,
 and verifies local and public health. It does not converge host dependencies,
 Caddy, LXD, the workspace base image, or project containers. Use
+infra/qa/deploy-local.sh to test an uncommitted working tree, or
 infra/qa/update.sh to exercise the full production infrastructure path.
 
 The requested ref must resolve to the clean local HEAD and to the same commit

--- a/infra/qa/deploy-app.sh
+++ b/infra/qa/deploy-app.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-# Deploy application code to QA without running the host/workspace updater.
+# QA application-only deploy wrapper for an existing QA installation.
+#
+# Unlike the production deployer, this accepts a pushed branch, tag, or commit
+# and intentionally does not enforce a semantic-version release boundary. Use
+# it only when the candidate needs frontend/backend deployment alone; use
+# infra/qa/update.sh when the candidate changes host or workspace
+# infrastructure. Connection settings come from .qa.env (see .qa.env.example).
 
 set -euo pipefail
 
@@ -14,8 +20,13 @@ Usage: bash infra/qa/deploy-app.sh <branch|tag|commit>
 Deploys application code only from one exact pushed commit: it builds the
 frontend and backend on the existing QA server, restarts remote.futrx.service,
 and verifies local and public health. It does not converge host dependencies,
-Caddy, LXD, the workspace base image, or project containers. Use update.sh to
-exercise those production update paths.
+Caddy, LXD, the workspace base image, or project containers. Use
+infra/qa/update.sh to exercise the full production infrastructure path.
+
+The requested ref must resolve to the clean local HEAD and to the same commit
+on origin. After the binary is replaced, restart or health-check failure
+restores the previous binary and checkout. A build failure leaves the live
+binary untouched, although the QA checkout remains on the candidate commit.
 EOF
 }
 

--- a/infra/qa/deploy-local.sh
+++ b/infra/qa/deploy-local.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# QA application-only deploy from the current local working tree.
+#
+# This command does not require a commit or push. It packages tracked files
+# plus non-ignored untracked files, uploads them to a temporary directory on
+# the QA server, builds the frontend and backend there, and replaces only the
+# installed application binary. The server's /opt/remote.futrx Git checkout is
+# left unchanged.
+#
+# Use this only for frontend/backend iteration. Local infrastructure changes
+# are present in the uploaded build context but are not applied to the host,
+# base image, or project containers. Exercise those changes through the
+# immutable, pushed-ref path in infra/qa/update.sh.
+#
+# Connection settings come from .qa.env (see .qa.env.example). The QA account
+# must be able to write the installed binary and restart remote.futrx.service.
+
+set -euo pipefail
+
+QA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=common.sh
+. "$QA_DIR/common.sh"
+
+usage() {
+    cat <<'EOF'
+Usage: bash infra/qa/deploy-local.sh
+
+Deploys application code from the current local working tree without a commit
+or push. Tracked files and non-ignored untracked files are built in a temporary
+directory on the QA server. The installed Git checkout is not changed.
+
+The deployment rebuilds the frontend and backend, atomically replaces the
+application binary, restarts remote.futrx.service, and verifies local and
+public health. Restart or local health-check failure restores the previous
+binary. Host dependencies, Caddy, LXD, the base image, and project containers
+are not changed.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    '') ;;
+    *) usage >&2; exit 2 ;;
+esac
+[ "$#" -eq 0 ] || {
+    usage >&2
+    exit 2
+}
+
+qa_prepare_connection
+
+for command_name in git tar scp ssh; do
+    command -v "$command_name" >/dev/null 2>&1 || \
+        qa_fail "required local command is missing: $command_name"
+done
+
+cd "$QA_REPO_ROOT"
+
+head_sha="$(git rev-parse --verify HEAD)"
+short_sha="$(git rev-parse --short=12 HEAD)"
+tree_state="clean"
+if [ -n "$(git status --porcelain --untracked-files=normal)" ]; then
+    tree_state="dirty"
+fi
+local_version="qa-local-${short_sha}-${tree_state}-$(date -u +%Y%m%d%H%M%S)"
+
+package_dir="$(mktemp -d)"
+archive_path="$package_dir/source.tar.gz"
+manifest_path="$package_dir/files.list"
+remote_archive=""
+
+cleanup() {
+    rm -rf -- "$package_dir"
+    if [ -n "$remote_archive" ]; then
+        ssh "${QA_SSH_ARGS[@]}" "$QA_SSH_USER@$QA_SSH_HOST" \
+            bash -s -- "$remote_archive" >/dev/null 2>&1 <<'REMOTE_CLEANUP' || true
+rm -f -- "$1"
+REMOTE_CLEANUP
+    fi
+}
+trap cleanup EXIT
+
+# git ls-files includes tracked modifications and non-ignored untracked files,
+# but also reports tracked files deleted from the working tree. Build a null-
+# delimited manifest containing only files that are actually present.
+while IFS= read -r -d '' relative_path; do
+    if [ -f "$QA_REPO_ROOT/$relative_path" ] || [ -L "$QA_REPO_ROOT/$relative_path" ]; then
+        printf '%s\0' "$relative_path"
+    fi
+done < <(git ls-files --cached --others --exclude-standard -z) > "$manifest_path"
+
+[ -s "$manifest_path" ] || qa_fail "the local working tree contains no deployable files"
+
+tar --create --gzip \
+    --file "$archive_path" \
+    --directory "$QA_REPO_ROOT" \
+    --null \
+    --files-from "$manifest_path"
+
+printf '==> Packaging local QA application at %s (%s)\n' "$head_sha" "$tree_state"
+printf '    version: %s\n' "$local_version"
+printf '    app only: the installed Git checkout and infrastructure stay unchanged\n'
+
+remote_archive="$(ssh "${QA_SSH_ARGS[@]}" "$QA_SSH_USER@$QA_SSH_HOST" \
+    mktemp '/tmp/remote-futrx-local.XXXXXX.tar.gz')"
+case "$remote_archive" in
+    /tmp/remote-futrx-local.*.tar.gz) ;;
+    *) qa_fail "QA server returned an unexpected temporary path: $remote_archive" ;;
+esac
+
+scp -q "${QA_SSH_ARGS[@]}" "$archive_path" \
+    "$QA_SSH_USER@$QA_SSH_HOST:$remote_archive"
+
+printf '==> Building and deploying on %s@%s\n' "$QA_SSH_USER" "$QA_SSH_HOST"
+
+ssh "${QA_SSH_ARGS[@]}" "$QA_SSH_USER@$QA_SSH_HOST" \
+    bash -s -- "$remote_archive" "$local_version" <<'REMOTE'
+set -euo pipefail
+
+archive_path="$1"
+app_version="$2"
+install_dir="/opt/remote.futrx"
+service_name="remote.futrx.service"
+binary="$install_dir/backend/remote"
+stage_dir=""
+candidate_binary=""
+previous_binary=""
+
+cleanup_remote() {
+    rm -f -- "$archive_path"
+    [ -z "$candidate_binary" ] || rm -f -- "$candidate_binary"
+    [ -z "$previous_binary" ] || rm -f -- "$previous_binary"
+    [ -z "$stage_dir" ] || rm -rf -- "$stage_dir"
+}
+trap cleanup_remote EXIT
+
+if [ ! -d "$install_dir/.git" ] || ! systemctl cat "$service_name" >/dev/null 2>&1; then
+    echo "QA server does not have an installed remote.futrx application" >&2
+    echo "Use infra/qa/install.sh before deploying local application code." >&2
+    exit 3
+fi
+for command_name in tar npm go install mktemp mv systemctl; do
+    command -v "$command_name" >/dev/null 2>&1 || {
+        echo "QA server is missing required command: $command_name" >&2
+        echo "Use infra/qa/update.sh to converge host dependencies." >&2
+        exit 1
+    }
+done
+[ -x "$binary" ] || {
+    echo "installed application binary is missing or not executable: $binary" >&2
+    exit 1
+}
+[ -r "$install_dir/infra/lib/health-check.sh" ] || {
+    echo "installed health-check helper is missing" >&2
+    echo "Use infra/qa/update.sh to converge the QA installation." >&2
+    exit 1
+}
+
+stage_dir="$(mktemp -d /tmp/remote-futrx-local-build.XXXXXX)"
+tar --extract --gzip --file "$archive_path" --directory "$stage_dir"
+for required_path in frontend/package.json backend/go.mod backend/cmd/remote; do
+    [ -e "$stage_dir/$required_path" ] || {
+        echo "local source archive is missing: $required_path" >&2
+        exit 1
+    }
+done
+
+echo "==> Building frontend"
+(
+    cd "$stage_dir/frontend"
+    npm install --silent --no-audit --no-fund 2>&1 | tail -3
+    npm run build
+)
+
+echo "==> Building backend"
+(
+    cd "$stage_dir/backend"
+    go build -trimpath \
+        -ldflags="-s -w -X github.com/futrx-com/remote.futrx.com/internal/version.Version=${app_version}" \
+        -o "$stage_dir/remote" ./cmd/remote
+)
+
+candidate_binary="$(mktemp "$install_dir/backend/.qa-local-candidate.XXXXXX")"
+previous_binary="$(mktemp "$install_dir/backend/.qa-local-previous.XXXXXX")"
+cp -p "$binary" "$previous_binary"
+install -m 0755 "$stage_dir/remote" "$candidate_binary"
+
+rollback() {
+    echo "Local QA deployment failed; restoring the previous application binary" >&2
+    install -m 0755 "$previous_binary" "$candidate_binary"
+    mv -f "$candidate_binary" "$binary"
+    systemctl restart "$service_name" || true
+}
+
+mv -f "$candidate_binary" "$binary"
+if ! systemctl restart "$service_name"; then
+    rollback
+    exit 1
+fi
+
+# Use the installed health-check implementation because this app-only command
+# must not apply or depend on local infrastructure changes.
+# shellcheck source=../lib/health-check.sh
+. "$install_dir/infra/lib/health-check.sh"
+if ! wait_for_http_health http://127.0.0.1:7682/ 30; then
+    rollback
+    exit 1
+fi
+if ! systemctl is-active --quiet "$service_name"; then
+    rollback
+    exit 1
+fi
+
+printf 'QA_DEPLOYED_VERSION=%s\n' "$app_version"
+REMOTE
+
+remote_archive=""
+qa_verify_public_url
+
+printf '\n✓ Local QA application deployed\n'
+printf '  Version: %s\n' "$local_version"
+printf '  Source HEAD: %s (%s working tree)\n' "$head_sha" "$tree_state"
+printf '  Git checkout: unchanged\n'
+printf '  https://%s/\n' "$QA_PUBLIC_HOST"

--- a/infra/qa/install.sh
+++ b/infra/qa/install.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# Exercise the public curl|bash installation flow on a fresh QA server.
+# QA wrapper for exercising installation on a fresh, disposable server.
+#
+# It reads SSH/public-host settings from .qa.env (see .qa.env.example), refuses
+# a server with an existing Remote installation, performs the installation over
+# SSH, and verifies both local and public health. It does not recreate or clean
+# the QA server for you.
 
 set -euo pipefail
 
@@ -16,6 +21,9 @@ user. With a ref, resolves the pushed ref to an immutable commit and
 curl-installs that exact candidate commit. It refuses to run when
 /opt/remote.futrx already exists; recreate the server before using this command
 to repeat a clean-install test.
+
+Candidate mode requires a clean local checkout whose HEAD matches the requested
+ref on origin. Connection settings come from .qa.env (see .qa.env.example).
 EOF
 }
 

--- a/infra/qa/update.sh
+++ b/infra/qa/update.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-# Update an existing QA installation to one exact pushed Git ref.
+# QA wrapper for a full infrastructure update of an existing installation.
+#
+# It resolves a pushed branch, tag, or commit to an immutable SHA, runs the
+# production infra/update.sh on the QA host, and verifies local and public
+# health. This is disruptive and can rebuild the base image and recycle
+# eligible project containers. Use infra/qa/deploy-app.sh for an app-only
+# candidate. Connection settings come from .qa.env (see .qa.env.example).
 
 set -euo pipefail
 
@@ -12,7 +18,12 @@ usage() {
 Usage: bash infra/qa/update.sh <branch|tag|commit>
 
 Updates an existing QA installation to an exact pushed Git commit. It refuses
-to provision a fresh server; use infra/qa/install.sh for the first install.
+to provision a fresh server; use infra/qa/install.sh for the first install. It
+runs the complete production infrastructure path, including host convergence,
+base-image rebuild, and eligible workspace recycling.
+
+The requested ref must resolve to the clean local HEAD and to the same commit
+on origin. Coordinate a maintenance window before running it.
 EOF
 }
 

--- a/infra/qa/update.sh
+++ b/infra/qa/update.sh
@@ -5,6 +5,7 @@
 # production infra/update.sh on the QA host, and verifies local and public
 # health. This is disruptive and can rebuild the base image and recycle
 # eligible project containers. Use infra/qa/deploy-app.sh for an app-only
+# pushed candidate or infra/qa/deploy-local.sh for an uncommitted app-only
 # candidate. Connection settings come from .qa.env (see .qa.env.example).
 
 set -euo pipefail

--- a/infra/steps/02-app.sh
+++ b/infra/steps/02-app.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Repo clone/update + frontend & backend build + Google OAuth config seed.
+# Application checkout, frontend/backend build, and Google OAuth config seed.
 #
-# This step is normally a no-op on CI deploy (the repo's already cloned and
-# CI does the pull itself) but stays here so the first-time installer works
-# end-to-end from curl|bash.
+# On a fresh install this clones the repository. On a full convergence it
+# selects FUTRX_CHECKOUT_REF (set by update.sh) or origin/main, hard-resets the
+# installed checkout to that commit, and rebuilds the embedded application.
 #
 # Expects from caller:
 #   - log / ok / err helpers
@@ -26,8 +26,8 @@ if [ -n "${GITHUB_TOKEN:-}" ]; then
 fi
 
 if [ -d "$INSTALL_DIR/.git" ]; then
-    # FUTRX_CHECKOUT_REF pins the deploy to a release tag (set by
-    # `update.sh --ref=<tag>`); default stays tracking origin/main.
+    # FUTRX_CHECKOUT_REF pins the deploy to the tag or commit selected by
+    # `update.sh --ref=<ref>`; default stays tracking origin/main.
     CHECKOUT_REF="${FUTRX_CHECKOUT_REF:-origin/main}"
     log "Updating repo at $INSTALL_DIR (ref: $CHECKOUT_REF)"
     git -C "$INSTALL_DIR" fetch --quiet --tags origin

--- a/infra/tests/deploy-app-script-test.sh
+++ b/infra/tests/deploy-app-script-test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DEPLOY_SCRIPT="$TESTS_DIR/../deploy-app.sh"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$TEST_DIR"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+bash -n "$DEPLOY_SCRIPT"
+bash "$DEPLOY_SCRIPT" --help | grep -q 'deploy frontend/backend code' || \
+    fail "help does not identify the application-only contract"
+
+if FUTRX_INSTALL_DIR="$TEST_DIR/missing" bash "$DEPLOY_SCRIPT" --ref=0.3.2 \
+    >"$TEST_DIR/out" 2>"$TEST_DIR/err"; then
+    fail "deploy-app.sh accepted a missing installation"
+fi
+grep -q 'not an installed git checkout' "$TEST_DIR/err" || \
+    fail "missing-installation error is unclear"
+
+for required_contract in \
+    'release_update_kind' \
+    'npm run build' \
+    'go build -trimpath' \
+    'systemctl restart' \
+    'wait_for_http_health' \
+    'restoring the previous release'; do
+    grep -Fq "$required_contract" "$DEPLOY_SCRIPT" || \
+        fail "deploy-app.sh is missing contract: $required_contract"
+done
+
+if grep -Eq '^[[:space:]]*(sudo[[:space:]]+)?bash .*infra/(install|update|upgrade-workspaces)[.]sh|FORCE_REBUILD_BASE_IMAGE|apt-get' "$DEPLOY_SCRIPT"; then
+    fail "deploy-app.sh invokes host or workspace convergence"
+fi
+
+ORIGIN="$TEST_DIR/origin.git"
+INSTALL_DIR="$TEST_DIR/install"
+FAKE_BIN="$TEST_DIR/bin"
+mkdir -p "$FAKE_BIN"
+git init --bare --quiet "$ORIGIN"
+git init --quiet "$INSTALL_DIR"
+git -C "$INSTALL_DIR" config user.name Test
+git -C "$INSTALL_DIR" config user.email test@example.com
+git -C "$INSTALL_DIR" remote add origin "$ORIGIN"
+mkdir -p "$INSTALL_DIR/frontend" "$INSTALL_DIR/backend" "$INSTALL_DIR/infra/lib"
+printf '/backend/remote\n/backend/public/\n' > "$INSTALL_DIR/.gitignore"
+printf 'baseline\n' > "$INSTALL_DIR/frontend/source.txt"
+cat > "$INSTALL_DIR/infra/lib/health-check.sh" <<'EOF'
+wait_for_http_health() {
+    [ "${FAIL_HEALTH:-0}" != "1" ]
+}
+EOF
+git -C "$INSTALL_DIR" add .
+git -C "$INSTALL_DIR" commit --quiet -m baseline
+git -C "$INSTALL_DIR" tag 0.4.0
+printf 'patch\n' > "$INSTALL_DIR/frontend/source.txt"
+git -C "$INSTALL_DIR" commit --quiet -am patch
+git -C "$INSTALL_DIR" tag 0.4.1
+printf 'minor\n' > "$INSTALL_DIR/frontend/source.txt"
+git -C "$INSTALL_DIR" commit --quiet -am minor
+git -C "$INSTALL_DIR" tag 0.5.0
+git -C "$INSTALL_DIR" push --quiet origin HEAD --tags
+
+cat > "$FAKE_BIN/npm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$FAKE_BIN/go" <<'EOF'
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        printf 'new binary\n' > "$2"
+        chmod 0755 "$2"
+        exit 0
+    fi
+    shift
+done
+exit 1
+EOF
+cat > "$FAKE_BIN/systemctl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BIN/npm" "$FAKE_BIN/go" "$FAKE_BIN/systemctl"
+
+reset_install() {
+    git -C "$INSTALL_DIR" reset --hard --quiet 0.4.0
+    printf 'old binary\n' > "$INSTALL_DIR/backend/remote"
+    chmod 0755 "$INSTALL_DIR/backend/remote"
+}
+
+reset_install
+PATH="$FAKE_BIN:$PATH" FUTRX_INSTALL_DIR="$INSTALL_DIR" \
+    bash "$DEPLOY_SCRIPT" --ref=0.4.1 >"$TEST_DIR/success.out"
+[ "$(git -C "$INSTALL_DIR" rev-parse HEAD)" = "$(git -C "$INSTALL_DIR" rev-parse 0.4.1)" ] || \
+    fail "successful patch deployment did not select its target commit"
+grep -q '^new binary$' "$INSTALL_DIR/backend/remote" || \
+    fail "successful patch deployment did not install the staged binary"
+
+reset_install
+if PATH="$FAKE_BIN:$PATH" FUTRX_INSTALL_DIR="$INSTALL_DIR" FAIL_HEALTH=1 \
+    bash "$DEPLOY_SCRIPT" --ref=0.4.1 >"$TEST_DIR/failure.out" 2>"$TEST_DIR/failure.err"; then
+    fail "deploy-app.sh accepted a failed health check"
+fi
+[ "$(git -C "$INSTALL_DIR" rev-parse HEAD)" = "$(git -C "$INSTALL_DIR" rev-parse 0.4.0)" ] || \
+    fail "failed deployment did not restore the previous checkout"
+grep -q '^old binary$' "$INSTALL_DIR/backend/remote" || \
+    fail "failed deployment did not restore the previous binary"
+
+reset_install
+if PATH="$FAKE_BIN:$PATH" FUTRX_INSTALL_DIR="$INSTALL_DIR" \
+    bash "$DEPLOY_SCRIPT" --ref=0.5.0 >"$TEST_DIR/minor.out" 2>"$TEST_DIR/minor.err"; then
+    fail "deploy-app.sh accepted a cross-minor deployment"
+fi
+grep -q 'refusing application-only deployment' "$TEST_DIR/minor.err" || \
+    fail "cross-minor refusal is unclear"
+[ "$(git -C "$INSTALL_DIR" rev-parse HEAD)" = "$(git -C "$INSTALL_DIR" rev-parse 0.4.0)" ] || \
+    fail "cross-minor refusal changed the installed checkout"
+
+echo "Production application deploy script tests passed"

--- a/infra/tests/qa-scripts-test.sh
+++ b/infra/tests/qa-scripts-test.sh
@@ -5,6 +5,7 @@ TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 INSTALL_SCRIPT="$TESTS_DIR/../qa/install.sh"
 UPDATE_SCRIPT="$TESTS_DIR/../qa/update.sh"
 DEPLOY_APP_SCRIPT="$TESTS_DIR/../qa/deploy-app.sh"
+DEPLOY_LOCAL_SCRIPT="$TESTS_DIR/../qa/deploy-local.sh"
 COMMON_SCRIPT="$TESTS_DIR/../qa/common.sh"
 CORE_INSTALL_SCRIPT="$TESTS_DIR/../install.sh"
 TEST_DIR="$(mktemp -d)"
@@ -15,7 +16,7 @@ fail() {
     exit 1
 }
 
-for script in "$COMMON_SCRIPT" "$INSTALL_SCRIPT" "$UPDATE_SCRIPT" "$DEPLOY_APP_SCRIPT"; do
+for script in "$COMMON_SCRIPT" "$INSTALL_SCRIPT" "$UPDATE_SCRIPT" "$DEPLOY_APP_SCRIPT" "$DEPLOY_LOCAL_SCRIPT"; do
     bash -n "$script"
 done
 
@@ -25,6 +26,8 @@ bash "$UPDATE_SCRIPT" --help | grep -q 'existing QA installation' || \
     fail "update help does not identify the existing-installation contract"
 bash "$DEPLOY_APP_SCRIPT" --help | grep -q 'application code only' || \
     fail "deploy-app help does not identify the app-only contract"
+bash "$DEPLOY_LOCAL_SCRIPT" --help | grep -q 'without a commit' || \
+    fail "deploy-local help does not identify the local-working-tree contract"
 
 if QA_ENV_FILE="$TEST_DIR/missing.env" bash "$INSTALL_SCRIPT" >"$TEST_DIR/out" 2>"$TEST_DIR/err"; then
     fail "install.sh accepted missing QA configuration"
@@ -68,6 +71,12 @@ fi
 grep -q 'unsupported characters' "$TEST_DIR/err" || \
     fail "deploy-app.sh gave an unclear unsafe-ref error"
 
+if QA_ENV_FILE="$TEST_DIR/missing.env" bash "$DEPLOY_LOCAL_SCRIPT" >"$TEST_DIR/out" 2>"$TEST_DIR/err"; then
+    fail "deploy-local.sh accepted missing QA configuration"
+fi
+grep -q 'missing .*missing.env' "$TEST_DIR/err" || \
+    fail "deploy-local.sh gave an unclear missing-config error"
+
 if bash "$CORE_INSTALL_SCRIPT" test.example.com --ref=main >"$TEST_DIR/out" 2>"$TEST_DIR/err"; then
     fail "core install.sh accepted a movable ref"
 fi
@@ -101,5 +110,12 @@ done
 if grep -Eq 'infra/(install|update|upgrade-workspaces)[.]sh|FORCE_REBUILD_BASE_IMAGE|apt-get' "$DEPLOY_APP_SCRIPT"; then
     fail "deploy-app.sh invokes host or workspace convergence"
 fi
+for required_contract in 'git ls-files' 'scp -q' 'npm run build' 'go build -trimpath' 'systemctl restart' 'wait_for_http_health' 'QA_DEPLOYED_VERSION'; do
+    grep -Fq "$required_contract" "$DEPLOY_LOCAL_SCRIPT" || \
+        fail "deploy-local.sh is missing contract: $required_contract"
+done
+if grep -Eq 'git (fetch|reset)|infra/(install|update|upgrade-workspaces)[.]sh|FORCE_REBUILD_BASE_IMAGE|apt-get' "$DEPLOY_LOCAL_SCRIPT"; then
+    fail "deploy-local.sh changes the installed checkout, host, or workspaces"
+fi
 
-echo "QA install/update/app-deploy script tests passed"
+echo "QA install/update/app-deploy/local-deploy script tests passed"

--- a/infra/tests/qa-scripts-test.sh
+++ b/infra/tests/qa-scripts-test.sh
@@ -8,6 +8,7 @@ DEPLOY_APP_SCRIPT="$TESTS_DIR/../qa/deploy-app.sh"
 DEPLOY_LOCAL_SCRIPT="$TESTS_DIR/../qa/deploy-local.sh"
 COMMON_SCRIPT="$TESTS_DIR/../qa/common.sh"
 CORE_INSTALL_SCRIPT="$TESTS_DIR/../install.sh"
+ROOT_PACKAGE_JSON="$TESTS_DIR/../../package.json"
 TEST_DIR="$(mktemp -d)"
 trap 'rm -rf -- "$TEST_DIR"' EXIT
 
@@ -117,5 +118,14 @@ done
 if grep -Eq 'git (fetch|reset)|infra/(install|update|upgrade-workspaces)[.]sh|FORCE_REBUILD_BASE_IMAGE|apt-get' "$DEPLOY_LOCAL_SCRIPT"; then
     fail "deploy-local.sh changes the installed checkout, host, or workspaces"
 fi
+for package_contract in \
+    '"qa:install": "bash infra/qa/install.sh"' \
+    '"qa:update": "bash infra/qa/update.sh"' \
+    '"qa:deploy-app": "bash infra/qa/deploy-app.sh"' \
+    '"qa:deploy-local": "bash infra/qa/deploy-local.sh"' \
+    '"qa:test": "bash infra/tests/qa-scripts-test.sh"'; do
+    grep -Fq "$package_contract" "$ROOT_PACKAGE_JSON" || \
+        fail "root package is missing QA command: $package_contract"
+done
 
 echo "QA install/update/app-deploy/local-deploy script tests passed"

--- a/infra/tests/qa-scripts-test.sh
+++ b/infra/tests/qa-scripts-test.sh
@@ -119,10 +119,10 @@ if grep -Eq 'git (fetch|reset)|infra/(install|update|upgrade-workspaces)[.]sh|FO
     fail "deploy-local.sh changes the installed checkout, host, or workspaces"
 fi
 for package_contract in \
-    '"qa:install": "bash infra/qa/install.sh"' \
-    '"qa:update": "bash infra/qa/update.sh"' \
-    '"qa:deploy-app": "bash infra/qa/deploy-app.sh"' \
-    '"qa:deploy-local": "bash infra/qa/deploy-local.sh"' \
+    '"qa:install": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/install.sh"' \
+    '"qa:update": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/update.sh"' \
+    '"qa:deploy-app": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/deploy-app.sh"' \
+    '"qa:deploy-local": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/deploy-local.sh"' \
     '"qa:test": "bash infra/tests/qa-scripts-test.sh"'; do
     grep -Fq "$package_contract" "$ROOT_PACKAGE_JSON" || \
         fail "root package is missing QA command: $package_contract"

--- a/infra/tests/release-version-test.sh
+++ b/infra/tests/release-version-test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=../lib/release-version.sh
+. "$TESTS_DIR/../lib/release-version.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_kind() {
+    local current="$1" target="$2" want="$3" got
+    got="$(release_update_kind "$current" "$target")"
+    [ "$got" = "$want" ] || fail "$current -> $target = $got, want $want"
+}
+
+assert_kind 0.3.1 0.3.2 application
+assert_kind 0.3.1 0.3.1.1 application
+assert_kind v0.3.1 v0.3.2 application
+assert_kind 0.3.1 0.4.0 infrastructure
+assert_kind 0.3.1 0.4.2 infrastructure
+assert_kind 0.4.0 0.4.2 application
+assert_kind 1.9.5 2.0.0 infrastructure
+assert_kind 0.3 0.3.1 infrastructure
+assert_kind dev 0.3.2 infrastructure
+assert_kind 0.3.1 candidate infrastructure
+
+echo "Release version tests passed"

--- a/infra/update.sh
+++ b/infra/update.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# remote.futrx — one-command update for an installed box.
+# remote.futrx — full infrastructure update for an installed box.
+#
+# Use this when a release crosses a MAJOR or MINOR boundary, or when an
+# operator intentionally needs to converge/repair host infrastructure. A
+# same-major/minor PATCH release should normally use Settings -> Updates or
+# infra/deploy-app.sh instead.
 #
 # The updater deliberately pulls and re-executes itself before doing any
 # convergence. That guarantees newly committed toolchain and agent CLI pins
@@ -11,18 +16,29 @@
 #   2. Converge host dependencies and all host agent CLIs.
 #   3. Build and restart the application.
 #   4. Rebuild the base image with the pinned agent CLIs.
-#   5. Recycle idle workspaces onto the new image (busy ones are skipped).
+#   5. Recycle eligible workspaces onto the new image.
+#
+# Workspace replacement is disruptive. The default upgrader intends to skip
+# containers with an active agent process, but busy-process detection is
+# best-effort; coordinate a maintenance window. Use --skip-workspaces when
+# project containers must remain untouched.
 #
 # Usage:
 #   sudo bash /opt/remote.futrx/infra/update.sh
-#   sudo bash /opt/remote.futrx/infra/update.sh <hostname>
-#   sudo bash /opt/remote.futrx/infra/update.sh --include-busy
+#   sudo bash /opt/remote.futrx/infra/update.sh --ref=<release-tag>
+#   sudo bash /opt/remote.futrx/infra/update.sh <hostname> [flags]
 #
 # Flags:
 #   --include-busy     also recycle workspaces with an active agent process
-#   --ref=<ref>        update to a release tag (or any ref) instead of origin/main
-#   --skip-workspaces  update the host/application without rebuilding the base
-#                      image or recycling workspace containers
+#   --ref=<ref>        select a release tag or Git ref resolvable after fetching
+#                      origin; the in-app updater supplies a release tag
+#   --skip-workspaces  do not force-rebuild an existing base image or recycle
+#                      project containers; host dependencies/configuration and
+#                      the application are still fully converged
+#
+# With no hostname, the script reads it from the installed systemd unit.
+# Test/QA overrides: FUTRX_INSTALL_DIR, FUTRX_LEGACY_INSTALL_DIR,
+# FUTRX_SERVICE_UNIT_PATH, and FUTRX_LEGACY_SERVICE_UNIT_PATH.
 set -euo pipefail
 
 INSTALL_DIR="${FUTRX_INSTALL_DIR:-/opt/remote.futrx}"
@@ -31,7 +47,7 @@ UNIT="${FUTRX_SERVICE_UNIT_PATH:-/etc/systemd/system/remote.futrx.service}"
 LEGACY_UNIT="${FUTRX_LEGACY_SERVICE_UNIT_PATH:-/etc/systemd/system/remote.futrx.dev.service}"
 
 usage() {
-    sed -n '2,25s/^# \{0,1\}//p' "$0"
+    sed -n '2,/^set -euo pipefail$/ { /^set -euo pipefail$/d; s/^# \{0,1\}//p; }' "$0"
 }
 
 HOSTNAME=""

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build:frontend": "cd /opt/remote.futrx/frontend && npm install && npm run build",
-    "build:backend": "cd ../backend && go build -trimpath -o /opt/remote.futrx/backend/remote ./cmd/remote",
+    "build:backend": "cd /opt/remote.futrx/backend && go build -trimpath -o /opt/remote.futrx/backend/remote ./cmd/remote",
     "service:restart": "systemctl restart remote.futrx.service",
     "build": "npm run build:frontend && npm run build:backend && npm run service:restart"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "remote.futrx-web",
+  "version": "0.3.2",
+  "private": true,
+  "scripts": {
+    "build:frontend": "cd /opt/remote.futrx/frontend && npm install && npm run build",
+    "build:backend": "cd ../backend && go build -trimpath -o /opt/remote.futrx/backend/remote ./cmd/remote",
+    "service:restart": "systemctl restart remote.futrx.service",
+    "build": "npm run build:frontend && npm run build:backend && npm run service:restart"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.4.0",
   "private": true,
   "scripts": {
-    "qa:install": "bash infra/qa/install.sh",
-    "qa:update": "bash infra/qa/update.sh",
-    "qa:deploy-app": "bash infra/qa/deploy-app.sh",
-    "qa:deploy-local": "bash infra/qa/deploy-local.sh",
+    "qa:install": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/install.sh",
+    "qa:update": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/update.sh",
+    "qa:deploy-app": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/deploy-app.sh",
+    "qa:deploy-local": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/deploy-local.sh",
     "qa:test": "bash infra/tests/qa-scripts-test.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "remote.futrx-web",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
-    "build:frontend": "cd /opt/remote.futrx/frontend && npm install && npm run build",
-    "build:backend": "cd /opt/remote.futrx/backend && go build -trimpath -o /opt/remote.futrx/backend/remote ./cmd/remote",
-    "service:restart": "systemctl restart remote.futrx.service",
-    "build": "npm run build:frontend && npm run build:backend && npm run service:restart"
+    "qa:install": "bash infra/qa/install.sh",
+    "qa:update": "bash infra/qa/update.sh",
+    "qa:deploy-app": "bash infra/qa/deploy-app.sh",
+    "qa:deploy-local": "bash infra/qa/deploy-local.sh",
+    "qa:test": "bash infra/tests/qa-scripts-test.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "remote.futrx-web",
+  "name": "remote.futrx",
   "version": "0.4.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Release `0.4.0` introduces separate application and infrastructure update paths.

- Same `MAJOR.MINOR` upgrades deploy only the frontend/backend application.
- Cross-major or cross-minor upgrades run the complete infrastructure updater.
- Skipped infrastructure releases remain safe: `0.3.1 → 0.4.2` still performs a full update.
- Settings displays the update type and its expected impact before installation.