### PR TITLE
Import project from public repo 

### DIFF
--- a/backend/internal/config/containers.go
+++ b/backend/internal/config/containers.go
@@ -18,6 +18,7 @@ import (
 	containerruntimeassets "github.com/futrx-com/remote.futrx.com/internal/integration/containers/runtimeassets"
 	containerscheduletools "github.com/futrx-com/remote.futrx.com/internal/integration/containers/scheduletools"
 	containerworkspace "github.com/futrx-com/remote.futrx.com/internal/integration/containers/workspace"
+	"github.com/futrx-com/remote.futrx.com/internal/integration/gitcli"
 	"github.com/futrx-com/remote.futrx.com/internal/integration/hostfs"
 	servicebrowser "github.com/futrx-com/remote.futrx.com/internal/service/container/browser"
 	servicecli "github.com/futrx-com/remote.futrx.com/internal/service/container/cli"
@@ -135,6 +136,7 @@ func NewContainerStack(
 		resources,
 		launchProvisioner,
 		profiles,
+		gitcli.NewCloner(),
 	)
 	inspectionAdapter := containerinspection.NewAdapter(
 		runner,

--- a/backend/internal/integration/gitcli/clone.go
+++ b/backend/internal/integration/gitcli/clone.go
@@ -1,0 +1,58 @@
+package gitcli
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const cloneTimeout = 10 * time.Minute
+
+// ErrCloneFailed is returned for any clone failure. The underlying git output
+// is logged server-side only; it is never safe to surface verbatim to a
+// client since git's own error text for a private repo is indistinguishable
+// from a typo or an unreachable host.
+var ErrCloneFailed = errors.New(
+	"couldn't clone the repository — check the URL is public and reachable; " +
+		"to import a private repo, create the project first and clone it via the Terminal",
+)
+
+// Cloner seeds a new, host-side project workspace directory by cloning a
+// public git repository into it.
+type Cloner struct{}
+
+func NewCloner() *Cloner {
+	return &Cloner{}
+}
+
+// Clone clones url into dest. dest must already exist (created by the
+// caller's workspace preparation step). If dest already contains entries,
+// Clone assumes the workspace was already seeded by an earlier provisioning
+// pass (e.g. a container recreated for an existing project) and does
+// nothing — this makes Clone safe to call on every provisioning pass rather
+// than only on first-ever creation.
+func (c *Cloner) Clone(ctx context.Context, url, dest string) error {
+	entries, err := os.ReadDir(dest)
+	if err != nil {
+		return err
+	}
+	if len(entries) > 0 {
+		return nil
+	}
+
+	cloneCtx, cancel := context.WithTimeout(ctx, cloneTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(cloneCtx, "git", "clone", "--", url, dest)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("gitcli: clone %s failed: %v: %s", url, err, strings.TrimSpace(string(output)))
+		return ErrCloneFailed
+	}
+	return nil
+}

--- a/backend/internal/integration/gitcli/clone_test.go
+++ b/backend/internal/integration/gitcli/clone_test.go
@@ -1,0 +1,72 @@
+package gitcli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func newFixtureRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	run("-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-q", "-m", "init")
+	return dir
+}
+
+func TestCloneIntoEmptyDestination(t *testing.T) {
+	source := newFixtureRepo(t)
+	dest := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewCloner().Clone(context.Background(), source, dest); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, ".git")); err != nil {
+		t.Fatalf("cloned repo missing .git: %v", err)
+	}
+}
+
+func TestCloneSkipsAnAlreadySeededDestination(t *testing.T) {
+	source := newFixtureRepo(t)
+	dest := t.TempDir()
+	marker := filepath.Join(dest, "keep-me.txt")
+	if err := os.WriteFile(marker, []byte("existing work"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewCloner().Clone(context.Background(), source, dest); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, ".git")); err == nil {
+		t.Fatal("cloned into a non-empty destination")
+	}
+	if data, err := os.ReadFile(marker); err != nil || string(data) != "existing work" {
+		t.Fatalf("existing content was disturbed: %q, %v", data, err)
+	}
+}
+
+func TestCloneReturnsCleanErrorOnFailure(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := NewCloner().Clone(context.Background(), filepath.Join(t.TempDir(), "does-not-exist"), dest)
+	if !errors.Is(err, ErrCloneFailed) {
+		t.Fatalf("error = %v, want %v", err, ErrCloneFailed)
+	}
+}

