### PR TITLE
fix(ws): filter real-time workspace events by project access

### DIFF
--- a/backend/internal/transport/ws/workspace_socket.go
+++ b/backend/internal/transport/ws/workspace_socket.go
@@ -96,9 +96,13 @@ func (s *WorkspaceSocket) handle(upgrader websocket.Upgrader, w http.ResponseWri
 		return
 	}
 
-	if s.visibility != nil && !isAdmin {
+	// Build the initial set of allowed project IDs for non-admin users.
+	// This set is updated dynamically as project.upsert events arrive.
+	needsFilter := s.visibility != nil && !isAdmin
+	allowed := projectIDSet(projects)
+	if needsFilter {
 		projects = s.filterProjects(r.Context(), projects, email)
-		allowed := projectIDSet(projects)
+		allowed = projectIDSet(projects)
 		chats = s.filterChats(chats, allowed)
 	}
 
@@ -123,6 +127,18 @@ func (s *WorkspaceSocket) handle(upgrader websocket.Upgrader, w http.ResponseWri
 				if !ok {
 					return
 				}
+
+				// Filter real-time events for non-admin users so
+				// they only see projects and chats they have access
+				// to. Admin users and single-user dev mode bypass
+				// filtering entirely.
+				if needsFilter {
+					ev, ok = filterEvent(s.visibility, email, allowed, ev)
+					if !ok {
+						continue
+					}
+				}
+
 				_ = conn.SetWriteDeadline(time.Now().Add(15 * time.Second))
 				if err := conn.WriteJSON(ev); err != nil {
 					return
@@ -143,6 +159,81 @@ func (s *WorkspaceSocket) handle(upgrader websocket.Upgrader, w http.ResponseWri
 			close(done)
 			return
 		}
+	}
+}
+
+// filterEvent decides whether ev should be forwarded to a non-admin client
+// identified by email. It returns the (possibly transformed) event and true
+// if the event should be sent, or a zero event and false to suppress it.
+//
+// The allowed map is maintained per-connection: project.upsert events that
+// pass the access check add the project; project.delete events and failed
+// access checks remove it. When an upsert arrives for a project the user
+// previously had access to but no longer does, the event is rewritten as a
+// project.delete so the client UI removes the stale entry.
+func filterEvent(
+	vis WorkspaceVisibility,
+	email string,
+	allowed map[serviceproject.ID]struct{},
+	ev workspacehub.Event,
+) (workspacehub.Event, bool) {
+	switch ev.Type {
+	case "project.upsert":
+		if ev.Project == nil {
+			return ev, false
+		}
+		// Use a short-lived background context: the original request
+		// context may already be cancelled for long-lived connections.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		ok, err := vis.HasAccess(ctx, ev.Project.ID, email)
+		if err != nil || !ok {
+			// If the user previously had access, they need a delete
+			// event so the UI removes the now-inaccessible project.
+			if _, had := allowed[ev.Project.ID]; had {
+				delete(allowed, ev.Project.ID)
+				return workspacehub.Event{
+					Type: "project.delete",
+					ID:   string(ev.Project.ID),
+				}, true
+			}
+			return ev, false
+		}
+		allowed[ev.Project.ID] = struct{}{}
+		return ev, true
+
+	case "project.delete":
+		pid := serviceproject.ID(ev.ID)
+		delete(allowed, pid)
+		// Only forward the delete if the user knew about this project.
+		if _, had := allowed[pid]; had {
+			return ev, true
+		}
+		// Still forward: the client might have it from an earlier
+		// snapshot and a delete for an unknown ID is harmless.
+		return ev, true
+
+	case "chat.upsert":
+		if ev.Chat == nil {
+			return ev, false
+		}
+		// Loose chats (not bound to a project) are visible to everyone.
+		if ev.Chat.ProjectID == "" {
+			return ev, true
+		}
+		if _, ok := allowed[serviceproject.ID(ev.Chat.ProjectID)]; ok {
+			return ev, true
+		}
+		return ev, false
+
+	case "chat.delete":
+		// chat.delete carries only an ID, not a project reference, so
+		// we cannot filter it. Deleting an unknown chat on the client
+		// is a harmless no-op, so we allow it through.
+		return ev, true
+
+	default:
+		return ev, true
 	}
 }
 
@@ -178,3 +269,4 @@ func projectIDSet(projects []serviceproject.Meta) map[serviceproject.ID]struct{}
 	}
 	return m
 }
+

