### PR TITLE
fix(containers): wait for builder IPv4 instead of failing on a bootin…

### DIFF
--- a/backend/internal/service/container/image/builder.go
+++ b/backend/internal/service/container/image/builder.go
@@ -35,6 +35,8 @@ const (
 	baseImageBuildTimeout    = 15 * time.Minute
 	baseImagePublishTimeout  = 5 * time.Minute
 	baseImageNetworkWarmup   = 3 * time.Second
+	baseImageNetworkTimeout  = 90 * time.Second
+	baseImageNetworkPoll     = 2 * time.Second
 	baseImageProgressTick    = 30 * time.Second
 	baseImageBuildStageCount = 6
 	deleteTimeout            = 30 * time.Second
@@ -111,6 +113,8 @@ type Builder struct {
 	browserInstallScript    string
 	codeServerInstallScript []byte
 	networkWarmup           time.Duration
+	networkTimeout          time.Duration
+	networkPoll             time.Duration
 	progress                ProgressReporter
 }
 
@@ -129,6 +133,8 @@ func NewBuilder(
 		browserInstallScript:    browserInstallScript,
 		codeServerInstallScript: codeServerInstallScript,
 		networkWarmup:           baseImageNetworkWarmup,
+		networkTimeout:          baseImageNetworkTimeout,
+		networkPoll:             baseImageNetworkPoll,
 		progress:                progress,
 	}
 }
@@ -184,9 +190,10 @@ func (b *Builder) Build(ctx context.Context, alias string) error {
 		return bctx.Err()
 	}
 