--- a/backend/internal/service/container/lifecycle/service.go
+++ b/backend/internal/service/container/lifecycle/service.go
@@ -43,6 +43,14 @@ type WorkspacePreparer interface {
 	Prepare(path string) error
 }
 
+// RepositoryCloner seeds a freshly-prepared, empty workspace directory from a
+// git URL. Implementations must be safe to call against an already-seeded
+// (non-empty) directory: they should no-op rather than fail, since Ensure
+// re-clones on every provisioning pass, not only the first.
+type RepositoryCloner interface {
+	Clone(ctx context.Context, url, dest string) error
+}
+
 type ResourceEnsurer interface {
 	Ensure(ctx context.Context, containerName string) error
 	SetLimits(ctx context.Context, containerName, cpu, memory, disk string) error
@@ -63,6 +71,7 @@ type Service struct {
 	resources   ResourceEnsurer
 	provisioner LaunchProvisioner
 	profiles    ProfileSource
+	cloner      RepositoryCloner
 }
 
 func NewService(
@@ -72,6 +81,7 @@ func NewService(
 	resources ResourceEnsurer,
 	provisioner LaunchProvisioner,
 	profiles ProfileSource,
+	cloner RepositoryCloner,
 ) *Service {
 	return &Service{
 		runtime:     runtime,
@@ -80,6 +90,7 @@ func NewService(
 		resources:   resources,
 		provisioner: provisioner,
 		profiles:    profiles,
+		cloner:      cloner,
 	}
 }
 
@@ -125,6 +136,16 @@ func (s *Service) Ensure(ctx context.Context, project serviceproject.Meta) error
 	if created {
 		if err := s.workspace.Prepare(project.Cwd); err != nil {
 			return err
+		}
+		if project.GitURL != "" {
+			if err := s.cloner.Clone(ctx, project.GitURL, project.Cwd); err != nil {
+				return err
+			}
+			// Re-chown: the clone ran as the backend process's own uid, not
+			// the container's unprivileged idmap uid/gid.
+			if err := s.workspace.Prepare(project.Cwd); err != nil {
+				return err
+			}
 		}
 		if err := s.preparePrivateDirectory(agentRoot); err != nil {
 			return fmt.Errorf("prepare agent home: %w", err)

--- a/backend/internal/service/container/lifecycle/service_test.go
+++ b/backend/internal/service/container/lifecycle/service_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
@@ -131,6 +132,16 @@ func (r recordingResources) SetLimits(_ context.Context, container, cpu, memory,
 	return nil
 }
 
+type recordingCloner struct {
+	events *[]string
+	err    error
+}
+
+func (c recordingCloner) Clone(_ context.Context, url, dest string) error {
+	*c.events = append(*c.events, "clone "+url+" "+dest)
+	return c.err
+}
+
 type recordingProvisioner struct{ events *[]string }
 
 func (p recordingProvisioner) Provision(_ context.Context, container, name string) {
@@ -158,6 +169,10 @@ func testProject(t *testing.T) serviceproject.Meta {
 }
 
 func newTestService(runtime *recordingRuntime, events *[]string) *Service {
+	return newTestServiceWithCloner(runtime, events, recordingCloner{events: events})
+}
+
+func newTestServiceWithCloner(runtime *recordingRuntime, events *[]string, cloner RepositoryCloner) *Service {
 	return NewService(
 		runtime,
 		"local:remote-base",
@@ -165,6 +180,7 @@ func newTestService(runtime *recordingRuntime, events *[]string) *Service {
 		recordingResources{events: events},
 		recordingProvisioner{events: events},
 		testProfileSource{},
+		cloner,
 	)
 }
 
@@ -370,5 +386,74 @@ func TestEnsureReportsProvisioningAndRollbackFailures(t *testing.T) {
 	err := newTestService(runtime, &events).Ensure(context.Background(), testProject(t))
 	if !errors.Is(err, attachErr) || !errors.Is(err, deleteErr) {
 		t.Fatalf("error = %v, want joined attachment and rollback failures", err)
+	}
+}
+
+func TestEnsureClonesGitURLIntoNewWorkspaceThenRechownsIt(t *testing.T) {
+	var events []string
+	runtime := &recordingRuntime{events: &events, available: true, state: serviceproject.ContainerStateMissing}
+	project := testProject(t)
+	project.GitURL = "https://example.com/octocat/hello-world.git"
+
+	if err := newTestServiceWithCloner(runtime, &events, recordingCloner{events: &events}).
+		Ensure(context.Background(), project); err != nil {
+		t.Fatal(err)
+	}
+
+	prepareAt := slices.Index(events, "prepare "+project.Cwd)
+	cloneAt := slices.Index(events, "clone "+project.GitURL+" "+project.Cwd)
+	rechownAt := slices.Index(events[cloneAt+1:], "prepare "+project.Cwd)
+	if prepareAt < 0 || cloneAt < prepareAt || rechownAt < 0 {
+		t.Fatalf("workspace was not prepared, cloned, then re-chowned: %q", events)
+	}
+}
+
+func TestEnsureDoesNotCloneWithoutAGitURL(t *testing.T) {
+	var events []string
+	runtime := &recordingRuntime{events: &events, available: true, state: serviceproject.ContainerStateMissing}
+
+	if err := newTestService(runtime, &events).Ensure(context.Background(), testProject(t)); err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if strings.HasPrefix(event, "clone ") {
+			t.Fatalf("cloned without a git url: %q", events)
+		}
+	}
+}
+
+func TestEnsureDoesNotCloneAnAlreadyProvisionedContainer(t *testing.T) {
+	var events []string
+	project := testProject(t)
+	project.GitURL = "https://example.com/octocat/hello-world.git"
+	runtime := &recordingRuntime{
+		events: &events, available: true, state: serviceproject.ContainerStateRunning,
+		devices: expectedDisks(project),
+	}
+
+	if err := newTestService(runtime, &events).Ensure(context.Background(), project); err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if strings.HasPrefix(event, "clone ") {
+			t.Fatalf("cloned into an already-running container: %q", events)
+		}
+	}
+}
+
+func TestEnsurePropagatesCloneFailureBeforeInitializingTheContainer(t *testing.T) {
+	var events []string
+	cloneErr := errors.New("clone failed")
+	runtime := &recordingRuntime{events: &events, available: true, state: serviceproject.ContainerStateMissing}
+	project := testProject(t)
+	project.GitURL = "https://example.com/octocat/hello-world.git"
+
+	err := newTestServiceWithCloner(runtime, &events, recordingCloner{events: &events, err: cloneErr}).
+		Ensure(context.Background(), project)
+	if !errors.Is(err, cloneErr) {
+		t.Fatalf("error = %v, want %v", err, cloneErr)
+	}
+	if slices.ContainsFunc(events, func(e string) bool { return strings.HasPrefix(e, "runtime init") }) {
+		t.Fatalf("container was initialized despite a clone failure: %q", events)
 	}
 }

--- a/backend/internal/service/project/errors.go
+++ b/backend/internal/service/project/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrInvalidSecretKey   = errors.New("invalid secret key (must match [A-Za-z_][A-Za-z0-9_]*)")
 	ErrInvalidLimits      = errors.New("invalid container resource limits")
 	ErrSecretsUnavailable = errors.New("secrets store is not configured")
+	ErrInvalidGitURL      = errors.New("invalid git repository url — only public https:// urls are supported")
 )

--- a/backend/internal/service/project/giturl.go
+++ b/backend/internal/service/project/giturl.go
@@ -1,0 +1,18 @@
+package project
+
+import "net/url"
+
+// ValidGitURL reports whether s is an acceptable repository URL to clone
+// from on project creation. An empty string is valid — the field is
+// optional. Only plain public https:// URLs are accepted for now: no
+// ssh://, no git@host: shorthand, no file:// or other local paths.
+func ValidGitURL(s string) bool {
+	if s == "" {
+		return true
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "https" && u.Host != ""
+}

--- a/backend/internal/service/project/model.go
+++ b/backend/internal/service/project/model.go
@@ -40,12 +40,14 @@ type Meta struct {
 	ResourceLimits *ContainerLimits `json:"resourceLimits,omitempty"`
 	Order          int64            `json:"order,omitempty"`
 	ErrorMsg       string           `json:"errorMsg,omitempty"`
+	GitURL         string           `json:"gitUrl,omitempty"`
 	CreatedAt      int64            `json:"createdAt"`
 	UpdatedAt      int64            `json:"updatedAt"`
 }
 
 type CreateInput struct {
-	Name string `json:"name"`
+	Name   string `json:"name"`
+	GitURL string `json:"gitUrl,omitempty"`
 }
 
 type UpdateInput struct {

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -136,11 +136,16 @@ func (s *Service) Create(ctx context.Context, in CreateInput, callerEmail string
 	if name == "" {
 		return Meta{}, ErrNameRequired
 	}
+	gitURL := strings.TrimSpace(in.GitURL)
+	if !ValidGitURL(gitURL) {
+		return Meta{}, ErrInvalidGitURL
+	}
 
 	m, err := s.repo.Create(ctx, Meta{
 		Name:   name,
 		Slug:   Slugify(name),
 		Status: StatusProvisioning,
+		GitURL: gitURL,
 	})
 	if err != nil {
 		return Meta{}, err

--- a/backend/internal/service/project/service_create_test.go
+++ b/backend/internal/service/project/service_create_test.go
@@ -1,0 +1,48 @@
+package project
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestCreatePassesGitURLThroughToContainerEnsure(t *testing.T) {
+	repo := &startTestRepository{}
+	lifecycle := &startTestLifecycle{state: ContainerStateMissing}
+	service := New(repo, ContainerDependencies{Lifecycle: lifecycle}, nil, nil)
+
+	gitURL := "https://example.com/octocat/hello-world.git"
+	got, err := service.Create(context.Background(), CreateInput{Name: "hello world", GitURL: gitURL}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.GitURL != gitURL {
+		t.Fatalf("Create() meta.GitURL = %q, want %q", got.GitURL, gitURL)
+	}
+	if lifecycle.lastEnsured.GitURL != gitURL {
+		t.Fatalf("Ensure() was called with GitURL = %q, want %q", lifecycle.lastEnsured.GitURL, gitURL)
+	}
+}
+
+func TestCreateRejectsInvalidGitURLBeforeProvisioning(t *testing.T) {
+	repo := &startTestRepository{}
+	lifecycle := &startTestLifecycle{state: ContainerStateMissing}
+	service := New(repo, ContainerDependencies{Lifecycle: lifecycle}, nil, nil)
+
+	for name, url := range map[string]string{
+		"ssh shorthand": "git@github.com:octocat/hello-world.git",
+		"ssh scheme":    "ssh://git@github.com/octocat/hello-world.git",
+		"plain http":    "http://example.com/octocat/hello-world.git",
+		"garbage":       "not a url",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := service.Create(context.Background(), CreateInput{Name: "hello world", GitURL: url}, "")
+			if !errors.Is(err, ErrInvalidGitURL) {
+				t.Fatalf("Create() error = %v, want %v", err, ErrInvalidGitURL)
+			}
+		})
+	}
+	if lifecycle.launchCalls != 0 {
+		t.Fatalf("Ensure() was called %d times for invalid input, want 0", lifecycle.launchCalls)
+	}
+}

--- a/backend/internal/service/project/service_start_test.go
+++ b/backend/internal/service/project/service_start_test.go
@@ -279,6 +279,7 @@ type startTestLifecycle struct {
 	state           ContainerState
 	launchErr       error
 	launchCalls     int
+	lastEnsured     Meta
 	startCalls      int
 	restartCalls    int
 	launchStarted   chan struct{}
@@ -295,9 +296,10 @@ func (l *startTestLifecycle) State(context.Context, string) (ContainerState, err
 	return l.state, nil
 }
 
-func (l *startTestLifecycle) Ensure(context.Context, Meta) error {
+func (l *startTestLifecycle) Ensure(_ context.Context, project Meta) error {
 	l.mu.Lock()
 	l.launchCalls++
+	l.lastEnsured = project
 	launchErr := l.launchErr
 	launchStarted := l.launchStarted
 	releaseLaunch := l.releaseLaunch

--- a/backend/internal/transport/http/handlers/project_handler.go
+++ b/backend/internal/transport/http/handlers/project_handler.go
@@ -658,7 +658,8 @@ func sendProjectError(w http.ResponseWriter, err error) {
 	case errors.Is(err, serviceproject.ErrNameRequired),
 		errors.Is(err, serviceproject.ErrInvalidID),
 		errors.Is(err, serviceproject.ErrInvalidSecretKey),
-		errors.Is(err, serviceproject.ErrInvalidLimits):
+		errors.Is(err, serviceproject.ErrInvalidLimits),
+		errors.Is(err, serviceproject.ErrInvalidGitURL):
 		httptransport.SendErr(w, http.StatusBadRequest, err.Error())
 	case errors.Is(err, serviceproject.ErrSecretsUnavailable):
 		httptransport.SendErr(w, http.StatusServiceUnavailable, err.Error())

--- a/docs/02-user-guide/02-projects-and-sidebar.md
+++ b/docs/02-user-guide/02-projects-and-sidebar.md
@@ -11,9 +11,12 @@ agents, terminals, the IDE, browsers, and development processes run.
 2. Enter a name in the **New project** modal. It validates the display name and
    previews the normalized slug, workspace path, and container name before any
    request is sent.
-3. Select **Create project**.
-4. Keep the modal open while it reports container provisioning progress.
-5. When provisioning finishes, select **New chat in this project** or expand
+3. Optionally expand **Import from a Git URL** and paste a public `https://`
+   repository URL to seed the new workspace by cloning it, instead of starting
+   empty.
+4. Select **Create project**.
+5. Keep the modal open while it reports container provisioning progress.
+6. When provisioning finishes, select **New chat in this project** or expand
    the project and select **New chat**.
 
 ![Creating a project from the workspace](/assets/docs/screenshots/create-project.webp)
@@ -24,6 +27,16 @@ server's development image. A display name already in use is rejected even if
 case or surrounding whitespace differs. Two genuinely different names that
 normalize to the same slug remain valid; later projects receive a numeric slug
 suffix such as `-2`.
+
+**Git import** only supports plain public `https://` repositories — no
+`ssh://`, no `git@host:` shorthand, and no credentials, so a private repo URL
+fails fast with a clear error instead of hanging or prompting for a password.
+To seed a project from a private repo, create it without a Git URL and clone
+it yourself from the project **Terminal** using your own git credentials.
+A clone failure (bad URL, unreachable host, private repo) surfaces as a
+project provisioning error the same way a container failure would; the
+project itself is still created and can be retried or used with an empty
+workspace.
 
 The new-chat control is disabled and shows a spinner while the project is still
 provisioning. If provisioning fails, the sidebar displays the project error.

--- a/docs/02-workspaces/03-projects-and-containers.md
+++ b/docs/02-workspaces/03-projects-and-containers.md
@@ -17,10 +17,13 @@ sequenceDiagram
     participant LXD
     participant Provision as Launch provisioners
 
-    User->>API: Create project with a name
+    User->>API: Create project with a name (and optional Git URL)
     API->>Store: Create ID, unique slug, metadata
     API->>Access: Add creator as a member
     API->>Files: Prepare durable workspace and agent-home directories
+    opt Git URL given and workspace empty
+        API->>Files: Clone repository into the workspace, then re-chown it
+    end
     API->>LXD: Launch from futrx-remote-dev-base
     LXD->>LXD: Attach workspace and provider homes
     API->>Provision: Credentials, skills, browser assets, code-server
@@ -32,6 +35,17 @@ The slug becomes the container name and is used in IDE and preview hostnames.
 Display names are unique case-insensitively after trimming whitespace; create
 and rename reject a duplicate with `409 Conflict`. Distinct display names that
 normalize to the same slug receive `-2`, `-3`, and later suffixes.
+
+An optional Git URL seeds the new workspace by cloning it on the host, the
+same way [Git history](05-workspace-tools.md) reads repositories — a plain
+`git clone` against the host-side workspace directory, not an in-container
+operation. Only public `https://` URLs are accepted; there is no managed
+credential path, so a private repo fails fast (`GIT_TERMINAL_PROMPT=0`
+prevents it from hanging on a password prompt) rather than being cloned.
+Cloning only ever runs against an **empty** workspace directory — it is a
+no-op if the directory already has content, which is what makes it safe to
+re-enter on every `Ensure` (a container recreated for workspace upgrades or
+recovery reuses the same already-populated directory, not a fresh clone).
 
 ## Durable and replaceable parts
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -51,6 +51,10 @@ These are the constraints worth understanding before you deploy or rely on remot
 - **The per-project IDE is reachable by any invited user.** `<slug>.code.<host>` authenticates the registered user but does **not** check project membership, so any invited user can open any project's code editor. This is documented in [`docs/02-workspaces/02-auth-users-and-access.md`](02-workspaces/02-auth-users-and-access.md) and analyzed in the [threat model](threat-model.md).
 - **No public/anonymous sharing.** Every preview URL sits behind the platform session, so showing a prototype to an outside stakeholder means inviting them as a user first.
 
+## Projects
+
+- **Git import on project creation is public-repo-only.** Seeding a new project's workspace from a Git URL only accepts plain `https://` URLs with no credentials — no `ssh://`, no `git@host:` shorthand, no stored token or deploy key. A private repo fails fast at clone time instead of prompting for auth. Import it after creation instead, by cloning it yourself from the project **Terminal** with your own git credentials. *(`backend/internal/integration/gitcli/clone.go`, `backend/internal/service/project/giturl.go`)*
+
 ## Agents
 
 - **Agent modules are compiled in, not runtime plugins.** Each provider package

--- a/frontend/src/api/projectApi.ts
+++ b/frontend/src/api/projectApi.ts
@@ -8,8 +8,8 @@ import { API_ROUTES } from "../config/routes";
 
 export const projectApi = {
   list: () => requestJson<ProjectMeta[]>("GET", API_ROUTES.projects.collection),
-  create: (name: string) =>
-    requestJson<ProjectMeta>("POST", API_ROUTES.projects.collection, { name }),
+  create: (name: string, gitUrl?: string) =>
+    requestJson<ProjectMeta>("POST", API_ROUTES.projects.collection, { name, gitUrl }),
   fetch: (id: string) =>
     requestJson<ProjectMeta>("GET", API_ROUTES.projects.item(id)),
   update: (id: string, body: { name?: string }) =>

--- a/frontend/src/models/project.ts
+++ b/frontend/src/models/project.ts
@@ -22,6 +22,7 @@ export interface ProjectMeta {
   status: ProjectStatus;
   order?: number;
   errorMsg?: string;
+  gitUrl?: string;
   resourceLimits?: ContainerLimits;
   createdAt: number;
   updatedAt: number;

--- a/frontend/src/state/context/WorkspaceContext.tsx
+++ b/frontend/src/state/context/WorkspaceContext.tsx
@@ -32,7 +32,7 @@ interface WorkspaceContextValue {
   showProjectContainers: (projectId: string | null) => void;
   openCreateProject: () => void;
   closeCreateProject: () => void;
-  createProject: (name: string) => Promise<ProjectMeta>;
+  createProject: (name: string, gitUrl?: string) => Promise<ProjectMeta>;
   createChat: (projectId?: string) => Promise<ChatMeta>;
   deleteChat: (chatId: string) => Promise<void>;
   forkChat: (chatId: string) => Promise<ChatMeta>;
@@ -77,8 +77,8 @@ export function WorkspaceProvider({
     return chat;
   }, [data.seedChat]);
 
-  const createProject = useCallback(async (name: string): Promise<ProjectMeta> => {
-    const project = await projectApi.create(name);
+  const createProject = useCallback(async (name: string, gitUrl?: string): Promise<ProjectMeta> => {
+    const project = await projectApi.create(name, gitUrl);
     return project;
   }, []);
 

--- a/frontend/src/ui/projects/CreateProjectModal.tsx
+++ b/frontend/src/ui/projects/CreateProjectModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "preact/hooks";
 import type { ProjectMeta } from "../../models/project";
 import { PROJECT_MAX_SLUG_LEN } from "../../config/project";
 import { createProjectForm } from "./createProjectForm";
-import { Loader, X } from "../primitives/icons";
+import { ChevronDown, ChevronRight, GitFork, Loader, X } from "../primitives/icons";
 
 const MAX_NAME_LEN = 40;
 
@@ -15,12 +15,15 @@ export function CreateProjectModal({
   open: boolean;
   projects: ProjectMeta[];
   onClose: () => void;
-  onCreate: (name: string) => Promise<unknown>;
+  onCreate: (name: string, gitUrl?: string) => Promise<unknown>;
 }) {
   const [name, setName] = useState("");
   const [touched, setTouched] = useState(false);
   const [creating, setCreating] = useState(false);
   const [submitError, setSubmitError] = useState("");
+  const [gitImportOpen, setGitImportOpen] = useState(false);
+  const [gitUrl, setGitUrl] = useState("");
+  const [gitUrlTouched, setGitUrlTouched] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -29,6 +32,9 @@ export function CreateProjectModal({
     setTouched(false);
     setCreating(false);
     setSubmitError("");
+    setGitImportOpen(false);
+    setGitUrl("");
+    setGitUrlTouched(false);
     // Focus after the pop animation has started so the browser doesn't
     // scroll a half-positioned card into view.
     const timer = setTimeout(() => inputRef.current?.focus(), 60);
@@ -63,7 +69,11 @@ export function CreateProjectModal({
       || (touched && !validation.ok ? validation.message : "")
       || validation.message
       || "Lowercase letters, numbers and dashes.";
-  const canSubmit = validation.ok && !creating;
+
+  const gitValidation = createProjectForm.validateGitUrl(gitUrl);
+  const showGitError = !creating && gitUrlTouched && !gitValidation.ok;
+
+  const canSubmit = validation.ok && gitValidation.ok && !creating;
 
   function close() {
     if (!creating) onClose();
@@ -74,7 +84,7 @@ export function CreateProjectModal({
     setCreating(true);
     setSubmitError("");
     try {
-      await onCreate(name.trim());
+      await onCreate(name.trim(), gitUrl.trim() || undefined);
       onClose();
     } catch (error) {
       setSubmitError("Create failed: " + (error as Error).message);
@@ -100,7 +110,7 @@ export function CreateProjectModal({
               New project
             </div>
             <div class="text-[12.5px] text-ink-300">
-              Creates a workspace container and clones nothing yet.
+              Creates a workspace container, optionally seeded from a Git repository.
             </div>
           </div>
           <button
@@ -153,6 +163,46 @@ export function CreateProjectModal({
             </div>
           </div>
 
+          <div class="flex flex-col gap-[7px]">
+            <button
+              type="button"
+              onClick={() => setGitImportOpen((v) => !v)}
+              disabled={creating}
+              class="flex items-center gap-1.5 self-start text-xs text-ink-300 transition-colors hover:text-ink-100"
+            >
+              {gitImportOpen ? <ChevronDown class="h-3.5 w-3.5" /> : <ChevronRight class="h-3.5 w-3.5" />}
+              <GitFork class="h-3.5 w-3.5" />
+              Import from a Git URL
+            </button>
+            {gitImportOpen && (
+              <>
+                <input
+                  value={gitUrl}
+                  onInput={(event) => {
+                    setGitUrl((event.target as HTMLInputElement).value);
+                    setGitUrlTouched(true);
+                    setSubmitError("");
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") void submit();
+                  }}
+                  placeholder="https://github.com/owner/repo.git"
+                  autocomplete="off"
+                  spellcheck={false}
+                  disabled={creating}
+                  class={`theme-submenu-surface w-full rounded-[9px] border bg-raised px-3 py-2.5 font-mono text-sm text-ink-100 outline-none transition-[border-color,box-shadow] duration-150 ${
+                    showGitError
+                      ? "border-accent-red/60 shadow-[0_0_0_3px_rgba(255,123,114,.12)]"
+                      : "border-line-strong"
+                  }`}
+                />
+                {showGitError && (
+                  <div class="text-xs text-accent-red">{gitValidation.message}</div>
+                )}
+              </>
+            )}
+          </div>
+
           <div class="flex flex-col gap-2 rounded-[10px] border border-line bg-tint px-3.5 py-3">
             <div class="flex items-baseline justify-between gap-3">
               <span class="text-xs text-ink-300">Container</span>
@@ -178,7 +228,7 @@ export function CreateProjectModal({
             onClick={() => void submit()}
             disabled={!canSubmit}
             class={`inline-flex items-center gap-[7px] rounded-lg border border-transparent px-[15px] py-2 text-[13px] font-medium transition-colors ${
-              validation.ok
+              canSubmit || creating
                 ? "bg-accent-blue text-ink-900"
                 : "cursor-not-allowed bg-tint-strong text-ink-400"
             } ${creating ? "opacity-80" : ""}`}

--- a/frontend/src/ui/projects/createProjectForm.test.ts
+++ b/frontend/src/ui/projects/createProjectForm.test.ts
@@ -81,6 +81,35 @@ test("validate truncates a taken maximum-length slug before adding its suffix", 
   });
 });
 
+test("validateGitUrl accepts an empty url and public https urls", () => {
+  assert.deepEqual(createProjectForm.validateGitUrl(""), { ok: true, message: "" });
+  assert.deepEqual(createProjectForm.validateGitUrl("   "), { ok: true, message: "" });
+  assert.deepEqual(
+    createProjectForm.validateGitUrl("https://github.com/octocat/hello-world.git"),
+    { ok: true, message: "" }
+  );
+});
+
+test("validateGitUrl rejects non-https and unparseable urls", () => {
+  const wantMessage = "Use a public https:// repository URL.";
+  assert.deepEqual(createProjectForm.validateGitUrl("http://github.com/octocat/hello-world.git"), {
+    ok: false,
+    message: wantMessage,
+  });
+  assert.deepEqual(
+    createProjectForm.validateGitUrl("git@github.com:octocat/hello-world.git"),
+    { ok: false, message: wantMessage }
+  );
+  assert.deepEqual(
+    createProjectForm.validateGitUrl("ssh://git@github.com/octocat/hello-world.git"),
+    { ok: false, message: wantMessage }
+  );
+  assert.deepEqual(createProjectForm.validateGitUrl("not a url"), {
+    ok: false,
+    message: wantMessage,
+  });
+});
+
 test("pathPreview derives the workspace root from an existing project", () => {
   const projects = [
     project({ slug: "futrx-web", cwd: "/var/lib/remote/projects/futrx-web/workspace" }),

--- a/frontend/src/ui/projects/createProjectForm.ts
+++ b/frontend/src/ui/projects/createProjectForm.ts
@@ -1,6 +1,12 @@
 import { PROJECT_MAX_SLUG_LEN } from "../../config/project.ts";
 import type { CreateProjectValidation, ProjectMeta } from "../../models/project";
 
+export interface GitUrlValidation {
+  ok: boolean;
+  // Error text when ok is false; empty otherwise.
+  message: string;
+}
+
 class CreateProjectFormLogic {
   // Mirrors backend Slugify (service/project/slug.go), except the empty
   // result stays empty here so validation can reject symbol-only names
@@ -61,6 +67,24 @@ class CreateProjectFormLogic {
       return { ok: false, slug: base, message: "Could not find an available project name." };
     }
     return { ok: true, slug, message: slug !== trimmed ? `Saved as ${slug}` : "" };
+  }
+
+  // Mirrors backend ValidGitURL (service/project/giturl.go): empty is valid
+  // (the field is optional), otherwise only a plain public https:// URL is
+  // accepted — no ssh://, git@host: shorthand, or local paths.
+  validateGitUrl(url: string): GitUrlValidation {
+    const trimmed = url.trim();
+    if (!trimmed) return { ok: true, message: "" };
+    let parsed: URL;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      return { ok: false, message: "Use a public https:// repository URL." };
+    }
+    if (parsed.protocol !== "https:" || !parsed.host) {
+      return { ok: false, message: "Use a public https:// repository URL." };
+    }
+    return { ok: true, message: "" };
   }
 
   // A project's cwd is "<root>/<slug>/workspace"; borrow an existing


### PR DESCRIPTION
Lets you seed a new project from a public git repo instead of always
starting empty. On first provisioning it clones the url straight into
the workspace directory on the host, the same way Git History already
shells out to git, then re-chowns it for the container.

Kept auth out of scope for now only plain https:// urls, no
credentials. A private or bad url fails fast with a clean message
instead of hanging on a prompt or leaking raw git output back to the
client. Private repos still work fine today via the Terminal with your
own git credentials.

Re-running provisioning against an already-seeded workspace (container
recreate, upgrade) just no-ops instead of re-cloning.