--- a/backend/internal/transport/ws/workspace_socket_test.go
+++ b/backend/internal/transport/ws/workspace_socket_test.go
@@ -1,0 +1,263 @@
+package wstransport
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
+	"github.com/futrx-com/remote.futrx.com/internal/service/workspacehub"
+)
+
+// stubVisibility is a test double for WorkspaceVisibility.
+type stubVisibility struct {
+	// access maps "projectID:email" → allowed
+	access map[string]bool
+}
+
+func (s *stubVisibility) CallerAndAdmin(_ context.Context, _ *http.Request) (string, bool, error) {
+	return "", false, nil // unused by filterEvent
+}
+
+func (s *stubVisibility) HasAccess(_ context.Context, pid serviceproject.ID, email string) (bool, error) {
+	key := string(pid) + ":" + email
+	ok, found := s.access[key]
+	if !found {
+		return false, nil
+	}
+	return ok, nil
+}
+
+func makeProject(id string) *serviceproject.Meta {
+	return &serviceproject.Meta{ID: serviceproject.ID(id), Name: "Project " + id}
+}
+
+func makeChat(id, projectID string) *servicechat.Meta {
+	return &servicechat.Meta{ID: servicechat.ID(id), ProjectID: servicechat.ProjectID(projectID)}
+}
+
+func TestFilterEvent_AdminBypassesFiltering(t *testing.T) {
+	// filterEvent is only called for non-admin users. For admin users the
+	// caller (handle) skips filtering entirely. This test verifies that
+	// filterEvent correctly passes through events when it IS called with
+	// a visibility that grants access.
+	vis := &stubVisibility{access: map[string]bool{
+		"proj1:admin@test.com": true,
+	}}
+	allowed := map[serviceproject.ID]struct{}{
+		"proj1": {},
+	}
+
+	ev := workspacehub.Event{
+		Type:    "project.upsert",
+		Project: makeProject("proj1"),
+	}
+	out, ok := filterEvent(vis, "admin@test.com", allowed, ev)
+	if !ok {
+		t.Fatal("expected event to be forwarded for user with access")
+	}
+	if out.Type != "project.upsert" {
+		t.Fatalf("expected project.upsert, got %s", out.Type)
+	}
+}
+
+func TestFilterEvent_NonAdminReceivesAccessibleProjectUpsert(t *testing.T) {
+	vis := &stubVisibility{access: map[string]bool{
+		"proj1:user@test.com": true,
+	}}
+	allowed := map[serviceproject.ID]struct{}{}
+
+	ev := workspacehub.Event{
+		Type:    "project.upsert",
+		Project: makeProject("proj1"),
+	}
+	out, ok := filterEvent(vis, "user@test.com", allowed, ev)
+	if !ok {
+		t.Fatal("expected event to be forwarded for authorized user")
+	}
+	if out.Type != "project.upsert" {
+		t.Fatalf("expected project.upsert, got %s", out.Type)
+	}
+	// proj1 should now be in the allowed set
+	if _, exists := allowed["proj1"]; !exists {
+		t.Fatal("expected proj1 to be added to allowed set")
+	}
+}
+
+func TestFilterEvent_NonAdminBlockedFromUnauthorizedProject(t *testing.T) {
+	vis := &stubVisibility{access: map[string]bool{
+		"proj_secret:user@test.com": false,
+	}}
+	allowed := map[serviceproject.ID]struct{}{}
+
+	ev := workspacehub.Event{
+		Type:    "project.upsert",
+		Project: makeProject("proj_secret"),
+	}
+	_, ok := filterEvent(vis, "user@test.com", allowed, ev)
+	if ok {
+		t.Fatal("expected event to be suppressed for unauthorized user")
+	}
+}
+
+func TestFilterEvent_RevokedAccessSendsDelete(t *testing.T) {
+	vis := &stubVisibility{access: map[string]bool{
+		"proj1:user@test.com": false, // access revoked
+	}}
+	// User previously had access
+	allowed := map[serviceproject.ID]struct{}{
+		"proj1": {},
+	}
+
+	ev := workspacehub.Event{
+		Type:    "project.upsert",
+		Project: makeProject("proj1"),
+	}
+	out, ok := filterEvent(vis, "user@test.com", allowed, ev)
+	if !ok {
+		t.Fatal("expected a synthetic delete event to be generated")
+	}
+	if out.Type != "project.delete" {
+		t.Fatalf("expected project.delete (synthetic), got %s", out.Type)
+	}
+	if out.ID != "proj1" {
+		t.Fatalf("expected delete for proj1, got %s", out.ID)
+	}
+	// proj1 should be removed from allowed
+	if _, exists := allowed["proj1"]; exists {
+		t.Fatal("expected proj1 to be removed from allowed set after revocation")
+	}
+}
+
+func TestFilterEvent_ChatUpsertForAccessibleProject(t *testing.T) {
+	vis := &stubVisibility{}
+	allowed := map[serviceproject.ID]struct{}{
+		"proj1": {},
+	}
+
+	ev := workspacehub.Event{
+		Type: "chat.upsert",
+		Chat: makeChat("chat1", "proj1"),
+	}
+	out, ok := filterEvent(vis, "user@test.com", allowed, ev)
+	if !ok {
+		t.Fatal("expected chat event to be forwarded for accessible project")
+	}
+	if out.Type != "chat.upsert" {
+		t.Fatalf("expected chat.upsert, got %s", out.Type)
+	}
+}
+
+func TestFilterEvent_ChatUpsertBlockedForInaccessibleProject(t *testing.T) {
+	vis := &stubVisibility{}
+	allowed := map[serviceproject.ID]struct{}{
+		"proj1": {},
+	}
+
+	ev := workspacehub.Event{
+		Type: "chat.upsert",
+		Chat: makeChat("chat_secret", "proj_secret"),
+	}
+	_, ok := filterEvent(vis, "user@test.com", allowed, ev)
+	if ok {
+		t.Fatal("expected chat event to be suppressed for inaccessible project")
+	}
+}
+
+func TestFilterEvent_LooseChatAlwaysForwarded(t *testing.T) {
+	vis := &stubVisibility{}
+	allowed := map[serviceproject.ID]struct{}{}
+
+	ev := workspacehub.Event{
+		Type: "chat.upsert",
+		Chat: makeChat("loose_chat", ""),
+	}
+	out, ok := filterEvent(vis, "user@test.com", allowed, ev)
+	if !ok {
+		t.Fatal("expected loose chat (no project) to be forwarded")
+	}
+	if out.Type != "chat.upsert" {
+		t.Fatalf("expected chat.upsert, got %s", out.Type)
+	}
+}
+
+func TestFilterEvent_ProjectDeleteAlwaysForwarded(t *testing.T) {
+	vis := &stubVisibility{}
+	allowed := map[serviceproject.ID]struct{}{
+		"proj1": {},
+	}
+
+	ev := workspacehub.Event{
+		Type: "project.delete",
+		ID:   "proj1",
+	}
+	out, ok := filterEvent(vis, "user@test.com", allowed, ev)
+	if !ok {
+		t.Fatal("expected project.delete to be forwarded")
+	}
+	if out.Type != "project.delete" {
+		t.Fatalf("expected project.delete, got %s", out.Type)
+	}
+}
+
+func TestFilterEvent_ChatDeleteAlwaysForwarded(t *testing.T) {
+	vis := &stubVisibility{}
+	allowed := map[serviceproject.ID]struct{}{}
+
+	ev := workspacehub.Event{
+		Type: "chat.delete",
+		ID:   "chat42",
+	}
+	out, ok := filterEvent(vis, "user@test.com", allowed, ev)
+	if !ok {
+		t.Fatal("expected chat.delete to always be forwarded")
+	}
+	if out.Type != "chat.delete" {
+		t.Fatalf("expected chat.delete, got %s", out.Type)
+	}
+}
+
+func TestFilterEvent_NilProjectUpsertSuppressed(t *testing.T) {
+	vis := &stubVisibility{}
+	allowed := map[serviceproject.ID]struct{}{}
+
+	ev := workspacehub.Event{
+		Type:    "project.upsert",
+		Project: nil,
+	}
+	_, ok := filterEvent(vis, "user@test.com", allowed, ev)
+	if ok {
+		t.Fatal("expected nil-project upsert to be suppressed")
+	}
+}
+
+func TestFilterEvent_NilChatUpsertSuppressed(t *testing.T) {
+	vis := &stubVisibility{}
+	allowed := map[serviceproject.ID]struct{}{}
+
+	ev := workspacehub.Event{
+		Type: "chat.upsert",
+		Chat: nil,
+	}
+	_, ok := filterEvent(vis, "user@test.com", allowed, ev)
+	if ok {
+		t.Fatal("expected nil-chat upsert to be suppressed")
+	}
+}
+
+func TestFilterEvent_UnknownEventTypeForwarded(t *testing.T) {
+	vis := &stubVisibility{}
+	allowed := map[serviceproject.ID]struct{}{}
+
+	ev := workspacehub.Event{
+		Type: "system.ping",
+	}
+	out, ok := filterEvent(vis, "user@test.com", allowed, ev)
+	if !ok {
+		t.Fatal("expected unknown event types to be forwarded")
+	}
+	if out.Type != "system.ping" {
+		t.Fatalf("expected system.ping, got %s", out.Type)
+	}
+}


### PR DESCRIPTION
The /ws/workspace streaming loop forwarded all hub events to every
connected client without checking project-level authorization. 
Non-admin users could see private project names, statuses, and chat
metadata appear on their UI in real time.

This patch adds per-event access filtering in the WebSocket writer
goroutine. Each connection now tracks an allowed-project set that is
updated dynamically as events arrive. Unauthorized events are silently
dropped, and revoked access triggers a synthetic `project.delete` so
the client removes stale entries without a page reload.

The initial snapshot path was already filtered correctly — only the
streaming path was missing checks.

**Tests:** 12 new unit tests covering all event types and edge cases.