-	// Fail fast on a container that can only reach IPv6 (see egress.go).
-	if _, err := b.runtime.ExecuteScript(bctx, baseImageBuilderName, ipv4EgressProbe); err != nil {
-		return errors.New(ipv4EgressHint)
+	// Block until the builder has IPv4 egress, rather than failing the build
+	// on a container that is merely still booting (see egress.go).
+	if err := b.waitForIPv4Egress(bctx); err != nil {
+		return err
 	}
 
 	out, err = b.runBuildStage(2, "Installing system tools, Node.js, and agent CLIs", func() (string, error) {
@@ -232,4 +239,35 @@ func (b *Builder) Build(ctx context.Context, alias string) error {
 	}
 
 	return nil
+}
+
+// waitForIPv4Egress blocks until the builder container can open an outbound
+// IPv4 connection, or until networkTimeout has passed without one.
+//
+// A container that has not yet finished DHCP on the bridge has no IPv4 route
+// at all, so connect() fails immediately with ENETUNREACH — indistinguishable
+// from a blocked path except in timing, and far more common. Probing once
+// after a fixed warmup therefore fails healthy hosts whenever the lease takes
+// longer than the warmup, which it does on a loaded or small machine. Polling
+// costs a healthy build only the time the lease actually needs, and the build
+// has a 15-minute budget to spend.
+func (b *Builder) waitForIPv4Egress(ctx context.Context) error {
+	deadline := time.Now().Add(b.networkTimeout)
+	for attempts := 1; ; attempts++ {
+		_, err := b.runtime.ExecuteScript(ctx, baseImageBuilderName, ipv4EgressProbe)
+		if err == nil {
+			return nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf(ipv4EgressHint, b.networkTimeout, attempts)
+		}
+		select {
+		case <-time.After(b.networkPoll):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }

--- a/backend/internal/service/container/image/builder_test.go
+++ b/backend/internal/service/container/image/builder_test.go
@@ -131,14 +131,17 @@ func TestBuildStopsBeforeAnyStageWhenContainerHasNoIPv4Egress(t *testing.T) {
 		nil,
 	)
 	builder.networkWarmup = 0
+	builder.networkTimeout = 0
+	builder.networkPoll = 0
 
 	err := builder.Build(context.Background(), "")
 	if err == nil {
 		t.Fatal("Build succeeded, want an IPv4 egress failure")
 	}
-	// The message has to name the cause, not the probe: this failure used to
-	// surface as a curl timeout against github.com four stages later.
-	for _, want := range []string{"cannot reach any IPv4", "Docker", "DOCKER-USER"} {
+	// The message has to leave the operator somewhere to go: this failure used
+	// to surface as a curl timeout against github.com four stages later, and
+	// then as a confident accusation against a Docker that was not installed.
+	for _, want := range []string{"no IPv4 egress", "ip_forward", "ipv4.nat", "iptables-legacy"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q does not mention %q", err, want)
 		}
@@ -208,5 +211,65 @@ func assertEvents(t *testing.T, got, want []string) {
 		if got[i] != want[i] {
 			t.Fatalf("event %d:\n got: %q\nwant: %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestBuildWaitsForIPv4EgressInsteadOfFailingOnABootingContainer(t *testing.T) {
+	// A container that has not finished DHCP yet fails the probe instantly with
+	// ENETUNREACH. That is the overwhelmingly common case on a fresh launch, and
+	// a single probe after a fixed warmup turned it into a failed build that
+	// blamed the host firewall.
+	runtime := &recordingRuntime{
+		available: true,
+		scriptResponses: []runtimeResponse{
+			{output: "", err: errors.New("exit 1")}, // no route yet
+			{output: "", err: errors.New("exit 1")}, // still no route
+		},
+	}
+	builder := NewBuilder(
+		runtime,
+		&recordingProfileSource{profiles: configuredProfiles()},
+		"browser-install",
+		[]byte("code-server-install"),
+		nil,
+	)
+	builder.networkWarmup = 0
+	builder.networkPoll = 0
+
+	if err := builder.Build(context.Background(), ""); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	probes := 0
+	for _, event := range runtime.events {
+		if strings.Contains(event, ipv4EgressProbe) {
+			probes++
+		}
+	}
+	if probes != 3 {
+		t.Fatalf("egress probes = %d, want 3 (two failures then success)", probes)
+	}
+	if !strings.Contains(strings.Join(runtime.events, "\n"), "browser-install") {
+		t.Fatalf("build did not continue past the probe: %q", runtime.events)
+	}
+}
+
+func TestWaitForIPv4EgressStopsWhenTheBuildIsCanceled(t *testing.T) {
+	runtime := &recordingRuntime{
+		available:       true,
+		scriptResponses: []runtimeResponse{{output: "", err: errors.New("exit 1")}},
+	}
+	builder := NewBuilder(
+		runtime,
+		&recordingProfileSource{profiles: configuredProfiles()},
+		"browser-install",
+		[]byte("code-server-install"),
+		nil,
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := builder.waitForIPv4Egress(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForIPv4Egress error = %v, want context.Canceled", err)
 	}
 }

--- a/backend/internal/service/container/image/egress.go
+++ b/backend/internal/service/container/image/egress.go
@@ -1,17 +1,18 @@
 package image
 
 // Pre-flight for the one network failure that is invisible until it is
-// expensive. Docker sets the host's iptables FORWARD policy to DROP and
-// accepts only its own bridges, which leaves LXD containers with no IPv4
-// egress. Docker does not touch ip6tables, so a stranded container still
-// reaches everything that publishes an AAAA record: apt, NodeSource, the npm
-// registry and Google's CDN all succeed, and the build only dies on the first
-// IPv4-only host it needs — github.com, four stages and several minutes in,
-// reported as a bare connection timeout with no hint at the cause.
+// expensive. When a container cannot reach IPv4, the build still gets a long
+// way: Docker and most host firewalls leave ip6tables untouched, so a stranded
+// container reaches everything that publishes an AAAA record — apt, NodeSource,
+// the npm registry and Google's CDN all succeed, and the build only dies on the
+// first IPv4-only host it needs, four stages and several minutes in, reported
+// as a bare connection timeout with no hint at the cause.
 //
-// Probing once, before any stage runs, turns that into an immediate and
-// actionable error. See infra/lib/container-forwarding.sh for the fix the
-// installer applies.
+// Probing before any stage runs turns that into an immediate, actionable
+// error. The probe is deliberately patient: a container that has just been
+// launched has no IPv4 route until DHCP completes on the bridge, and until then
+// connect() fails instantly with ENETUNREACH. That is a booting container, not
+// a broken host, so waitForIPv4Egress polls rather than deciding on one look.
 
 // ipv4EgressProbe opens a TCP connection to well-known IPv4-only resolver
 // endpoints. Bash's /dev/tcp keeps this dependency-free, which matters because
@@ -22,14 +23,38 @@ done
 exit 1`
 
 // ipv4EgressHint explains the failure in the terms an operator can act on,
-// rather than the terms the probe failed in.
-const ipv4EgressHint = `the builder container cannot reach any IPv4 address.
+// rather than the terms the probe failed in. It takes the time waited and the
+// number of attempts, so the message cannot be mistaken for a single unlucky
+// probe. It deliberately does not assert a cause: every candidate below has
+// been the real one at least once, and naming only the most familiar of them
+// sends operators to audit a firewall that may not even be installed.
+const ipv4EgressHint = `the builder container had no IPv4 egress after %s (%d attempts).
 
-This is usually Docker: it sets the host's iptables FORWARD policy to DROP and
-allows only its own bridges, so LXD containers lose IPv4 while IPv6 keeps
-working — which is why apt and npm succeed and only IPv4-only hosts fail.
+The container reached the point of having a route, or never got one at all.
+Check which, on the host:
 
-Fix it by re-running infra/install.sh, which configures this automatically, or
-by hand:
+  lxc launch ubuntu:24.04 nettest
+  lxc exec nettest -- ip -4 addr show scope global
+  lxc exec nettest -- bash -c 'timeout 5 bash -c "exec 3<>/dev/tcp/1.1.1.1/443" && echo OK'
+  lxc delete -f nettest
+
+No address on eth0 means DHCP on the bridge is not answering. An address but
+no connection means forwarded IPv4 is not getting out, and the usual causes
+are, in the order worth checking:
+
+  sysctl net.ipv4.ip_forward                 must be 1 (IPv6 forwarding can be
+                                             on while this is off, which is why
+                                             IPv6 destinations keep working)
+  lxc network get lxdbr0 ipv4.nat            must be true
+  nft list ruleset                           expect a masquerade rule for the
+                                             bridge subnet
+  iptables -S FORWARD                        and iptables-legacy -S FORWARD:
+                                             both backends are live, and a DROP
+                                             in either one is enough
+
+Docker is a common source of that last one — it sets the FORWARD policy to DROP
+and allows only its own bridges. If it is installed:
   iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
-  iptables -I DOCKER-USER -o lxdbr0 -j ACCEPT`
+  iptables -I DOCKER-USER -o lxdbr0 -j ACCEPT
+
+Re-running infra/install.sh applies those rules for you.`


### PR DESCRIPTION
…g container

The base-image build probed IPv4 egress exactly once, three seconds after launching the builder. A container that has not finished DHCP on lxdbr0 has no IPv4 route at all, so connect() returns ENETUNREACH immediately — which is why the probe failed in two seconds rather than timing out. Builds died on hosts whose networking was fine and had simply not finished booting the container.

The reported cause made that worse: the hint asserted a Docker FORWARD DROP and printed two DOCKER-USER commands, so the failure read as a firewall problem on a host with no Docker installed.

Poll for egress every 2s up to 90s, well inside the existing 15-minute build budget, so a healthy build pays only the time the DHCP lease actually needs and a genuinely blocked path still fails. Rewrite the hint to report what was observed rather than assert a cause: how long it waited and how many attempts, the container check that separates "no address" from "no route", and the ip_forward / ipv4.nat / masquerade checklist. It also names iptables-legacy, since both backends can be live and a DROP in either is enough while the nft view alone reads clean.

Fixes #153
Closes #39