### PR TITLE
fix(image): give the base image publish step room to finish

### DIFF
--- a/backend/internal/service/container/image/builder.go
+++ b/backend/internal/service/container/image/builder.go
@@ -33,7 +33,7 @@ const (
 	baseImageBuilderName = "futrx-remote-dev-builder"
 
 	baseImageBuildTimeout    = 15 * time.Minute
-	baseImagePublishTimeout  = 5 * time.Minute
+	baseImagePublishTimeout  = 15 * time.Minute
 	baseImageNetworkWarmup   = 3 * time.Second
 	baseImageProgressTick    = 30 * time.Second
 	baseImageBuildStageCount = 6


### PR DESCRIPTION
Publishing packs a multi-gigabyte rootfs, and five minutes was not enough for it: a build reached 72% before the deadline killed the publish, failing a run whose five earlier stages had all succeeded. Match the build timeout so packing has the same budget the install stages get.