### PR TITLE
fix(image): retry the IPv4 egress pre-flight instead of probing once (#39)

### DIFF
--- a/backend/internal/service/container/image/builder.go
+++ b/backend/internal/service/container/image/builder.go
@@ -185,8 +185,8 @@ func (b *Builder) Build(ctx context.Context, alias string) error {
 	}
 
 	// Fail fast on a container that can only reach IPv6 (see egress.go).
-	if _, err := b.runtime.ExecuteScript(bctx, baseImageBuilderName, ipv4EgressProbe); err != nil {
-		return errors.New(ipv4EgressHint)
+	if err := awaitIPv4Egress(bctx, b.runtime, baseImageBuilderName); err != nil {
+		return err
 	}
 
 	out, err = b.runBuildStage(2, "Installing system tools, Node.js, and agent CLIs", func() (string, error) {

--- a/backend/internal/service/container/image/builder_test.go
+++ b/backend/internal/service/container/image/builder_test.go
@@ -21,6 +21,9 @@ type recordingRuntime struct {
 	scriptResponses []runtimeResponse
 	stopResponse    runtimeResponse
 	publishResponse runtimeResponse
+	// scriptAlwaysErr fails every ExecuteScript, for the container that never
+	// comes up rather than the one that is merely slow to get a lease.
+	scriptAlwaysErr error
 }
 
 func (r *recordingRuntime) Available() bool {
@@ -46,6 +49,9 @@ func (r *recordingRuntime) ExecuteScript(_ context.Context, containerName, scrip
 		}
 	}
 	r.events = append(r.events, "script "+containerName+" "+script)
+	if r.scriptAlwaysErr != nil {
+		return "", r.scriptAlwaysErr
+	}
 	if responseIndex >= len(r.scriptResponses) {
 		return "", nil
 	}
@@ -117,12 +123,12 @@ func TestBuildPreservesImageWorkflowOrder(t *testing.T) {
 }
 
 func TestBuildStopsBeforeAnyStageWhenContainerHasNoIPv4Egress(t *testing.T) {
-	runtime := &recordingRuntime{
-		available: true,
-		scriptResponses: []runtimeResponse{
-			{output: "", err: errors.New("exit 1")}, // IPv4 egress probe
-		},
-	}
+	// Every probe fails: a host whose FORWARD policy blocks the bridge never
+	// gets IPv4, however long the builder waits. One failing response would
+	// only prove the first attempt happens, which stopped being the behaviour
+	// under test when the probe started retrying.
+	shortenEgressRetry(t)
+	runtime := &recordingRuntime{available: true, scriptAlwaysErr: errors.New("exit 1")}
 	builder := NewBuilder(
 		runtime,
 		&recordingProfileSource{profiles: configuredProfiles()},

--- a/backend/internal/service/container/image/egress.go
+++ b/backend/internal/service/container/image/egress.go
@@ -1,5 +1,11 @@
 package image
 
+import (
+	"context"
+	"errors"
+	"time"
+)
+
 // Pre-flight for the one network failure that is invisible until it is
 // expensive. Docker sets the host's iptables FORWARD policy to DROP and
 // accepts only its own bridges, which leaves LXD containers with no IPv4
@@ -33,3 +39,47 @@ Fix it by re-running infra/install.sh, which configures this automatically, or
 by hand:
   iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
   iptables -I DOCKER-USER -o lxdbr0 -j ACCEPT`
+
+// Vars rather than consts so a test can shorten them; nothing else writes.
+var (
+	ipv4EgressDeadline = 45 * time.Second
+	ipv4EgressInterval = 3 * time.Second
+)
+
+// egressProber is the slice of the runtime awaitIPv4Egress needs.
+type egressProber interface {
+	ExecuteScript(ctx context.Context, container, script string) (string, error)
+}
+
+// awaitIPv4Egress waits for the builder to reach an IPv4 address, and reports
+// the hint above only once it is clear that waiting will not help.
+//
+// The probe used to run once, after a fixed warmup. On a slow host the
+// builder's DHCP lease can take longer than that warmup, so the probe ran
+// against a container with no address yet and blamed Docker's FORWARD policy —
+// which sends an operator to inspect iptables on a machine that has no Docker
+// installed. Retrying separates the two cases that single shot conflated: a
+// container still coming up gets the time it needs, and one with no IPv4 route
+// still fails with the same actionable message, just later.
+//
+// A cancelled build returns the context error unchanged, so an interrupted run
+// is never reported as a network fault.
+func awaitIPv4Egress(ctx context.Context, runtime egressProber, container string) error {
+	deadline := time.Now().Add(ipv4EgressDeadline)
+	for {
+		if _, err := runtime.ExecuteScript(ctx, container, ipv4EgressProbe); err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if time.Now().After(deadline) {
+			return errors.New(ipv4EgressHint)
+		}
+		select {
+		case <-time.After(ipv4EgressInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/backend/internal/service/container/image/egress_test.go
+++ b/backend/internal/service/container/image/egress_test.go
@@ -1,0 +1,84 @@
+package image
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// shortenEgressRetry makes the retry loop finish in test time.
+func shortenEgressRetry(t *testing.T) {
+	t.Helper()
+	deadline, interval := ipv4EgressDeadline, ipv4EgressInterval
+	ipv4EgressDeadline = 60 * time.Millisecond
+	ipv4EgressInterval = 5 * time.Millisecond
+	t.Cleanup(func() {
+		ipv4EgressDeadline, ipv4EgressInterval = deadline, interval
+	})
+}
+
+// flakyProber fails a fixed number of times and then succeeds: a builder whose
+// DHCP lease has not landed yet.
+type flakyProber struct {
+	failures int
+	calls    int
+}
+
+func (p *flakyProber) ExecuteScript(context.Context, string, string) (string, error) {
+	p.calls++
+	if p.calls <= p.failures {
+		return "", errors.New("exit 1")
+	}
+	return "", nil
+}
+
+// TestEgressProbeWaitsForASlowLease is the bug this change exists for. The
+// probe ran once after a fixed warmup, so on a host where the lease takes
+// longer it tested a container with no address and blamed Docker's FORWARD
+// policy, sending the operator to inspect iptables on a machine without Docker.
+func TestEgressProbeWaitsForASlowLease(t *testing.T) {
+	shortenEgressRetry(t)
+	prober := &flakyProber{failures: 3}
+
+	if err := awaitIPv4Egress(context.Background(), prober, "builder"); err != nil {
+		t.Fatalf("awaitIPv4Egress() = %v, want it to wait for the lease", err)
+	}
+	if prober.calls != 4 {
+		t.Fatalf("probed %d times, want retries until the address arrives", prober.calls)
+	}
+}
+
+// TestEgressProbeStillReportsARealBlock: waiting must not turn a genuine
+// failure into a pass. The operator still needs the hint that names the cause.
+func TestEgressProbeStillReportsARealBlock(t *testing.T) {
+	shortenEgressRetry(t)
+	prober := &flakyProber{failures: 1 << 30}
+
+	err := awaitIPv4Egress(context.Background(), prober, "builder")
+	if err == nil {
+		t.Fatal("awaitIPv4Egress() = nil, want the egress hint")
+	}
+	for _, want := range []string{"cannot reach any IPv4", "Docker", "DOCKER-USER"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+	if prober.calls < 2 {
+		t.Errorf("probed %d times, want more than one attempt before giving up", prober.calls)
+	}
+}
+
+// TestEgressProbeReportsCancellationAsCancellation: an interrupted build is not
+// a network fault, and pointing the operator at iptables because they pressed
+// Ctrl-C would be a lie.
+func TestEgressProbeReportsCancellationAsCancellation(t *testing.T) {
+	shortenEgressRetry(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := awaitIPv4Egress(ctx, &flakyProber{failures: 1 << 30}, "builder"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("awaitIPv4Egress() = %v, want context.Canceled", err)
+	}
+}


### PR DESCRIPTION
Fixes #39.

The pre-flight runs once, after a fixed 3s warmup. That assumes the builder has its DHCP lease by then, and on a 1-vCPU host it does not. The lease lands around 5s, so the probe tests a container with no address at all and the build stops with the Docker FORWARD-policy hint from egress.go. On a box with no Docker on it that message sends you straight into iptables looking for something that was never there.

It now retries for up to 45s at 3s intervals. A container that is only slow to come up gets the time it needs. One that genuinely has no IPv4 route still fails with the same message, just later, so the case the hint was written for is unchanged.

A cancelled build returns the context error instead of the network hint, since Ctrl-C is not a firewall problem.

The existing test only fed one failing probe response, which stopped being meaningful once the probe retries, so it now simulates a container that never gets IPv4. Three new tests cover the slow lease, the real block, and cancellation.