### PR TITLE
fix(installer): handle non-main default branches

### DIFF
--- a/infra/install.sh
+++ b/infra/install.sh
@@ -90,7 +90,12 @@ if [ -z "$INFRA_DIR_PROBE" ] || [ ! -d "${INFRA_DIR_PROBE}/steps" ]; then
             else
                 # Existing shallow clones may follow a different default branch,
                 # so fetch main explicitly instead of relying on their refspec.
-                git -C "$LEGACY_TARGET" fetch --quiet --tags origin "$MAIN_REFSPEC"
+                # Persist that refspec too — otherwise remote.origin.fetch stays
+                # on the stale branch and a later plain `git fetch origin` (in
+                # update.sh, steps/00-checkout.sh, ...) silently stops refreshing
+                # origin/main.
+                git -C "$LEGACY_TARGET" config remote.origin.fetch "$MAIN_REFSPEC"
+                git -C "$LEGACY_TARGET" fetch --quiet --tags origin
                 git -C "$LEGACY_TARGET" reset --hard origin/main
             fi
             exec bash "$LEGACY_TARGET/infra/install.sh" "$@"
@@ -127,7 +132,12 @@ if [ -z "$INFRA_DIR_PROBE" ] || [ ! -d "${INFRA_DIR_PROBE}/steps" ]; then
             git -C "$TARGET" reset --hard "$BOOTSTRAP_REF"
         else
             echo "==> repo already at $TARGET, pulling latest"
-            git -C "$TARGET" fetch --quiet --tags origin "$MAIN_REFSPEC"
+            # Persist the main refspec (not just this one-off fetch) so later
+            # plain `git fetch origin` calls — update.sh, steps/00-checkout.sh —
+            # keep refreshing origin/main instead of silently going stale on a
+            # checkout whose remote.origin.fetch still points at another branch.
+            git -C "$TARGET" config remote.origin.fetch "$MAIN_REFSPEC"
+            git -C "$TARGET" fetch --quiet --tags origin
             git -C "$TARGET" reset --hard origin/main
         fi
     fi

--- a/infra/install.sh
+++ b/infra/install.sh
@@ -58,6 +58,7 @@ if [ -z "$INFRA_DIR_PROBE" ] || [ ! -d "${INFRA_DIR_PROBE}/steps" ]; then
 
     TARGET="${FUTRX_INSTALL_DIR:-/opt/remote.futrx}"
     LEGACY_TARGET="${FUTRX_LEGACY_INSTALL_DIR:-/opt/remote.futrx.dev}"
+    MAIN_REFSPEC="+refs/heads/main:refs/remotes/origin/main"
 
     # Parse bootstrap-only values before touching either checkout. The full
     # argument loop below parses them again after we re-exec from disk.
@@ -87,7 +88,9 @@ if [ -z "$INFRA_DIR_PROBE" ] || [ ! -d "${INFRA_DIR_PROBE}/steps" ]; then
                 git -C "$LEGACY_TARGET" fetch --quiet --depth=1 origin "$BOOTSTRAP_REF"
                 git -C "$LEGACY_TARGET" reset --hard "$BOOTSTRAP_REF"
             else
-                git -C "$LEGACY_TARGET" fetch --quiet --tags origin
+                # Existing shallow clones may follow a different default branch,
+                # so fetch main explicitly instead of relying on their refspec.
+                git -C "$LEGACY_TARGET" fetch --quiet --tags origin "$MAIN_REFSPEC"
                 git -C "$LEGACY_TARGET" reset --hard origin/main
             fi
             exec bash "$LEGACY_TARGET/infra/install.sh" "$@"
@@ -108,7 +111,9 @@ if [ -z "$INFRA_DIR_PROBE" ] || [ ! -d "${INFRA_DIR_PROBE}/steps" ]; then
             exit 1
         fi
         mkdir -p "$TARGET"
-        git clone --depth=1 "$CLONE_URL" "$TARGET"
+        # Production installs track main regardless of the repository's GitHub
+        # default branch (which may temporarily point at a QA branch).
+        git clone --depth=1 --branch main --single-branch "$CLONE_URL" "$TARGET"
         chmod 0600 "$TARGET/.git/config"
         if [ -n "$BOOTSTRAP_REF" ]; then
             echo "==> bootstrapping candidate commit $BOOTSTRAP_REF"
@@ -122,7 +127,7 @@ if [ -z "$INFRA_DIR_PROBE" ] || [ ! -d "${INFRA_DIR_PROBE}/steps" ]; then
             git -C "$TARGET" reset --hard "$BOOTSTRAP_REF"
         else
             echo "==> repo already at $TARGET, pulling latest"
-            git -C "$TARGET" fetch --quiet --tags origin
+            git -C "$TARGET" fetch --quiet --tags origin "$MAIN_REFSPEC"
             git -C "$TARGET" reset --hard origin/main
         fi
     fi

--- a/infra/tests/qa-scripts-test.sh
+++ b/infra/tests/qa-scripts-test.sh
@@ -102,6 +102,9 @@ grep -Fq 'git clone --depth=1 --branch main --single-branch "$CLONE_URL" "$TARGE
     fail "core install.sh does not pin production bootstrap clones to main"
 grep -Fq 'MAIN_REFSPEC="+refs/heads/main:refs/remotes/origin/main"' "$CORE_INSTALL_SCRIPT" || \
     fail "core install.sh does not explicitly fetch main for existing narrow clones"
+if [ "$(grep -Fc 'config remote.origin.fetch "$MAIN_REFSPEC"' "$CORE_INSTALL_SCRIPT")" -ne 2 ]; then
+    fail "core install.sh does not persist the main refspec for both existing-checkout repair paths (legacy + primary), so later plain fetches would go stale"
+fi
 if grep -Eq 'apt-get|git clone' "$INSTALL_SCRIPT"; then
     fail "install.sh bootstraps dependencies or clones the repository itself"
 fi

--- a/infra/tests/qa-scripts-test.sh
+++ b/infra/tests/qa-scripts-test.sh
@@ -98,6 +98,10 @@ grep -Fq 'raw.githubusercontent.com/futrx-com/remote.futrx/${CANDIDATE_SHA}/infr
     fail "install.sh does not download the installer from the immutable candidate commit"
 grep -Fq '"--ref=$candidate_sha"' "$INSTALL_SCRIPT" || \
     fail "install.sh does not pin the bootstrap clone to the candidate commit"
+grep -Fq 'git clone --depth=1 --branch main --single-branch "$CLONE_URL" "$TARGET"' "$CORE_INSTALL_SCRIPT" || \
+    fail "core install.sh does not pin production bootstrap clones to main"
+grep -Fq 'MAIN_REFSPEC="+refs/heads/main:refs/remotes/origin/main"' "$CORE_INSTALL_SCRIPT" || \
+    fail "core install.sh does not explicitly fetch main for existing narrow clones"
 if grep -Eq 'apt-get|git clone' "$INSTALL_SCRIPT"; then
     fail "install.sh bootstraps dependencies or clones the repository itself"
 fi


### PR DESCRIPTION
I found this while installing Remote on my VPS, which runs as an LXC container under Proxmox. I used the documented command:

```bash
curl -fsSL https://remote.futrx.com/get | sudo bash -s -- yasmeenremote.mosalam.com
```

The installer found the existing checkout in `/opt/remote.futrx`, printed that it was pulling the latest version, and then failed because `origin/main` did not exist.

The problem happens because the repository default branch currently points to `qa`. A shallow clone follows that default and is configured to fetch only `qa`. Later, the installer runs a normal fetch and tries to reset to `origin/main`, but that fetch never creates the missing remote-tracking branch, so Git reports `origin/main` as an ambiguous revision.

This fix makes the production branch explicit in both paths: fresh installs clone `main`, and existing narrow checkouts fetch `main` directly before resetting to it. I also added regression checks so changing the GitHub default branch cannot silently break the public installer again.

I reproduced the issue on the affected VPS with a `qa`-only fetch refspec and confirmed that the fixed fetch creates `origin/main` at the exact upstream commit. The installer shell checks pass as well.

@kingsoftheweb Mazen, thank you for the great work on this project. Remote is genuinely useful, and I appreciate how much thought has gone into making the self-hosted setup approachable.