### PR TITLE
fix(push): stop losing notification permission on every update

### DIFF
--- a/docs/dev/push-notifications/01-components-and-state.md
+++ b/docs/dev/push-notifications/01-components-and-state.md
@@ -32,7 +32,7 @@ flowchart LR
 | Presence claims | Backend memory | Claims live for 55 seconds; revisions are bounded per user |
 | Parked-question state | Backend memory | Until a user, completion, or error event |
 | Browser permission and subscription | Browser profile | Controlled by the browser and user |
-| Per-account opt-in for this browser | `localStorage`, `remote.futrx.pushOptIn` | Until the account turns notifications off or signs out |
+| Per-account opt-in for this browser | `localStorage`, `remote.futrx.pushOptIn` (SHA-256 fingerprints, not addresses) | Until the account turns notifications off or signs out |
 
 At startup, Remote loads or creates the VAPID key, verifies the key pair, and
 constructs the Web Push client. If that fails, notifications are disabled but

--- a/docs/dev/push-notifications/01-components-and-state.md
+++ b/docs/dev/push-notifications/01-components-and-state.md
@@ -32,6 +32,7 @@ flowchart LR
 | Presence claims | Backend memory | Claims live for 55 seconds; revisions are bounded per user |
 | Parked-question state | Backend memory | Until a user, completion, or error event |
 | Browser permission and subscription | Browser profile | Controlled by the browser and user |
+| Per-account opt-in for this browser | `localStorage`, `remote.futrx.pushOptIn` | Until the account turns notifications off or signs out |
 
 At startup, Remote loads or creates the VAPID key, verifies the key pair, and
 constructs the Web Push client. If that fails, notifications are disabled but
@@ -44,5 +45,7 @@ the rest of Remote still starts normally.
 - [`backend/internal/integration/webpush/`](../../../backend/internal/integration/webpush/)
 - [`backend/internal/stores/filepush/`](../../../backend/internal/stores/filepush/)
 - [`frontend/src/api/pushSubscriptionApi.ts`](../../../frontend/src/api/pushSubscriptionApi.ts)
+- [`frontend/src/api/pushDeviceRegistration.ts`](../../../frontend/src/api/pushDeviceRegistration.ts)
+- [`frontend/src/api/pushSubscriptionOwnership.ts`](../../../frontend/src/api/pushSubscriptionOwnership.ts)
 - [`frontend/src/state/push/pushPresenceState.ts`](../../../frontend/src/state/push/pushPresenceState.ts)
 - [`frontend/public/sw.js`](../../../frontend/public/sw.js)

--- a/docs/dev/push-notifications/02-device-subscription-lifecycle.md
+++ b/docs/dev/push-notifications/02-device-subscription-lifecycle.md
@@ -64,8 +64,10 @@ Two rules make this safe:
   granted permission. The permission dialog belongs to **Turn on** alone.
 - **A restore is per account.** Each browser remembers which accounts turned
   notifications on in it (`localStorage`, key `remote.futrx.pushOptIn`), so a
-  shared browser never subscribes someone who never asked. Turning
-  notifications off, or signing out, forgets the account immediately.
+  shared browser never subscribes someone who never asked. The record holds
+  SHA-256 fingerprints, never addresses, so it cannot enumerate who has signed
+  in on a shared machine. Turning notifications off, or signing out, forgets
+  the account immediately.
 
 The service worker covers the case the app cannot see, because the app is not
 running: when a push service retires an endpoint it fires

--- a/docs/dev/push-notifications/02-device-subscription-lifecycle.md
+++ b/docs/dev/push-notifications/02-device-subscription-lifecycle.md
@@ -29,11 +29,55 @@ may store up to 20 device subscriptions.
 | Loading | Remote is checking the server and browser |
 | Blocked | Push is unsupported, server-side push is disabled, or permission was denied |
 | Off | This browser has no subscription owned by the current account |
-| On | The server confirms this exact endpoint belongs to the current account |
+| On | This browser holds a subscription for the current account |
 
 On every authenticated app startup, Remote compares the browser's exact
 endpoint with the current user's stored endpoints. An endpoint left by another
 account is invalidated locally before it can be treated as enabled.
+
+## Keeping a device registered
+
+A browser subscription is not durable. A push service may retire an endpoint
+after a long idle period, a browser may drop a worker registration, and a
+restored `DATA_DIR` may no longer contain the server's record of a device. None
+of those is the user withdrawing consent, so Remote restores the registration
+instead of reporting the device as off.
+
+```mermaid
+flowchart TB
+    Boot["App start, or a tab returning after 30 minutes"] --> Worker["Ensure the worker is registered"]
+    Worker --> Have{"Subscription present?"}
+    Have -- "yes" --> Owned{"Server confirms the account owns it?"}
+    Owned -- "yes" --> On["Registered"]
+    Owned -- "unreachable" --> Keep["Keep it untouched, re-check later"]
+    Owned -- "no" --> Drop["Invalidate it locally"]
+    Drop --> OptIn
+    Have -- "no" --> OptIn{"This account opted in here,<br/>and permission is granted?"}
+    OptIn -- "yes" --> Create["Subscribe again and register"]
+    Create --> On
+    OptIn -- "no" --> Off["Off, until the user selects Turn on"]
+```
+
+Two rules make this safe:
+
+- **A restore never prompts.** It runs only when the browser has already
+  granted permission. The permission dialog belongs to **Turn on** alone.
+- **A restore is per account.** Each browser remembers which accounts turned
+  notifications on in it (`localStorage`, key `remote.futrx.pushOptIn`), so a
+  shared browser never subscribes someone who never asked. Turning
+  notifications off, or signing out, forgets the account immediately.
+
+The service worker covers the case the app cannot see, because the app is not
+running: when a push service retires an endpoint it fires
+`pushsubscriptionchange`, and the worker confirms the current session owns the
+retired endpoint, subscribes again with the same application server key,
+registers the replacement, and deletes the retired one. A rotation it cannot
+attribute to the signed-in account is left for the app to restore, which is the
+only place the per-account opt-in is known.
+
+An unsubscribe is never used as a way to express uncertainty. On Safari,
+removing the last subscription also removes the site's notification permission,
+which is what puts the "Allow notifications?" prompt back in front of the user.
 
 ## Turn notifications off
 
@@ -49,13 +93,19 @@ store when a later API request fails.
 Signing out performs the same server and browser cleanup before clearing the
 session. As a second boundary, the service worker verifies its exact endpoint
 against the current session before displaying every incoming push. A logged-out
-or different account cannot display the previous user's notification.
+or different account cannot display the previous user's notification: without a
+session the worker stays silent, and an endpoint the server reports as
+belonging to someone else is invalidated on the spot.
 
 ## VAPID key changes
 
-When the public VAPID key changes, an old subscription cannot be reused for
-delivery. The next enable action removes the old browser subscription, creates
-one with the new key, and saves the replacement on the server.
+The key pair lives in `DATA_DIR` and survives updates; only losing or rotating
+it deliberately changes it. When the public key does change, an old
+subscription cannot be reused for delivery, so Remote removes it, creates one
+with the new key, and saves the replacement on the server — during a restore as
+well as on the next enable action. A browser that does not expose the key its
+subscription was signed with is left alone, because an unprovable mismatch is
+not worth the permission a replacement can cost.
 
 ## Account and user cleanup
 

--- a/docs/dev/push-notifications/05-security-and-failure-model.md
+++ b/docs/dev/push-notifications/05-security-and-failure-model.md
@@ -34,6 +34,9 @@ The transport also:
 - `webpush-go` encrypts the payload and signs the request.
 - The push provider routes ciphertext to the browser.
 - Logs include only the endpoint hostname, never its full capability URL.
+- The browser-side opt-in record stores SHA-256 fingerprints of accounts, so
+  `localStorage` on a shared machine does not enumerate this server's users —
+  matching the hashed filenames of the server's subscription store.
 
 ## Failure behavior
 

--- a/docs/dev/push-notifications/05-security-and-failure-model.md
+++ b/docs/dev/push-notifications/05-security-and-failure-model.md
@@ -46,12 +46,22 @@ The transport also:
 | `404` or `410` | Subscription is removed |
 | Timeout, `429`, `5xx`, TLS, or protocol error | Failure is logged without retry |
 | Presence state is lost | A redundant notification may be displayed |
+| Ownership cannot be verified (backend restarting, offline) | Nothing is displayed; the device registration is kept and re-checked |
+| Worker receives a push with no session | Nothing is displayed; the registration is kept for the next sign-in |
+| Push service retires an endpoint | The worker re-registers the device when the session owns the retired endpoint; otherwise the app restores it on its next start |
+| Server has no record of a device that opted in here | The subscription is re-created silently, without a new permission prompt |
 
 ## Remaining release-safety work
 
 1. Notification previews include chat titles and truncated backend errors that
    may appear on a lock screen.
 2. Delivery has no bounded worker queue or transient retry policy.
+
+Displaying a notification is gated on a live ownership check, so keeping an
+unverified registration cannot reveal another account's alert. Discarding one
+can cost the browser's notification permission outright — Safari drops the
+permission with the site's last subscription — so uncertainty suppresses
+display, never registration.
 
 Web Push encryption protects data in transit. It does not replace correct
 audience selection, account lifecycle cleanup, or lock-screen privacy policy.

--- a/docs/dev/push-notifications/05-security-and-failure-model.md
+++ b/docs/dev/push-notifications/05-security-and-failure-model.md
@@ -53,6 +53,7 @@ The transport also:
 | Worker receives a push with no session | Nothing is displayed; the registration is kept for the next sign-in |
 | Push service retires an endpoint | The worker re-registers the device when the session owns the retired endpoint; otherwise the app restores it on its next start |
 | Server has no record of a device that opted in here | The subscription is re-created silently, without a new permission prompt |
+| Server definitively rejects the re-created device (device cap, invalid keys) | The opt-in is forgotten so restore stops retrying; "Turn on" surfaces the same error to the user |
 
 ## Remaining release-safety work
 

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -98,27 +98,34 @@ async function subscriptionBelongsToCurrentAccount() {
   const subscription = await self.registration.pushManager.getSubscription();
   if (!subscription) return false;
 
+  const ownership = await accountOwnsEndpoint(subscription.endpoint);
+  if (ownership === "yes") return true;
+  // A definite "this endpoint is not yours": it belongs to whoever used this
+  // browser before, so the current session must not keep it alive. An
+  // unanswerable check is not that verdict — a missing session or a backend
+  // still coming back up after an update only costs this one notification.
+  if (ownership === "no") await subscription.unsubscribe();
+  return false;
+}
+
+// Whether the current session's account owns one endpoint. "unknown" keeps
+// both callers honest: nothing is displayed and nothing is discarded until the
+// server actually answers.
+async function accountOwnsEndpoint(endpoint) {
   try {
     const response = await fetch("/api/push/subscriptions/status", {
       method: "POST",
       credentials: "same-origin",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ endpoint: subscription.endpoint }),
+      body: JSON.stringify({ endpoint }),
     });
-    if (response.status === 401) {
-      await subscription.unsubscribe();
-      return false;
-    }
-    if (!response.ok) return false;
-
+    if (!response.ok) return "unknown";
     const status = await response.json();
-    if (status.owned === true) return true;
-    await subscription.unsubscribe();
-    return false;
+    return status.owned === true ? "yes" : "no";
   } catch {
     // A transient server failure may cost one notification, but must never
     // reveal an alert before account ownership can be proven.
-    return false;
+    return "unknown";
   }
 }
 
@@ -161,6 +168,54 @@ function askClient(client, message) {
       resolve(null);
     }
   });
+}
+
+// Push services retire endpoints on their own schedule — after a long idle
+// period, or when the browser rotates its registration. This event is the only
+// notice a device gets, and without a replacement the user simply stops
+// receiving notifications and reads that as having lost permission.
+self.addEventListener("pushsubscriptionchange", (event) => {
+  event.waitUntil(resubscribe(event));
+});
+
+// Only the account that owned the retired endpoint is re-registered. A browser
+// subscription belongs to the whole origin, so on a shared browser this worker
+// must not sign whoever is currently logged in up for notifications they never
+// asked for; the app restores those from its own record of the opt-in.
+async function resubscribe(event) {
+  const retired = event.oldSubscription;
+  const key = retired && retired.options && retired.options.applicationServerKey;
+  if (!retired || !key) return;
+
+  try {
+    if ((await accountOwnsEndpoint(retired.endpoint)) !== "yes") return;
+
+    const replacement =
+      event.newSubscription ||
+      (await self.registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: key,
+      }));
+    if (replacement.endpoint === retired.endpoint) return;
+
+    await fetch("/api/push/subscriptions", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(replacement.toJSON()),
+    });
+    // Drop the retired endpoint: it is unreachable, and a device that rotates
+    // repeatedly would otherwise fill this account's registration slots.
+    await fetch("/api/push/subscriptions", {
+      method: "DELETE",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ endpoint: retired.endpoint }),
+    });
+  } catch {
+    // Nothing more the worker can do while offline or signed out. The app
+    // restores the registration the next time it starts.
+  }
 }
 
 self.addEventListener("notificationclick", (event) => {

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -98,20 +98,21 @@ async function subscriptionBelongsToCurrentAccount() {
   const subscription = await self.registration.pushManager.getSubscription();
   if (!subscription) return false;
 
-  const ownership = await accountOwnsEndpoint(subscription.endpoint);
-  if (ownership === "yes") return true;
+  const ownership = await endpointOwnership(subscription.endpoint);
+  if (ownership === "owned") return true;
   // A definite "this endpoint is not yours": it belongs to whoever used this
   // browser before, so the current session must not keep it alive. An
   // unanswerable check is not that verdict — a missing session or a backend
   // still coming back up after an update only costs this one notification.
-  if (ownership === "no") await subscription.unsubscribe();
+  if (ownership === "foreign") await subscription.unsubscribe();
   return false;
 }
 
-// Whether the current session's account owns one endpoint. "unknown" keeps
-// both callers honest: nothing is displayed and nothing is discarded until the
-// server actually answers.
-async function accountOwnsEndpoint(endpoint) {
+// Who owns one endpoint, in the same three words the app uses:
+// "owned" | "foreign" | "unverified". Keeping one vocabulary on both sides of
+// the origin matters, because the two act on the same verdicts — and
+// "unverified" means nothing is displayed and nothing is discarded.
+async function endpointOwnership(endpoint) {
   try {
     const response = await fetch("/api/push/subscriptions/status", {
       method: "POST",
@@ -119,13 +120,13 @@ async function accountOwnsEndpoint(endpoint) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ endpoint }),
     });
-    if (!response.ok) return "unknown";
+    if (!response.ok) return "unverified";
     const status = await response.json();
-    return status.owned === true ? "yes" : "no";
+    return status.owned === true ? "owned" : "foreign";
   } catch {
     // A transient server failure may cost one notification, but must never
     // reveal an alert before account ownership can be proven.
-    return "unknown";
+    return "unverified";
   }
 }
 
@@ -188,7 +189,7 @@ async function resubscribe(event) {
   if (!retired || !key) return;
 
   try {
-    if ((await accountOwnsEndpoint(retired.endpoint)) !== "yes") return;
+    if ((await endpointOwnership(retired.endpoint)) !== "owned") return;
 
     const replacement =
       event.newSubscription ||

--- a/frontend/src/api/apiError.test.ts
+++ b/frontend/src/api/apiError.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ApiError, isDefinitiveRejection } from "./apiError.ts";
+
+test("a server rejection carries its message and status", () => {
+  const rejection = new ApiError("too many push subscriptions for this user", 409);
+
+  assert.equal(rejection.message, "too many push subscriptions for this user");
+  assert.equal(rejection.status, 409);
+  assert.ok(rejection instanceof Error);
+});
+
+test("definitive rejections are the deliberate client-error answers", () => {
+  assert.equal(isDefinitiveRejection(new ApiError("no", 400)), true);
+  assert.equal(isDefinitiveRejection(new ApiError("cap", 409)), true);
+  assert.equal(isDefinitiveRejection(new ApiError("restarting", 502)), false);
+  assert.equal(isDefinitiveRejection(new ApiError("busy", 503)), false);
+  assert.equal(isDefinitiveRejection(new Error("network down")), false);
+  assert.equal(isDefinitiveRejection("string"), false);
+});

--- a/frontend/src/api/apiError.ts
+++ b/frontend/src/api/apiError.ts
@@ -1,0 +1,21 @@
+/** An error response the server produced deliberately, with its status. */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+/**
+ * Whether the server rejected the request itself, as opposed to failing while
+ * handling it. A definitive rejection repeats on every retry until something
+ * else changes, so background work must stop rather than try again; a network
+ * failure or 5xx may succeed next time. 401 never reaches callers — the
+ * request layer reloads into the sign-in flow instead of throwing.
+ */
+export function isDefinitiveRejection(cause: unknown): boolean {
+  return cause instanceof ApiError && cause.status >= 400 && cause.status < 500;
+}

--- a/frontend/src/api/apiRequest.ts
+++ b/frontend/src/api/apiRequest.ts
@@ -1,6 +1,7 @@
 import { sendHttpRequest } from "../transport/http";
 import type { HttpMethod } from "../types/transport";
 import { API_RESPONSE_STATUS } from "../config/api";
+import { ApiError } from "./apiError.ts";
 
 export async function requestJson<T>(
   method: HttpMethod,
@@ -17,7 +18,7 @@ export async function requestJson<T>(
     try {
       msg = (await response.json()).error || msg;
     } catch {}
-    throw new Error(msg);
+    throw new ApiError(msg, response.status);
   }
   if (response.status === API_RESPONSE_STATUS.noContent) return undefined as T;
   return response.json() as Promise<T>;

--- a/frontend/src/api/pushDeviceRegistration.test.ts
+++ b/frontend/src/api/pushDeviceRegistration.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { restoreDeviceRegistration } from "./pushDeviceRegistration.ts";
+
+interface Recorder {
+  unsubscribed: string[];
+  forgotten: string[];
+  registered: string[];
+  created: number;
+}
+
+function environment(overrides: Record<string, unknown> = {}) {
+  const recorder: Recorder = {
+    unsubscribed: [],
+    forgotten: [],
+    registered: [],
+    created: 0,
+  };
+  const base = {
+    existing: { endpoint: "https://push.example.com/device" },
+    matchesServerKey: () => true,
+    ownsEndpoint: async () => true,
+    optedIn: true,
+    permissionGranted: true,
+    unsubscribeLocal: async (subscription: { endpoint: string }) => {
+      recorder.unsubscribed.push(subscription.endpoint);
+    },
+    forgetOnServer: async (endpoint: string) => {
+      recorder.forgotten.push(endpoint);
+    },
+    subscribeLocal: async () => {
+      recorder.created++;
+      return { endpoint: `https://push.example.com/fresh-${recorder.created}` };
+    },
+    registerOnServer: async (subscription: { endpoint: string }) => {
+      recorder.registered.push(subscription.endpoint);
+    },
+  };
+  return { environment: { ...base, ...overrides }, recorder };
+}
+
+test("a confirmed device is left exactly as it is", async () => {
+  const { environment: env, recorder } = environment();
+
+  assert.equal(await restoreDeviceRegistration(env), "registered");
+  assert.deepEqual(recorder.unsubscribed, []);
+  assert.equal(recorder.created, 0);
+});
+
+test("a device the server cannot confirm keeps its subscription", async () => {
+  const { environment: env, recorder } = environment({
+    ownsEndpoint: async () => {
+      throw new Error("502 while the backend restarts");
+    },
+  });
+
+  assert.equal(await restoreDeviceRegistration(env), "unverified");
+  assert.deepEqual(recorder.unsubscribed, []);
+  assert.equal(recorder.created, 0);
+});
+
+test("a subscription the server lost is recreated without asking again", async () => {
+  const { environment: env, recorder } = environment({ ownsEndpoint: async () => false });
+
+  assert.equal(await restoreDeviceRegistration(env), "registered");
+  assert.deepEqual(recorder.unsubscribed, ["https://push.example.com/device"]);
+  assert.deepEqual(recorder.registered, ["https://push.example.com/fresh-1"]);
+});
+
+test("a subscription signed with a retired key is replaced on both sides", async () => {
+  const { environment: env, recorder } = environment({ matchesServerKey: () => false });
+
+  assert.equal(await restoreDeviceRegistration(env), "registered");
+  assert.deepEqual(recorder.forgotten, ["https://push.example.com/device"]);
+  assert.deepEqual(recorder.unsubscribed, ["https://push.example.com/device"]);
+  assert.deepEqual(recorder.registered, ["https://push.example.com/fresh-1"]);
+});
+
+test("a device with nothing registered is restored from a remembered opt-in", async () => {
+  const { environment: env, recorder } = environment({ existing: null });
+
+  assert.equal(await restoreDeviceRegistration(env), "registered");
+  assert.deepEqual(recorder.registered, ["https://push.example.com/fresh-1"]);
+});
+
+test("an account that never opted in on this device is left alone", async () => {
+  const { environment: env, recorder } = environment({ existing: null, optedIn: false });
+
+  assert.equal(await restoreDeviceRegistration(env), "absent");
+  assert.equal(recorder.created, 0);
+});
+
+test("restoring never subscribes before permission is granted", async () => {
+  const { environment: env, recorder } = environment({
+    existing: null,
+    permissionGranted: false,
+  });
+
+  assert.equal(await restoreDeviceRegistration(env), "absent");
+  assert.equal(recorder.created, 0);
+});

--- a/frontend/src/api/pushDeviceRegistration.test.ts
+++ b/frontend/src/api/pushDeviceRegistration.test.ts
@@ -1,102 +1,124 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { restoreDeviceRegistration } from "./pushDeviceRegistration.ts";
+import {
+  restoreDeviceRegistration,
+  type PushDevice,
+  type PushDevicePorts,
+} from "./pushDeviceRegistration.ts";
 
-interface Recorder {
-  unsubscribed: string[];
-  forgotten: string[];
-  registered: string[];
-  created: number;
+interface Subscription {
+  endpoint: string;
 }
 
-function environment(overrides: Record<string, unknown> = {}) {
-  const recorder: Recorder = {
-    unsubscribed: [],
-    forgotten: [],
-    registered: [],
-    created: 0,
+const HELD = "https://push.example.com/device";
+
+interface ServerAnswer {
+  /** What the ownership check returns, or the failure it raises. */
+  owns?: boolean | Error;
+  retiredKey?: boolean;
+}
+
+class RecordingPorts implements PushDevicePorts<Subscription> {
+  readonly invalidated: string[] = [];
+  readonly discarded: string[] = [];
+  created = 0;
+  #answer: ServerAnswer;
+
+  constructor(answer: ServerAnswer = {}) {
+    this.#answer = answer;
+  }
+
+  isSignedWithRetiredKey = (): boolean => this.#answer.retiredKey === true;
+
+  ownsEndpoint = async (): Promise<boolean> => {
+    if (this.#answer.owns instanceof Error) throw this.#answer.owns;
+    return this.#answer.owns ?? true;
   };
-  const base = {
-    existing: { endpoint: "https://push.example.com/device" },
-    matchesServerKey: () => true,
-    ownsEndpoint: async () => true,
+
+  invalidateLocally = async (subscription: Subscription): Promise<void> => {
+    this.invalidated.push(subscription.endpoint);
+  };
+
+  discardRegistration = async (subscription: Subscription): Promise<void> => {
+    this.discarded.push(subscription.endpoint);
+  };
+
+  createRegistration = async (): Promise<void> => {
+    this.created++;
+  };
+}
+
+function device(overrides: Partial<PushDevice<Subscription>> = {}): PushDevice<Subscription> {
+  return {
+    subscription: { endpoint: HELD },
     optedIn: true,
     permissionGranted: true,
-    unsubscribeLocal: async (subscription: { endpoint: string }) => {
-      recorder.unsubscribed.push(subscription.endpoint);
-    },
-    forgetOnServer: async (endpoint: string) => {
-      recorder.forgotten.push(endpoint);
-    },
-    subscribeLocal: async () => {
-      recorder.created++;
-      return { endpoint: `https://push.example.com/fresh-${recorder.created}` };
-    },
-    registerOnServer: async (subscription: { endpoint: string }) => {
-      recorder.registered.push(subscription.endpoint);
-    },
+    ...overrides,
   };
-  return { environment: { ...base, ...overrides }, recorder };
 }
 
 test("a confirmed device is left exactly as it is", async () => {
-  const { environment: env, recorder } = environment();
+  const ports = new RecordingPorts();
 
-  assert.equal(await restoreDeviceRegistration(env), "registered");
-  assert.deepEqual(recorder.unsubscribed, []);
-  assert.equal(recorder.created, 0);
+  assert.equal(await restoreDeviceRegistration(device(), ports), "registered");
+  assert.deepEqual(ports.invalidated, []);
+  assert.equal(ports.created, 0);
 });
 
 test("a device the server cannot confirm keeps its subscription", async () => {
-  const { environment: env, recorder } = environment({
-    ownsEndpoint: async () => {
-      throw new Error("502 while the backend restarts");
-    },
-  });
+  const ports = new RecordingPorts({ owns: new Error("502 while the backend restarts") });
 
-  assert.equal(await restoreDeviceRegistration(env), "unverified");
-  assert.deepEqual(recorder.unsubscribed, []);
-  assert.equal(recorder.created, 0);
+  assert.equal(await restoreDeviceRegistration(device(), ports), "unverified");
+  assert.deepEqual(ports.invalidated, []);
+  assert.equal(ports.created, 0);
 });
 
 test("a subscription the server lost is recreated without asking again", async () => {
-  const { environment: env, recorder } = environment({ ownsEndpoint: async () => false });
+  const ports = new RecordingPorts({ owns: false });
 
-  assert.equal(await restoreDeviceRegistration(env), "registered");
-  assert.deepEqual(recorder.unsubscribed, ["https://push.example.com/device"]);
-  assert.deepEqual(recorder.registered, ["https://push.example.com/fresh-1"]);
+  assert.equal(await restoreDeviceRegistration(device(), ports), "registered");
+  assert.deepEqual(ports.invalidated, [HELD]);
+  assert.equal(ports.created, 1);
 });
 
 test("a subscription signed with a retired key is replaced on both sides", async () => {
-  const { environment: env, recorder } = environment({ matchesServerKey: () => false });
+  const ports = new RecordingPorts({ retiredKey: true });
 
-  assert.equal(await restoreDeviceRegistration(env), "registered");
-  assert.deepEqual(recorder.forgotten, ["https://push.example.com/device"]);
-  assert.deepEqual(recorder.unsubscribed, ["https://push.example.com/device"]);
-  assert.deepEqual(recorder.registered, ["https://push.example.com/fresh-1"]);
+  assert.equal(await restoreDeviceRegistration(device(), ports), "registered");
+  assert.deepEqual(ports.discarded, [HELD]);
+  assert.equal(ports.created, 1);
 });
 
 test("a device with nothing registered is restored from a remembered opt-in", async () => {
-  const { environment: env, recorder } = environment({ existing: null });
+  const ports = new RecordingPorts();
 
-  assert.equal(await restoreDeviceRegistration(env), "registered");
-  assert.deepEqual(recorder.registered, ["https://push.example.com/fresh-1"]);
+  assert.equal(
+    await restoreDeviceRegistration(device({ subscription: null }), ports),
+    "registered"
+  );
+  assert.equal(ports.created, 1);
 });
 
 test("an account that never opted in on this device is left alone", async () => {
-  const { environment: env, recorder } = environment({ existing: null, optedIn: false });
+  const ports = new RecordingPorts();
 
-  assert.equal(await restoreDeviceRegistration(env), "absent");
-  assert.equal(recorder.created, 0);
+  assert.equal(
+    await restoreDeviceRegistration(device({ subscription: null, optedIn: false }), ports),
+    "absent"
+  );
+  assert.equal(ports.created, 0);
 });
 
 test("restoring never subscribes before permission is granted", async () => {
-  const { environment: env, recorder } = environment({
-    existing: null,
-    permissionGranted: false,
-  });
+  const ports = new RecordingPorts();
 
-  assert.equal(await restoreDeviceRegistration(env), "absent");
-  assert.equal(recorder.created, 0);
+  assert.equal(
+    await restoreDeviceRegistration(
+      device({ subscription: null, permissionGranted: false }),
+      ports
+    ),
+    "absent"
+  );
+  assert.equal(ports.created, 0);
 });

--- a/frontend/src/api/pushDeviceRegistration.ts
+++ b/frontend/src/api/pushDeviceRegistration.ts
@@ -4,7 +4,7 @@ import {
 } from "./pushSubscriptionOwnership.ts";
 
 /** Where a device ended up after Remote tried to restore its registration. */
-export type PushDeviceRegistration =
+export type PushDeviceState =
   /** This device holds a subscription the signed-in account owns. */
   | "registered"
   /** A subscription is present but the server could not confirm it yet. */
@@ -12,26 +12,32 @@ export type PushDeviceRegistration =
   /** This device receives nothing, and nothing may be created without asking. */
   | "absent";
 
-/**
- * Everything the restore policy is allowed to touch. Passing the browser and
- * the server in as functions keeps the policy — which is the part that decides
- * whether a user gets asked for permission again — testable on its own.
- */
-export interface PushDeviceEnvironment<T extends EndpointSubscription> {
+/** What this browser currently holds, and what it is allowed to hold. */
+export interface PushDevice<T extends EndpointSubscription> {
   /** The subscription this browser currently holds, if any. */
-  existing: T | null;
-  /** Whether the endpoint was signed with the key the server signs with today. */
-  matchesServerKey: (subscription: T) => boolean;
-  /** Server answer for one endpoint; rejects when the server cannot answer. */
-  ownsEndpoint: (endpoint: string) => Promise<boolean>;
+  subscription: T | null;
   /** Whether this account already turned notifications on in this browser. */
   optedIn: boolean;
   /** True only when permission is already granted, so restoring never prompts. */
   permissionGranted: boolean;
-  unsubscribeLocal: (subscription: T) => Promise<unknown>;
-  forgetOnServer: (endpoint: string) => Promise<unknown>;
-  subscribeLocal: () => Promise<T>;
-  registerOnServer: (subscription: T) => Promise<unknown>;
+}
+
+/**
+ * The only things the restore policy may do. Each one is a whole action rather
+ * than a step of one, so the policy decides *whether* a device is registered
+ * and never how a subscription reaches the server.
+ */
+export interface PushDevicePorts<T extends EndpointSubscription> {
+  /** Whether the endpoint was signed with a key the server has since replaced. */
+  isSignedWithRetiredKey: (subscription: T) => boolean;
+  /** Server answer for one endpoint; rejects when the server cannot answer. */
+  ownsEndpoint: (endpoint: string) => Promise<boolean>;
+  /** Drops the browser's endpoint alone, leaving another account's record be. */
+  invalidateLocally: (subscription: T) => Promise<unknown>;
+  /** Removes this device's registration from the server and the browser. */
+  discardRegistration: (subscription: T) => Promise<unknown>;
+  /** Subscribes this browser and registers the result under the account. */
+  createRegistration: () => Promise<unknown>;
 }
 
 /**
@@ -45,33 +51,33 @@ export interface PushDeviceEnvironment<T extends EndpointSubscription> {
  * ever comes from the user pressing "Turn on".
  */
 export async function restoreDeviceRegistration<T extends EndpointSubscription>(
-  environment: PushDeviceEnvironment<T>
-): Promise<PushDeviceRegistration> {
-  const existing = environment.existing;
-  if (existing) {
-    if (environment.matchesServerKey(existing)) {
+  device: PushDevice<T>,
+  ports: PushDevicePorts<T>
+): Promise<PushDeviceState> {
+  const subscription = device.subscription;
+  if (subscription) {
+    if (ports.isSignedWithRetiredKey(subscription)) {
+      // The push service can never deliver to it, so replace it rather than
+      // leaving the device believing it is on.
+      await ports.discardRegistration(subscription);
+    } else {
       const ownership = await reconcileSubscriptionOwnership(
-        existing,
-        environment.ownsEndpoint,
-        environment.unsubscribeLocal
+        subscription,
+        ports.ownsEndpoint,
+        ports.invalidateLocally
       );
       if (ownership === "owned") return "registered";
       // Keep an unconfirmed registration exactly as it is: the server being
       // unreachable — mid-update, or offline — is not the user turning
       // notifications off, and discarding it here would cost the subscription.
       if (ownership === "unverified") return "unverified";
-      // "foreign": already unsubscribed locally. Fall through and mint one for
+      // "foreign": already invalidated locally. Fall through and mint one for
       // the account that is actually signed in.
-    } else {
-      // Signed with a retired key, so the push service can never deliver to it.
-      await environment.forgetOnServer(existing.endpoint);
-      await environment.unsubscribeLocal(existing);
     }
   }
 
-  if (!environment.optedIn || !environment.permissionGranted) return "absent";
+  if (!device.optedIn || !device.permissionGranted) return "absent";
 
-  const created = await environment.subscribeLocal();
-  await environment.registerOnServer(created);
+  await ports.createRegistration();
   return "registered";
 }

--- a/frontend/src/api/pushDeviceRegistration.ts
+++ b/frontend/src/api/pushDeviceRegistration.ts
@@ -1,0 +1,77 @@
+import {
+  reconcileSubscriptionOwnership,
+  type EndpointSubscription,
+} from "./pushSubscriptionOwnership.ts";
+
+/** Where a device ended up after Remote tried to restore its registration. */
+export type PushDeviceRegistration =
+  /** This device holds a subscription the signed-in account owns. */
+  | "registered"
+  /** A subscription is present but the server could not confirm it yet. */
+  | "unverified"
+  /** This device receives nothing, and nothing may be created without asking. */
+  | "absent";
+
+/**
+ * Everything the restore policy is allowed to touch. Passing the browser and
+ * the server in as functions keeps the policy — which is the part that decides
+ * whether a user gets asked for permission again — testable on its own.
+ */
+export interface PushDeviceEnvironment<T extends EndpointSubscription> {
+  /** The subscription this browser currently holds, if any. */
+  existing: T | null;
+  /** Whether the endpoint was signed with the key the server signs with today. */
+  matchesServerKey: (subscription: T) => boolean;
+  /** Server answer for one endpoint; rejects when the server cannot answer. */
+  ownsEndpoint: (endpoint: string) => Promise<boolean>;
+  /** Whether this account already turned notifications on in this browser. */
+  optedIn: boolean;
+  /** True only when permission is already granted, so restoring never prompts. */
+  permissionGranted: boolean;
+  unsubscribeLocal: (subscription: T) => Promise<unknown>;
+  forgetOnServer: (endpoint: string) => Promise<unknown>;
+  subscribeLocal: () => Promise<T>;
+  registerOnServer: (subscription: T) => Promise<unknown>;
+}
+
+/**
+ * Restores what the user already agreed to, without ever asking again.
+ *
+ * A push subscription outlives neither a rotated VAPID key nor a push service
+ * that retires an endpoint, and the server's record of it can disappear with a
+ * restore of `DATA_DIR`. None of that is the user withdrawing consent, so when
+ * this device is missing a usable subscription and permission is still granted,
+ * a replacement is created and registered silently. A permission prompt only
+ * ever comes from the user pressing "Turn on".
+ */
+export async function restoreDeviceRegistration<T extends EndpointSubscription>(
+  environment: PushDeviceEnvironment<T>
+): Promise<PushDeviceRegistration> {
+  const existing = environment.existing;
+  if (existing) {
+    if (environment.matchesServerKey(existing)) {
+      const ownership = await reconcileSubscriptionOwnership(
+        existing,
+        environment.ownsEndpoint,
+        environment.unsubscribeLocal
+      );
+      if (ownership === "owned") return "registered";
+      // Keep an unconfirmed registration exactly as it is: the server being
+      // unreachable — mid-update, or offline — is not the user turning
+      // notifications off, and discarding it here would cost the subscription.
+      if (ownership === "unverified") return "unverified";
+      // "foreign": already unsubscribed locally. Fall through and mint one for
+      // the account that is actually signed in.
+    } else {
+      // Signed with a retired key, so the push service can never deliver to it.
+      await environment.forgetOnServer(existing.endpoint);
+      await environment.unsubscribeLocal(existing);
+    }
+  }
+
+  if (!environment.optedIn || !environment.permissionGranted) return "absent";
+
+  const created = await environment.subscribeLocal();
+  await environment.registerOnServer(created);
+  return "registered";
+}

--- a/frontend/src/api/pushServiceWorkerAccount.test.ts
+++ b/frontend/src/api/pushServiceWorkerAccount.test.ts
@@ -82,13 +82,13 @@ test("the worker drops and invalidates a previous account's endpoint", async () 
   assert.equal(harness.unsubscribed(), 1);
 });
 
-test("the worker drops and invalidates pushes after logout", async () => {
+test("the worker stays quiet without a session, keeping the device registered", async () => {
   const harness = workerHarness({ status: 401 });
 
   await harness.receivePush();
 
   assert.equal(harness.displayed(), 0);
-  assert.equal(harness.unsubscribed(), 1);
+  assert.equal(harness.unsubscribed(), 0);
 });
 
 test("the worker fails closed without deleting a subscription on a transient error", async () => {

--- a/frontend/src/api/pushServiceWorkerResubscribe.test.ts
+++ b/frontend/src/api/pushServiceWorkerResubscribe.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+type ChangeEvent = {
+  oldSubscription?: unknown;
+  newSubscription?: unknown;
+  waitUntil: (promise: Promise<unknown>) => void;
+};
+
+interface Call {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+function subscriptionAt(endpoint: string, applicationServerKey?: ArrayBuffer) {
+  return {
+    endpoint,
+    options: applicationServerKey ? { applicationServerKey } : {},
+    toJSON: () => ({ endpoint, keys: { p256dh: "p256dh", auth: "auth" } }),
+  };
+}
+
+const RETIRED = "https://push.example.com/retired";
+const REPLACEMENT = "https://push.example.com/replacement";
+
+function workerHarness(options: { owned?: boolean; statusCode?: number } = {}) {
+  const listeners = new Map<string, (event: ChangeEvent) => void>();
+  const calls: Call[] = [];
+  let created = 0;
+
+  const worker = {
+    registration: {
+      pushManager: {
+        getSubscription: async () => null,
+        subscribe: async (subscribeOptions: { applicationServerKey: unknown }) => {
+          assert.ok(subscribeOptions.applicationServerKey, "subscribe needs a server key");
+          created++;
+          return subscriptionAt(REPLACEMENT);
+        },
+      },
+      showNotification: async () => {},
+    },
+    clients: { claim: async () => {} },
+    skipWaiting: () => {},
+    addEventListener: (type: string, listener: (event: ChangeEvent) => void) => {
+      listeners.set(type, listener);
+    },
+  };
+
+  const script = readFileSync(new URL("../../public/sw.js", import.meta.url), "utf8");
+  vm.runInNewContext(script, {
+    self: worker,
+    fetch: async (url: string, init: { method?: string; body?: string } = {}) => {
+      calls.push({
+        url,
+        method: init.method ?? "GET",
+        body: init.body ? JSON.parse(init.body) : undefined,
+      });
+      const status = options.statusCode ?? 200;
+      return {
+        status,
+        ok: status >= 200 && status < 300,
+        json: async () => ({ owned: options.owned ?? true }),
+      };
+    },
+    JSON,
+    Date,
+    URL,
+    setTimeout,
+    clearTimeout,
+  });
+
+  return {
+    async rotate(event: Omit<ChangeEvent, "waitUntil">): Promise<void> {
+      let work: Promise<unknown> | undefined;
+      listeners.get("pushsubscriptionchange")?.({
+        ...event,
+        waitUntil: (promise) => {
+          work = Promise.resolve(promise);
+        },
+      });
+      await work;
+    },
+    calls: () => calls,
+    created: () => created,
+  };
+}
+
+test("a retired endpoint is replaced and re-registered without the user acting", async () => {
+  const harness = workerHarness();
+
+  await harness.rotate({ oldSubscription: subscriptionAt(RETIRED, new ArrayBuffer(65)) });
+
+  const [ownership, registration, removal] = harness.calls();
+  assert.equal(harness.created(), 1);
+  assert.equal(ownership.url, "/api/push/subscriptions/status");
+  assert.equal(registration.method, "POST");
+  assert.equal((registration.body as { endpoint: string }).endpoint, REPLACEMENT);
+  // The retired endpoint would otherwise sit in the account's registrations
+  // forever, unreachable.
+  assert.equal(removal.method, "DELETE");
+  assert.deepEqual(removal.body, { endpoint: RETIRED });
+});
+
+test("a replacement the browser already made is registered as it is", async () => {
+  const harness = workerHarness();
+
+  await harness.rotate({
+    oldSubscription: subscriptionAt(RETIRED, new ArrayBuffer(65)),
+    newSubscription: subscriptionAt("https://push.example.com/browser-made"),
+  });
+
+  assert.equal(harness.created(), 0);
+  assert.equal(
+    (harness.calls()[1].body as { endpoint: string }).endpoint,
+    "https://push.example.com/browser-made"
+  );
+});
+
+test("an endpoint the signed-in account does not own is not replaced", async () => {
+  const harness = workerHarness({ owned: false });
+
+  await harness.rotate({ oldSubscription: subscriptionAt(RETIRED, new ArrayBuffer(65)) });
+
+  assert.equal(harness.created(), 0);
+  assert.deepEqual(
+    harness.calls().map((call) => call.url),
+    ["/api/push/subscriptions/status"]
+  );
+});
+
+test("a rotation while signed out is left for the app to restore", async () => {
+  const harness = workerHarness({ statusCode: 401 });
+
+  await harness.rotate({ oldSubscription: subscriptionAt(RETIRED, new ArrayBuffer(65)) });
+
+  assert.equal(harness.created(), 0);
+  assert.deepEqual(
+    harness.calls().map((call) => call.url),
+    ["/api/push/subscriptions/status"]
+  );
+});
+
+test("a rotation the browser reports no old endpoint for changes nothing", async () => {
+  const harness = workerHarness();
+
+  await harness.rotate({});
+
+  assert.equal(harness.created(), 0);
+  assert.deepEqual(harness.calls(), []);
+});

--- a/frontend/src/api/pushSubscriptionApi.ts
+++ b/frontend/src/api/pushSubscriptionApi.ts
@@ -7,7 +7,7 @@ import {
   type PushDeviceRegistration,
 } from "./pushDeviceRegistration.ts";
 import { revokeSubscriptionForLogout } from "./pushSubscriptionOwnership.ts";
-import { forgetOptIn, hasOptedIn, rememberOptIn } from "../shared/pushDeviceOptIn.ts";
+import { pushDeviceOptIn } from "../shared/pushDeviceOptIn.ts";
 
 class PushSubscriptionApi {
   /** Why this browser cannot subscribe, or null when it can. */
@@ -38,7 +38,7 @@ class PushSubscriptionApi {
     if (!registration) return "absent";
 
     const existing = await webPushTransport.currentSubscription(registration);
-    const optedIn = hasOptedIn(account);
+    const optedIn = pushDeviceOptIn.has(account);
     // A device with nothing registered that was never asked to receive
     // anything needs no server round trip at all.
     if (!existing && !optedIn) return "absent";
@@ -105,14 +105,14 @@ class PushSubscriptionApi {
     await pushApi.subscribe(this.#payload(subscription));
     // Remembered last: only a registration that reached the server should be
     // restored without asking.
-    rememberOptIn(account);
+    pushDeviceOptIn.remember(account);
   }
 
   /** Removes this device, both locally and on the server. */
   async disable(account: string): Promise<void> {
     // Forget the opt-in first, so a restore racing this cannot resurrect the
     // subscription the user just asked to be rid of.
-    forgetOptIn(account);
+    pushDeviceOptIn.forget(account);
     const subscription = await this.#currentSubscription();
     if (!subscription) return;
     // Tell the server first: if unsubscribing locally succeeded but the server
@@ -123,7 +123,7 @@ class PushSubscriptionApi {
 
   /** Revokes this browser on both sides before its session cookie is cleared. */
   async prepareForLogout(account: string): Promise<void> {
-    forgetOptIn(account);
+    pushDeviceOptIn.forget(account);
     const subscription = await this.#currentSubscription();
     if (!subscription) return;
 

--- a/frontend/src/api/pushSubscriptionApi.ts
+++ b/frontend/src/api/pushSubscriptionApi.ts
@@ -56,11 +56,19 @@ class PushSubscriptionApi {
           // Restoring must never surface a prompt: only "Turn on" may do that.
           permissionGranted: webPushTransport.notificationPermission === "granted",
         },
-        this.#restorePorts(registration, serverKey, account)
+        this.#restorePorts(registration, serverKey)
       );
-    } catch {
-      // A failed restore must not read as "the user turned this off". Report
-      // what the device still holds and try again on the next boot or focus.
+    } catch (cause) {
+      // The server refused the re-created device outright — the account is at
+      // its device cap, or the browser produced keys the server rejects.
+      // Retrying on every boot would unsubscribe and resubscribe forever, and
+      // on Safari each unsubscribe can cost the notification permission
+      // itself, so stop asking. Pressing "Turn on" still surfaces this same
+      // error to the user.
+      if (isDefinitiveRejection(cause)) await pushDeviceOptIn.forget(account);
+      // A failed restore must not otherwise read as "the user turned this
+      // off". Report what the device still holds and try again on the next
+      // boot or focus.
       const remaining = await webPushTransport
         .currentSubscription(registration)
         .catch(() => null);
@@ -135,8 +143,7 @@ class PushSubscriptionApi {
   /** What restoring one device is allowed to do to this browser and account. */
   #restorePorts(
     registration: ServiceWorkerRegistration,
-    serverKey: string,
-    account: string
+    serverKey: string
   ): PushDevicePorts<PushSubscription> {
     return {
       isSignedWithRetiredKey: (subscription) =>
@@ -150,18 +157,7 @@ class PushSubscriptionApi {
       },
       createRegistration: async () => {
         const created = await webPushTransport.subscribe(registration, serverKey);
-        try {
-          await pushApi.subscribe(this.#payload(created));
-        } catch (cause) {
-          // The server refused this device outright — the account is at its
-          // device cap, or the browser produced keys the server rejects.
-          // Retrying on every boot would unsubscribe and resubscribe forever,
-          // and on Safari each unsubscribe can cost the notification
-          // permission itself. Forget the opt-in so restore goes quiet;
-          // pressing "Turn on" still surfaces this same error to the user.
-          if (isDefinitiveRejection(cause)) await pushDeviceOptIn.forget(account);
-          throw cause;
-        }
+        await pushApi.subscribe(this.#payload(created));
       },
     };
   }

--- a/frontend/src/api/pushSubscriptionApi.ts
+++ b/frontend/src/api/pushSubscriptionApi.ts
@@ -1,3 +1,4 @@
+import { isDefinitiveRejection } from "./apiError.ts";
 import { pushApi } from "./pushApi";
 import { pushServiceWorkerApi } from "./pushServiceWorkerApi";
 import type { PushBlocker, PushSubscriptionPayload } from "../models/push";
@@ -55,7 +56,7 @@ class PushSubscriptionApi {
           // Restoring must never surface a prompt: only "Turn on" may do that.
           permissionGranted: webPushTransport.notificationPermission === "granted",
         },
-        this.#restorePorts(registration, serverKey)
+        this.#restorePorts(registration, serverKey, account)
       );
     } catch {
       // A failed restore must not read as "the user turned this off". Report
@@ -134,7 +135,8 @@ class PushSubscriptionApi {
   /** What restoring one device is allowed to do to this browser and account. */
   #restorePorts(
     registration: ServiceWorkerRegistration,
-    serverKey: string
+    serverKey: string,
+    account: string
   ): PushDevicePorts<PushSubscription> {
     return {
       isSignedWithRetiredKey: (subscription) =>
@@ -148,7 +150,18 @@ class PushSubscriptionApi {
       },
       createRegistration: async () => {
         const created = await webPushTransport.subscribe(registration, serverKey);
-        await pushApi.subscribe(this.#payload(created));
+        try {
+          await pushApi.subscribe(this.#payload(created));
+        } catch (cause) {
+          // The server refused this device outright — the account is at its
+          // device cap, or the browser produced keys the server rejects.
+          // Retrying on every boot would unsubscribe and resubscribe forever,
+          // and on Safari each unsubscribe can cost the notification
+          // permission itself. Forget the opt-in so restore goes quiet;
+          // pressing "Turn on" still surfaces this same error to the user.
+          if (isDefinitiveRejection(cause)) await pushDeviceOptIn.forget(account);
+          throw cause;
+        }
       },
     };
   }

--- a/frontend/src/api/pushSubscriptionApi.ts
+++ b/frontend/src/api/pushSubscriptionApi.ts
@@ -3,9 +3,11 @@ import { pushServiceWorkerApi } from "./pushServiceWorkerApi";
 import type { PushBlocker, PushSubscriptionPayload } from "../models/push";
 import { webPushTransport } from "../transport/webPushTransport";
 import {
-  reconcileSubscriptionOwnership,
-  revokeSubscriptionForLogout,
-} from "./pushSubscriptionOwnership";
+  restoreDeviceRegistration,
+  type PushDeviceRegistration,
+} from "./pushDeviceRegistration.ts";
+import { revokeSubscriptionForLogout } from "./pushSubscriptionOwnership.ts";
+import { forgetOptIn, hasOptedIn, rememberOptIn } from "../shared/pushDeviceOptIn.ts";
 
 class PushSubscriptionApi {
   /** Why this browser cannot subscribe, or null when it can. */
@@ -24,26 +26,55 @@ class PushSubscriptionApi {
   }
 
   /**
-   * Removes an origin-wide browser subscription unless the server confirms
-   * that its exact endpoint belongs to the signed-in account. This runs on
-   * every authenticated app boot, not only when Settings happens to open.
+   * Brings this device back to whatever the account already asked for, and
+   * runs on every authenticated app boot — not only when Settings happens to
+   * open. A subscription the browser or a deploy invalidated is replaced
+   * silently; one belonging to another account is dropped; one the server
+   * cannot confirm right now is left alone.
    */
-  async reconcileCurrentAccount(): Promise<boolean> {
-    const subscription = await this.#currentSubscription();
-    if (!subscription) return false;
+  async ensureRegistered(account: string, publicKey?: string): Promise<PushDeviceRegistration> {
+    if (!account || !this.#browserCanSubscribe()) return "absent";
+    const registration = await this.#registration();
+    if (!registration) return "absent";
 
-    return reconcileSubscriptionOwnership(
-      subscription,
-      async (endpoint) => (await pushApi.subscriptionStatus(endpoint)).owned,
-      (candidate) => webPushTransport.unsubscribe(candidate)
-    );
+    const existing = await webPushTransport.currentSubscription(registration);
+    const optedIn = hasOptedIn(account);
+    // A device with nothing registered that was never asked to receive
+    // anything needs no server round trip at all.
+    if (!existing && !optedIn) return "absent";
+
+    const serverKey = publicKey ?? (await this.#serverKey());
+    if (!serverKey) return "absent";
+
+    try {
+      return await restoreDeviceRegistration<PushSubscription>({
+        existing,
+        matchesServerKey: (subscription) =>
+          !webPushTransport.isStaleForApplicationServerKey(subscription, serverKey),
+        ownsEndpoint: async (endpoint) => (await pushApi.subscriptionStatus(endpoint)).owned,
+        optedIn,
+        // Restoring must never surface a prompt: only "Turn on" may do that.
+        permissionGranted: webPushTransport.notificationPermission === "granted",
+        unsubscribeLocal: (subscription) => webPushTransport.unsubscribe(subscription),
+        forgetOnServer: (endpoint) => pushApi.unsubscribe(endpoint).catch(() => undefined),
+        subscribeLocal: () => webPushTransport.subscribe(registration, serverKey),
+        registerOnServer: (subscription) => pushApi.subscribe(this.#payload(subscription)),
+      });
+    } catch {
+      // A failed restore must not read as "the user turned this off". Report
+      // what the device still holds and try again on the next boot or focus.
+      const remaining = await webPushTransport
+        .currentSubscription(registration)
+        .catch(() => null);
+      return remaining ? "unverified" : "absent";
+    }
   }
 
   /**
    * Asks for permission, subscribes this device, and registers it with the
    * server. Must be called from a user gesture — iOS rejects it otherwise.
    */
-  async enable(publicKey: string): Promise<void> {
+  async enable(account: string, publicKey: string): Promise<void> {
     // Ask first, before any await. Safari ties requestPermission to the user
     // activation that triggered it, and awaiting anything first spends it.
     const permission = await webPushTransport.requestPermission();
@@ -63,7 +94,7 @@ class PushSubscriptionApi {
     const existing = await webPushTransport.currentSubscription(registration);
     // A stored subscription signed with a previous server key can never be
     // delivered to, so replace it rather than reporting success.
-    if (existing && !webPushTransport.matchesApplicationServerKey(existing, publicKey)) {
+    if (existing && webPushTransport.isStaleForApplicationServerKey(existing, publicKey)) {
       await webPushTransport.unsubscribe(existing);
     }
 
@@ -72,10 +103,16 @@ class PushSubscriptionApi {
       (await webPushTransport.subscribe(registration, publicKey));
 
     await pushApi.subscribe(this.#payload(subscription));
+    // Remembered last: only a registration that reached the server should be
+    // restored without asking.
+    rememberOptIn(account);
   }
 
   /** Removes this device, both locally and on the server. */
-  async disable(): Promise<void> {
+  async disable(account: string): Promise<void> {
+    // Forget the opt-in first, so a restore racing this cannot resurrect the
+    // subscription the user just asked to be rid of.
+    forgetOptIn(account);
     const subscription = await this.#currentSubscription();
     if (!subscription) return;
     // Tell the server first: if unsubscribing locally succeeded but the server
@@ -85,7 +122,8 @@ class PushSubscriptionApi {
   }
 
   /** Revokes this browser on both sides before its session cookie is cleared. */
-  async prepareForLogout(): Promise<void> {
+  async prepareForLogout(account: string): Promise<void> {
+    forgetOptIn(account);
     const subscription = await this.#currentSubscription();
     if (!subscription) return;
 
@@ -96,10 +134,44 @@ class PushSubscriptionApi {
     );
   }
 
+  /** Whether this browser exposes the APIs a subscription needs at all. */
+  #browserCanSubscribe(): boolean {
+    return (
+      pushServiceWorkerApi.isSupported &&
+      webPushTransport.isPushManagerSupported &&
+      webPushTransport.isNotificationSupported
+    );
+  }
+
+  async #serverKey(): Promise<string> {
+    try {
+      const config = await pushApi.config();
+      return config.enabled ? config.publicKey : "";
+    } catch {
+      return "";
+    }
+  }
+
   #payload(subscription: PushSubscription): PushSubscriptionPayload {
     // PushManager-created subscriptions contain the endpoint and both keys.
     // Keep the browser's serialized object intact at the server boundary.
     return subscription.toJSON() as PushSubscriptionPayload;
+  }
+
+  /**
+   * The worker backing this origin, registering it when the browser has none.
+   * A dropped registration takes the push subscription with it, so re-creating
+   * it is the first half of restoring a device.
+   */
+  async #registration(): Promise<ServiceWorkerRegistration | null> {
+    if (!pushServiceWorkerApi.isSupported) return null;
+    const existing = await pushServiceWorkerApi.currentRegistration();
+    if (existing) return existing;
+    const registered = await pushServiceWorkerApi.register();
+    if (!registered) return null;
+    // PushManager needs an active worker, not merely a queued install.
+    await pushServiceWorkerApi.ready();
+    return registered;
   }
 
   async #currentSubscription(): Promise<PushSubscription | null> {

--- a/frontend/src/api/pushSubscriptionApi.ts
+++ b/frontend/src/api/pushSubscriptionApi.ts
@@ -4,7 +4,8 @@ import type { PushBlocker, PushSubscriptionPayload } from "../models/push";
 import { webPushTransport } from "../transport/webPushTransport";
 import {
   restoreDeviceRegistration,
-  type PushDeviceRegistration,
+  type PushDevicePorts,
+  type PushDeviceState,
 } from "./pushDeviceRegistration.ts";
 import { revokeSubscriptionForLogout } from "./pushSubscriptionOwnership.ts";
 import { pushDeviceOptIn } from "../shared/pushDeviceOptIn.ts";
@@ -32,7 +33,7 @@ class PushSubscriptionApi {
    * silently; one belonging to another account is dropped; one the server
    * cannot confirm right now is left alone.
    */
-  async ensureRegistered(account: string, publicKey?: string): Promise<PushDeviceRegistration> {
+  async ensureRegistered(account: string, publicKey?: string): Promise<PushDeviceState> {
     if (!account || !this.#browserCanSubscribe()) return "absent";
     const registration = await this.#registration();
     if (!registration) return "absent";
@@ -43,23 +44,19 @@ class PushSubscriptionApi {
     // anything needs no server round trip at all.
     if (!existing && !optedIn) return "absent";
 
-    const serverKey = publicKey ?? (await this.#serverKey());
+    const serverKey = publicKey ?? (await this.#fetchServerKey());
     if (!serverKey) return "absent";
 
     try {
-      return await restoreDeviceRegistration<PushSubscription>({
-        existing,
-        matchesServerKey: (subscription) =>
-          !webPushTransport.isStaleForApplicationServerKey(subscription, serverKey),
-        ownsEndpoint: async (endpoint) => (await pushApi.subscriptionStatus(endpoint)).owned,
-        optedIn,
-        // Restoring must never surface a prompt: only "Turn on" may do that.
-        permissionGranted: webPushTransport.notificationPermission === "granted",
-        unsubscribeLocal: (subscription) => webPushTransport.unsubscribe(subscription),
-        forgetOnServer: (endpoint) => pushApi.unsubscribe(endpoint).catch(() => undefined),
-        subscribeLocal: () => webPushTransport.subscribe(registration, serverKey),
-        registerOnServer: (subscription) => pushApi.subscribe(this.#payload(subscription)),
-      });
+      return await restoreDeviceRegistration(
+        {
+          subscription: existing,
+          optedIn,
+          // Restoring must never surface a prompt: only "Turn on" may do that.
+          permissionGranted: webPushTransport.notificationPermission === "granted",
+        },
+        this.#restorePorts(registration, serverKey)
+      );
     } catch {
       // A failed restore must not read as "the user turned this off". Report
       // what the device still holds and try again on the next boot or focus.
@@ -94,7 +91,7 @@ class PushSubscriptionApi {
     const existing = await webPushTransport.currentSubscription(registration);
     // A stored subscription signed with a previous server key can never be
     // delivered to, so replace it rather than reporting success.
-    if (existing && webPushTransport.isStaleForApplicationServerKey(existing, publicKey)) {
+    if (existing && webPushTransport.isSignedWithRetiredKey(existing, publicKey)) {
       await webPushTransport.unsubscribe(existing);
     }
 
@@ -134,6 +131,28 @@ class PushSubscriptionApi {
     );
   }
 
+  /** What restoring one device is allowed to do to this browser and account. */
+  #restorePorts(
+    registration: ServiceWorkerRegistration,
+    serverKey: string
+  ): PushDevicePorts<PushSubscription> {
+    return {
+      isSignedWithRetiredKey: (subscription) =>
+        webPushTransport.isSignedWithRetiredKey(subscription, serverKey),
+      ownsEndpoint: async (endpoint) => (await pushApi.subscriptionStatus(endpoint)).owned,
+      invalidateLocally: (subscription) => webPushTransport.unsubscribe(subscription),
+      discardRegistration: async (subscription) => {
+        // The server first: an endpoint it kept would keep being pushed to.
+        await pushApi.unsubscribe(subscription.endpoint).catch(() => undefined);
+        await webPushTransport.unsubscribe(subscription);
+      },
+      createRegistration: async () => {
+        const created = await webPushTransport.subscribe(registration, serverKey);
+        await pushApi.subscribe(this.#payload(created));
+      },
+    };
+  }
+
   /** Whether this browser exposes the APIs a subscription needs at all. */
   #browserCanSubscribe(): boolean {
     return (
@@ -143,7 +162,7 @@ class PushSubscriptionApi {
     );
   }
 
-  async #serverKey(): Promise<string> {
+  async #fetchServerKey(): Promise<string> {
     try {
       const config = await pushApi.config();
       return config.enabled ? config.publicKey : "";

--- a/frontend/src/api/pushSubscriptionApi.ts
+++ b/frontend/src/api/pushSubscriptionApi.ts
@@ -39,7 +39,7 @@ class PushSubscriptionApi {
     if (!registration) return "absent";
 
     const existing = await webPushTransport.currentSubscription(registration);
-    const optedIn = pushDeviceOptIn.has(account);
+    const optedIn = await pushDeviceOptIn.has(account);
     // A device with nothing registered that was never asked to receive
     // anything needs no server round trip at all.
     if (!existing && !optedIn) return "absent";
@@ -102,14 +102,14 @@ class PushSubscriptionApi {
     await pushApi.subscribe(this.#payload(subscription));
     // Remembered last: only a registration that reached the server should be
     // restored without asking.
-    pushDeviceOptIn.remember(account);
+    await pushDeviceOptIn.remember(account);
   }
 
   /** Removes this device, both locally and on the server. */
   async disable(account: string): Promise<void> {
     // Forget the opt-in first, so a restore racing this cannot resurrect the
     // subscription the user just asked to be rid of.
-    pushDeviceOptIn.forget(account);
+    await pushDeviceOptIn.forget(account);
     const subscription = await this.#currentSubscription();
     if (!subscription) return;
     // Tell the server first: if unsubscribing locally succeeded but the server
@@ -120,7 +120,7 @@ class PushSubscriptionApi {
 
   /** Revokes this browser on both sides before its session cookie is cleared. */
   async prepareForLogout(account: string): Promise<void> {
-    pushDeviceOptIn.forget(account);
+    await pushDeviceOptIn.forget(account);
     const subscription = await this.#currentSubscription();
     if (!subscription) return;
 

--- a/frontend/src/api/pushSubscriptionOwnership.test.ts
+++ b/frontend/src/api/pushSubscriptionOwnership.test.ts
@@ -10,7 +10,7 @@ const subscription = { endpoint: "https://push.example.com/browser-device" };
 
 test("an endpoint owned by the signed-in account remains subscribed", async () => {
   let invalidations = 0;
-  const retained = await reconcileSubscriptionOwnership(
+  const ownership = await reconcileSubscriptionOwnership(
     subscription,
     async () => true,
     async () => {
@@ -18,13 +18,13 @@ test("an endpoint owned by the signed-in account remains subscribed", async () =
     }
   );
 
-  assert.equal(retained, true);
+  assert.equal(ownership, "owned");
   assert.equal(invalidations, 0);
 });
 
 test("an endpoint belonging to another account is invalidated locally", async () => {
   let invalidations = 0;
-  const retained = await reconcileSubscriptionOwnership(
+  const ownership = await reconcileSubscriptionOwnership(
     subscription,
     async () => false,
     async () => {
@@ -32,13 +32,13 @@ test("an endpoint belonging to another account is invalidated locally", async ()
     }
   );
 
-  assert.equal(retained, false);
+  assert.equal(ownership, "foreign");
   assert.equal(invalidations, 1);
 });
 
-test("ownership checks fail closed when the account cannot be verified", async () => {
+test("an unreachable server leaves the registration alone", async () => {
   let invalidations = 0;
-  const retained = await reconcileSubscriptionOwnership(
+  const ownership = await reconcileSubscriptionOwnership(
     subscription,
     async () => {
       throw new Error("offline");
@@ -48,8 +48,8 @@ test("ownership checks fail closed when the account cannot be verified", async (
     }
   );
 
-  assert.equal(retained, false);
-  assert.equal(invalidations, 1);
+  assert.equal(ownership, "unverified");
+  assert.equal(invalidations, 0);
 });
 
 test("logout invalidates the browser even when server cleanup fails", async () => {

--- a/frontend/src/api/pushSubscriptionOwnership.ts
+++ b/frontend/src/api/pushSubscriptionOwnership.ts
@@ -1,24 +1,40 @@
 /** The browser subscription shape needed by account ownership policy. */
-interface EndpointSubscription {
+export interface EndpointSubscription {
   endpoint: string;
 }
 
 /**
- * Keeps a browser endpoint only when the authenticated account owns it.
- * Verification failures deliberately fail closed to protect shared browsers.
+ * What the server said about one browser endpoint.
+ *
+ * `unverified` is deliberately distinct from `foreign`: "the server says this
+ * belongs to somebody else" and "the server could not be reached" call for
+ * opposite actions, and treating them alike is what silently unregistered
+ * devices during every backend restart.
+ */
+export type SubscriptionOwnership = "owned" | "foreign" | "unverified";
+
+/**
+ * Keeps a browser endpoint unless the account that owns it is provably not the
+ * signed-in one. An endpoint left behind by another account is invalidated
+ * immediately; an unreachable server leaves the registration untouched, since
+ * the service worker re-checks ownership before displaying any notification
+ * and so nothing can leak while verification is pending.
  */
 export async function reconcileSubscriptionOwnership<T extends EndpointSubscription>(
   subscription: T,
   ownsEndpoint: (endpoint: string) => Promise<boolean>,
   invalidateLocal: (subscription: T) => Promise<unknown>
-): Promise<boolean> {
+): Promise<SubscriptionOwnership> {
+  let owned: boolean;
   try {
-    if (await ownsEndpoint(subscription.endpoint)) return true;
+    owned = await ownsEndpoint(subscription.endpoint);
   } catch {
-    // The endpoint is untrusted until its account ownership is proven.
+    return "unverified";
   }
+  if (owned) return "owned";
+
   await invalidateLocal(subscription);
-  return false;
+  return "foreign";
 }
 
 /** Removes both halves of a subscription, always invalidating the browser. */

--- a/frontend/src/app/containers/SettingsContainer.tsx
+++ b/frontend/src/app/containers/SettingsContainer.tsx
@@ -46,7 +46,10 @@ export function SettingsContainer({
       setUsageRebuilding(false);
     }
   }, [usageDashboard]);
-  const push = usePushNotifications(activeTab === "notifications");
+  const push = usePushNotifications(
+    activeTab === "notifications",
+    auth.email || auth.adminEmail
+  );
 
   return (
     <SettingsPage

--- a/frontend/src/app/containers/SidebarContainer.tsx
+++ b/frontend/src/app/containers/SidebarContainer.tsx
@@ -17,7 +17,7 @@ export function SidebarContainer() {
     workspace.chats
   );
   const commands = useWorkspaceCommands();
-  const signOut = useAccountSignOut();
+  const signOut = useAccountSignOut(auth.email || auth.adminEmail);
   const model = useMemo(
     () => workspaceSidebarState.model(workspace.chats, workspace.projects, sidebar.query),
     [workspace.chats, workspace.projects, sidebar.query]

--- a/frontend/src/config/storageKeys.ts
+++ b/frontend/src/config/storageKeys.ts
@@ -12,4 +12,5 @@ export const STORAGE_KEYS = {
   sidebarCollapsed: "remote.futrx.sidebarCollapsed",
   collapsedProjects: "remote.futrx.collapsedProjects",
   workspaceBoot: "remote.futrx.workspaceBoot",
+  pushOptIn: "remote.futrx.pushOptIn",
 } as const;

--- a/frontend/src/shared/browserStore.ts
+++ b/frontend/src/shared/browserStore.ts
@@ -27,6 +27,12 @@ export function writeString(key: string, value: string): void {
   } catch {}
 }
 
+export function removeString(key: string): void {
+  try {
+    store()?.removeItem(key);
+  } catch {}
+}
+
 export function readBool(key: string): boolean {
   return readString(key) === "true";
 }

--- a/frontend/src/shared/pushDeviceOptIn.test.ts
+++ b/frontend/src/shared/pushDeviceOptIn.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { pushDeviceOptIn } from "./pushDeviceOptIn.ts";
 
-function useMemoryStorage(): void {
+function useMemoryStorage(): Map<string, string> {
   const entries = new Map<string, string>();
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
@@ -17,36 +17,48 @@ function useMemoryStorage(): void {
       },
     },
   });
+  return entries;
 }
 
-test("an account that turned notifications on is remembered for this browser", () => {
+test("an account that turned notifications on is remembered for this browser", async () => {
   useMemoryStorage();
 
-  pushDeviceOptIn.remember("Person@Example.com");
+  await pushDeviceOptIn.remember("Person@Example.com");
 
-  assert.equal(pushDeviceOptIn.has("person@example.com"), true);
+  assert.equal(await pushDeviceOptIn.has("person@example.com"), true);
 });
 
-test("one account's opt-in never speaks for another in a shared browser", () => {
+test("the stored record never contains the account's address", async () => {
+  const entries = useMemoryStorage();
+
+  await pushDeviceOptIn.remember("Person@Example.com");
+
+  const stored = [...entries.values()].join(" ").toLowerCase();
+  assert.ok(stored.length > 0, "an opt-in was stored");
+  assert.ok(!stored.includes("person"), "no local part at rest");
+  assert.ok(!stored.includes("example.com"), "no domain at rest");
+});
+
+test("one account's opt-in never speaks for another in a shared browser", async () => {
   useMemoryStorage();
 
-  pushDeviceOptIn.remember("first@example.com");
+  await pushDeviceOptIn.remember("first@example.com");
 
-  assert.equal(pushDeviceOptIn.has("second@example.com"), false);
+  assert.equal(await pushDeviceOptIn.has("second@example.com"), false);
 });
 
-test("turning notifications off stops the device from being restored", () => {
+test("turning notifications off stops the device from being restored", async () => {
   useMemoryStorage();
-  pushDeviceOptIn.remember("first@example.com");
-  pushDeviceOptIn.remember("second@example.com");
+  await pushDeviceOptIn.remember("first@example.com");
+  await pushDeviceOptIn.remember("second@example.com");
 
-  pushDeviceOptIn.forget("first@example.com");
+  await pushDeviceOptIn.forget("first@example.com");
 
-  assert.equal(pushDeviceOptIn.has("first@example.com"), false);
-  assert.equal(pushDeviceOptIn.has("second@example.com"), true);
+  assert.equal(await pushDeviceOptIn.has("first@example.com"), false);
+  assert.equal(await pushDeviceOptIn.has("second@example.com"), true);
 });
 
-test("an unusable store is not an opt-in", () => {
+test("an unusable store is not an opt-in", async () => {
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
     get() {
@@ -54,7 +66,7 @@ test("an unusable store is not an opt-in", () => {
     },
   });
 
-  pushDeviceOptIn.remember("first@example.com");
+  await pushDeviceOptIn.remember("first@example.com");
 
-  assert.equal(pushDeviceOptIn.has("first@example.com"), false);
+  assert.equal(await pushDeviceOptIn.has("first@example.com"), false);
 });

--- a/frontend/src/shared/pushDeviceOptIn.test.ts
+++ b/frontend/src/shared/pushDeviceOptIn.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { forgetOptIn, hasOptedIn, rememberOptIn } from "./pushDeviceOptIn.ts";
+
+function useMemoryStorage(): void {
+  const entries = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => entries.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        entries.set(key, value);
+      },
+      removeItem: (key: string) => {
+        entries.delete(key);
+      },
+    },
+  });
+}
+
+test("an account that turned notifications on is remembered for this browser", () => {
+  useMemoryStorage();
+
+  rememberOptIn("Person@Example.com");
+
+  assert.equal(hasOptedIn("person@example.com"), true);
+});
+
+test("one account's opt-in never speaks for another in a shared browser", () => {
+  useMemoryStorage();
+
+  rememberOptIn("first@example.com");
+
+  assert.equal(hasOptedIn("second@example.com"), false);
+});
+
+test("turning notifications off stops the device from being restored", () => {
+  useMemoryStorage();
+  rememberOptIn("first@example.com");
+  rememberOptIn("second@example.com");
+
+  forgetOptIn("first@example.com");
+
+  assert.equal(hasOptedIn("first@example.com"), false);
+  assert.equal(hasOptedIn("second@example.com"), true);
+});
+
+test("an unusable store is not an opt-in", () => {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    get() {
+      throw new Error("blocked");
+    },
+  });
+
+  rememberOptIn("first@example.com");
+
+  assert.equal(hasOptedIn("first@example.com"), false);
+});

--- a/frontend/src/shared/pushDeviceOptIn.test.ts
+++ b/frontend/src/shared/pushDeviceOptIn.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { forgetOptIn, hasOptedIn, rememberOptIn } from "./pushDeviceOptIn.ts";
+import { pushDeviceOptIn } from "./pushDeviceOptIn.ts";
 
 function useMemoryStorage(): void {
   const entries = new Map<string, string>();
@@ -22,28 +22,28 @@ function useMemoryStorage(): void {
 test("an account that turned notifications on is remembered for this browser", () => {
   useMemoryStorage();
 
-  rememberOptIn("Person@Example.com");
+  pushDeviceOptIn.remember("Person@Example.com");
 
-  assert.equal(hasOptedIn("person@example.com"), true);
+  assert.equal(pushDeviceOptIn.has("person@example.com"), true);
 });
 
 test("one account's opt-in never speaks for another in a shared browser", () => {
   useMemoryStorage();
 
-  rememberOptIn("first@example.com");
+  pushDeviceOptIn.remember("first@example.com");
 
-  assert.equal(hasOptedIn("second@example.com"), false);
+  assert.equal(pushDeviceOptIn.has("second@example.com"), false);
 });
 
 test("turning notifications off stops the device from being restored", () => {
   useMemoryStorage();
-  rememberOptIn("first@example.com");
-  rememberOptIn("second@example.com");
+  pushDeviceOptIn.remember("first@example.com");
+  pushDeviceOptIn.remember("second@example.com");
 
-  forgetOptIn("first@example.com");
+  pushDeviceOptIn.forget("first@example.com");
 
-  assert.equal(hasOptedIn("first@example.com"), false);
-  assert.equal(hasOptedIn("second@example.com"), true);
+  assert.equal(pushDeviceOptIn.has("first@example.com"), false);
+  assert.equal(pushDeviceOptIn.has("second@example.com"), true);
 });
 
 test("an unusable store is not an opt-in", () => {
@@ -54,7 +54,7 @@ test("an unusable store is not an opt-in", () => {
     },
   });
 
-  rememberOptIn("first@example.com");
+  pushDeviceOptIn.remember("first@example.com");
 
-  assert.equal(hasOptedIn("first@example.com"), false);
+  assert.equal(pushDeviceOptIn.has("first@example.com"), false);
 });

--- a/frontend/src/shared/pushDeviceOptIn.ts
+++ b/frontend/src/shared/pushDeviceOptIn.ts
@@ -6,46 +6,54 @@
 // locally is what lets the app restore the subscription silently instead of
 // asking the user to allow notifications all over again.
 //
-// It is keyed by account because a browser subscription belongs to the whole
-// origin: on a shared browser, one user's opt-in must never quietly turn
+// It is recorded per account because a browser subscription belongs to the
+// whole origin: on a shared browser, one user's opt-in must never quietly turn
 // notifications on for the next person who signs in.
+//
+// Leaf module: it owns one list in the browser's store and knows nothing about
+// subscriptions, the server, or who is signed in.
 
 import { STORAGE_KEYS } from "../config/storageKeys.ts";
 import { readJson, removeString, writeJson } from "./browserStore.ts";
 
-function normalize(account: string): string {
-  return account.trim().toLowerCase();
-}
-
-function accounts(): string[] {
-  const stored = readJson(STORAGE_KEYS.pushOptIn);
-  if (!Array.isArray(stored)) return [];
-  return stored.filter((entry): entry is string => typeof entry === "string");
-}
-
-/** Whether this account turned notifications on in this browser before. */
-export function hasOptedIn(account: string): boolean {
-  const wanted = normalize(account);
-  if (!wanted) return false;
-  return accounts().includes(wanted);
-}
-
-/** Records that this account wants notifications on this device. */
-export function rememberOptIn(account: string): void {
-  const wanted = normalize(account);
-  if (!wanted) return;
-  const known = accounts();
-  if (known.includes(wanted)) return;
-  writeJson(STORAGE_KEYS.pushOptIn, [...known, wanted]);
-}
-
-/** Drops the opt-in, so nothing restores a device the user turned off. */
-export function forgetOptIn(account: string): void {
-  const wanted = normalize(account);
-  const kept = accounts().filter((entry) => entry !== wanted);
-  if (kept.length === 0) {
-    removeString(STORAGE_KEYS.pushOptIn);
-    return;
+class PushDeviceOptIn {
+  /** Whether this account turned notifications on in this browser before. */
+  has(account: string): boolean {
+    const wanted = this.#identify(account);
+    return wanted !== "" && this.#accounts().includes(wanted);
   }
-  writeJson(STORAGE_KEYS.pushOptIn, kept);
+
+  /** Records that this account wants notifications on this device. */
+  remember(account: string): void {
+    const wanted = this.#identify(account);
+    if (wanted === "") return;
+    const known = this.#accounts();
+    if (known.includes(wanted)) return;
+    writeJson(STORAGE_KEYS.pushOptIn, [...known, wanted]);
+  }
+
+  /** Drops the opt-in, so nothing restores a device the user turned off. */
+  forget(account: string): void {
+    const wanted = this.#identify(account);
+    const kept = this.#accounts().filter((entry) => entry !== wanted);
+    if (kept.length === 0) {
+      removeString(STORAGE_KEYS.pushOptIn);
+      return;
+    }
+    writeJson(STORAGE_KEYS.pushOptIn, kept);
+  }
+
+  /** One spelling per account, so a re-typed address still matches. */
+  #identify(account: string): string {
+    return account.trim().toLowerCase();
+  }
+
+  /** The stored list, tolerating anything an older build may have left. */
+  #accounts(): string[] {
+    const stored = readJson(STORAGE_KEYS.pushOptIn);
+    if (!Array.isArray(stored)) return [];
+    return stored.filter((entry): entry is string => typeof entry === "string");
+  }
 }
+
+export const pushDeviceOptIn = new PushDeviceOptIn();

--- a/frontend/src/shared/pushDeviceOptIn.ts
+++ b/frontend/src/shared/pushDeviceOptIn.ts
@@ -10,6 +10,11 @@
 // whole origin: on a shared browser, one user's opt-in must never quietly turn
 // notifications on for the next person who signs in.
 //
+// Accounts are stored as SHA-256 fingerprints, never as addresses: localStorage
+// is readable by anyone with local access to the profile, and this list must
+// not enumerate who has signed in here — the same reason the server hashes the
+// filenames in its push-subscription store.
+//
 // Leaf module: it owns one list in the browser's store and knows nothing about
 // subscriptions, the server, or who is signed in.
 
@@ -18,24 +23,24 @@ import { readJson, removeString, writeJson } from "./browserStore.ts";
 
 class PushDeviceOptIn {
   /** Whether this account turned notifications on in this browser before. */
-  has(account: string): boolean {
-    const wanted = this.#identify(account);
-    return wanted !== "" && this.#accounts().includes(wanted);
+  async has(account: string): Promise<boolean> {
+    const wanted = await this.#fingerprint(account);
+    return wanted !== "" && this.#fingerprints().includes(wanted);
   }
 
   /** Records that this account wants notifications on this device. */
-  remember(account: string): void {
-    const wanted = this.#identify(account);
+  async remember(account: string): Promise<void> {
+    const wanted = await this.#fingerprint(account);
     if (wanted === "") return;
-    const known = this.#accounts();
+    const known = this.#fingerprints();
     if (known.includes(wanted)) return;
     writeJson(STORAGE_KEYS.pushOptIn, [...known, wanted]);
   }
 
   /** Drops the opt-in, so nothing restores a device the user turned off. */
-  forget(account: string): void {
-    const wanted = this.#identify(account);
-    const kept = this.#accounts().filter((entry) => entry !== wanted);
+  async forget(account: string): Promise<void> {
+    const wanted = await this.#fingerprint(account);
+    const kept = this.#fingerprints().filter((entry) => entry !== wanted);
     if (kept.length === 0) {
       removeString(STORAGE_KEYS.pushOptIn);
       return;
@@ -43,13 +48,30 @@ class PushDeviceOptIn {
     writeJson(STORAGE_KEYS.pushOptIn, kept);
   }
 
-  /** One spelling per account, so a re-typed address still matches. */
-  #identify(account: string): string {
-    return account.trim().toLowerCase();
+  /**
+   * One irreversible spelling per account, so a re-typed address still matches
+   * but the stored list never contains an address. "" — from a blank account
+   * or a context without WebCrypto — never matches and is never stored, so an
+   * unusable digest degrades to "no restore", not to plaintext.
+   */
+  async #fingerprint(account: string): Promise<string> {
+    const normalized = account.trim().toLowerCase();
+    if (normalized === "") return "";
+    try {
+      const digest = await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(normalized)
+      );
+      return Array.from(new Uint8Array(digest), (byte) =>
+        byte.toString(16).padStart(2, "0")
+      ).join("");
+    } catch {
+      return "";
+    }
   }
 
   /** The stored list, tolerating anything an older build may have left. */
-  #accounts(): string[] {
+  #fingerprints(): string[] {
     const stored = readJson(STORAGE_KEYS.pushOptIn);
     if (!Array.isArray(stored)) return [];
     return stored.filter((entry): entry is string => typeof entry === "string");

--- a/frontend/src/shared/pushDeviceOptIn.ts
+++ b/frontend/src/shared/pushDeviceOptIn.ts
@@ -1,0 +1,51 @@
+// Which accounts asked for notifications in *this* browser.
+//
+// The browser's push subscription is not durable: a service restart, a deploy,
+// or the push service rotating an endpoint can leave the device with nothing
+// registered even though permission was never revoked. Remembering the opt-in
+// locally is what lets the app restore the subscription silently instead of
+// asking the user to allow notifications all over again.
+//
+// It is keyed by account because a browser subscription belongs to the whole
+// origin: on a shared browser, one user's opt-in must never quietly turn
+// notifications on for the next person who signs in.
+
+import { STORAGE_KEYS } from "../config/storageKeys.ts";
+import { readJson, removeString, writeJson } from "./browserStore.ts";
+
+function normalize(account: string): string {
+  return account.trim().toLowerCase();
+}
+
+function accounts(): string[] {
+  const stored = readJson(STORAGE_KEYS.pushOptIn);
+  if (!Array.isArray(stored)) return [];
+  return stored.filter((entry): entry is string => typeof entry === "string");
+}
+
+/** Whether this account turned notifications on in this browser before. */
+export function hasOptedIn(account: string): boolean {
+  const wanted = normalize(account);
+  if (!wanted) return false;
+  return accounts().includes(wanted);
+}
+
+/** Records that this account wants notifications on this device. */
+export function rememberOptIn(account: string): void {
+  const wanted = normalize(account);
+  if (!wanted) return;
+  const known = accounts();
+  if (known.includes(wanted)) return;
+  writeJson(STORAGE_KEYS.pushOptIn, [...known, wanted]);
+}
+
+/** Drops the opt-in, so nothing restores a device the user turned off. */
+export function forgetOptIn(account: string): void {
+  const wanted = normalize(account);
+  const kept = accounts().filter((entry) => entry !== wanted);
+  if (kept.length === 0) {
+    removeString(STORAGE_KEYS.pushOptIn);
+    return;
+  }
+  writeJson(STORAGE_KEYS.pushOptIn, kept);
+}

--- a/frontend/src/state/context/WorkspaceContext.tsx
+++ b/frontend/src/state/context/WorkspaceContext.tsx
@@ -61,7 +61,8 @@ export function WorkspaceProvider({
     () => workspaceUiState.createInitial(takePushNotificationChatId())
   );
   const activeChat = workspaceSidebarState.activeChat(data.chats, ui.activeChatId);
-  const capabilityUserId = auth.email || auth.adminEmail || "anonymous";
+  const account = auth.email || auth.adminEmail;
+  const capabilityUserId = account || "anonymous";
   const activeCapabilityProjectId = activeChat?.projectId;
 
   useEffect(() => {
@@ -75,6 +76,7 @@ export function WorkspaceProvider({
     dispatch({ type: "select-chat", chatId });
   }, []);
   useWorkspacePushLifecycle({
+    account: enabled ? account : "",
     activeChatId: ui.activeChatId,
     view: ui.view,
     openChat: openPushChat,

--- a/frontend/src/state/hooks/auth/useAccountSignOut.ts
+++ b/frontend/src/state/hooks/auth/useAccountSignOut.ts
@@ -3,11 +3,11 @@ import { useCallback } from "preact/hooks";
 import { pushSubscriptionApi } from "../../../api/pushSubscriptionApi";
 
 /** Revokes this browser's push endpoint before ending the current session. */
-export function useAccountSignOut(): () => void {
+export function useAccountSignOut(account: string): () => void {
   return useCallback(() => {
     void pushSubscriptionApi
-      .prepareForLogout()
+      .prepareForLogout(account)
       .catch(() => {})
       .then(() => window.location.assign("/auth/logout"));
-  }, []);
+  }, [account]);
 }

--- a/frontend/src/state/hooks/push/usePushDeviceRestore.ts
+++ b/frontend/src/state/hooks/push/usePushDeviceRestore.ts
@@ -1,0 +1,41 @@
+import { useEffect } from "preact/hooks";
+
+import { pushSubscriptionApi } from "../../../api/pushSubscriptionApi";
+
+// How long a tab may stay open before its registration is worth re-checking.
+// Push services retire endpoints on their own schedule, and a workspace left
+// open for days would otherwise only find out when a notification never came.
+const REVALIDATE_AFTER_MS = 30 * 60 * 1000;
+
+/**
+ * Restores what this account already opted into on this device, on startup and
+ * whenever a long-idle tab comes back to the foreground. A backend restart, a
+ * deploy, or a push service retiring an endpoint can leave the browser with
+ * nothing registered, and none of those are the user withdrawing permission.
+ *
+ * @param account the signed-in account, or "" while there is no session.
+ */
+export function usePushDeviceRestore(account: string): void {
+  useEffect(() => {
+    if (!account) return;
+    let cancelled = false;
+    let checkedAt = 0;
+
+    const restore = () => {
+      checkedAt = Date.now();
+      void pushSubscriptionApi.ensureRegistered(account).catch(() => undefined);
+    };
+    const restoreIfStale = () => {
+      if (cancelled || document.visibilityState !== "visible") return;
+      if (Date.now() - checkedAt < REVALIDATE_AFTER_MS) return;
+      restore();
+    };
+
+    restore();
+    document.addEventListener("visibilitychange", restoreIfStale);
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", restoreIfStale);
+    };
+  }, [account]);
+}

--- a/frontend/src/state/hooks/push/usePushNotifications.ts
+++ b/frontend/src/state/hooks/push/usePushNotifications.ts
@@ -15,7 +15,7 @@ export interface PushNotifications {
   sendTest: () => Promise<void>;
 }
 
-export function usePushNotifications(active: boolean): PushNotifications {
+export function usePushNotifications(active: boolean, account: string): PushNotifications {
   const [status, setStatus] = useState<PushStatus>("loading");
   const [blocker, setBlocker] = useState<PushBlocker | null>(null);
   const [publicKey, setPublicKey] = useState("");
@@ -37,13 +37,15 @@ export function usePushNotifications(active: boolean): PushNotifications {
       }
       // The server's record and this device's registration can disagree — a
       // second device, or a subscription the browser dropped — so trust the
-      // browser for what *this* device receives.
-      setStatus((await pushSubscriptionApi.reconcileCurrentAccount()) ? "on" : "off");
+      // browser for what *this* device receives. A registration this account
+      // asked for is restored here rather than reported as off.
+      const device = await pushSubscriptionApi.ensureRegistered(account, config.publicKey);
+      setStatus(device === "absent" ? "off" : "on");
     } catch (cause) {
       setStatus("blocked");
       setError(messageOf(cause));
     }
-  }, []);
+  }, [account]);
 
   useEffect(() => {
     if (!active) return;
@@ -55,7 +57,7 @@ export function usePushNotifications(active: boolean): PushNotifications {
     setError(null);
     setNotice(null);
     try {
-      await pushSubscriptionApi.enable(publicKey);
+      await pushSubscriptionApi.enable(account, publicKey);
       setStatus("on");
       setNotice("This device will now receive notifications.");
     } catch (cause) {
@@ -65,21 +67,21 @@ export function usePushNotifications(active: boolean): PushNotifications {
     } finally {
       setBusy(false);
     }
-  }, [publicKey, refresh]);
+  }, [account, publicKey, refresh]);
 
   const disable = useCallback(async () => {
     setBusy(true);
     setError(null);
     setNotice(null);
     try {
-      await pushSubscriptionApi.disable();
+      await pushSubscriptionApi.disable(account);
       setStatus("off");
     } catch (cause) {
       setError(messageOf(cause));
     } finally {
       setBusy(false);
     }
-  }, []);
+  }, [account]);
 
   const sendTest = useCallback(async () => {
     setTesting(true);

--- a/frontend/src/state/hooks/push/usePushNotifications.ts
+++ b/frontend/src/state/hooks/push/usePushNotifications.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
 import { pushApi } from "../../../api/pushApi";
 import { pushSubscriptionApi } from "../../../api/pushSubscriptionApi";
+import type { PushDeviceState } from "../../../api/pushDeviceRegistration.ts";
 import type { PushBlocker, PushStatus } from "../../../models/push";
 
 export interface PushNotifications {
@@ -39,8 +40,7 @@ export function usePushNotifications(active: boolean, account: string): PushNoti
       // second device, or a subscription the browser dropped — so trust the
       // browser for what *this* device receives. A registration this account
       // asked for is restored here rather than reported as off.
-      const device = await pushSubscriptionApi.ensureRegistered(account, config.publicKey);
-      setStatus(device === "absent" ? "off" : "on");
+      setStatus(statusOf(await pushSubscriptionApi.ensureRegistered(account, config.publicKey)));
     } catch (cause) {
       setStatus("blocked");
       setError(messageOf(cause));
@@ -98,6 +98,15 @@ export function usePushNotifications(active: boolean, account: string): PushNoti
   }, []);
 
   return { status, blocker, busy, testing, error, notice, enable, disable, sendTest };
+}
+
+/**
+ * A device the server could not confirm still holds its subscription, so it
+ * reads as on: reporting off would tell the user to press a button that asks
+ * for a permission they already granted.
+ */
+function statusOf(device: PushDeviceState): PushStatus {
+  return device === "absent" ? "off" : "on";
 }
 
 function messageOf(cause: unknown): string {

--- a/frontend/src/state/hooks/push/useWorkspacePushLifecycle.ts
+++ b/frontend/src/state/hooks/push/useWorkspacePushLifecycle.ts
@@ -1,9 +1,9 @@
 import { useEffect } from "preact/hooks";
 
-import { pushSubscriptionApi } from "../../../api/pushSubscriptionApi";
 import type { WorkspaceView } from "../../workspace/workspaceUiState";
 import { pushNotificationState } from "../../push/pushNotificationState";
 import { pushPresenceState } from "../../push/pushPresenceState";
+import { usePushDeviceRestore } from "./usePushDeviceRestore";
 
 interface WorkspacePushLifecycleOptions {
   /** The signed-in account, or "" while the session is not established. */
@@ -13,12 +13,7 @@ interface WorkspacePushLifecycleOptions {
   openChat: (chatId: string) => void;
 }
 
-// How long a tab may stay open before its registration is worth re-checking.
-// Push services retire endpoints on their own schedule, and a workspace left
-// open for days would otherwise only find out when a notification never came.
-const REVALIDATE_AFTER_MS = 30 * 60 * 1000;
-
-/** Keeps subscription ownership, worker routing, and presence in sync. */
+/** Keeps this device's registration, worker routing, and presence in sync. */
 export function useWorkspacePushLifecycle({
   account,
   activeChatId,
@@ -33,31 +28,7 @@ export function useWorkspacePushLifecycle({
     });
   }, [openChat]);
 
-  // Restore what this account already opted into. A backend restart, a deploy,
-  // or a push service retiring an endpoint can leave the browser with nothing
-  // registered, and none of those are the user withdrawing permission.
-  useEffect(() => {
-    if (!account) return;
-    let cancelled = false;
-    let checkedAt = 0;
-
-    const ensure = () => {
-      checkedAt = Date.now();
-      void pushSubscriptionApi.ensureRegistered(account).catch(() => undefined);
-    };
-    const ensureIfStale = () => {
-      if (cancelled || document.visibilityState !== "visible") return;
-      if (Date.now() - checkedAt < REVALIDATE_AFTER_MS) return;
-      ensure();
-    };
-
-    ensure();
-    document.addEventListener("visibilitychange", ensureIfStale);
-    return () => {
-      cancelled = true;
-      document.removeEventListener("visibilitychange", ensureIfStale);
-    };
-  }, [account]);
+  usePushDeviceRestore(account);
 
   // Say which chat is on screen, so nothing interrupts the user about the one
   // they are already watching. The worker covers this browser; the server

--- a/frontend/src/state/hooks/push/useWorkspacePushLifecycle.ts
+++ b/frontend/src/state/hooks/push/useWorkspacePushLifecycle.ts
@@ -6,13 +6,21 @@ import { pushNotificationState } from "../../push/pushNotificationState";
 import { pushPresenceState } from "../../push/pushPresenceState";
 
 interface WorkspacePushLifecycleOptions {
+  /** The signed-in account, or "" while the session is not established. */
+  account: string;
   activeChatId: string | null;
   view: WorkspaceView;
   openChat: (chatId: string) => void;
 }
 
+// How long a tab may stay open before its registration is worth re-checking.
+// Push services retire endpoints on their own schedule, and a workspace left
+// open for days would otherwise only find out when a notification never came.
+const REVALIDATE_AFTER_MS = 30 * 60 * 1000;
+
 /** Keeps subscription ownership, worker routing, and presence in sync. */
 export function useWorkspacePushLifecycle({
+  account,
   activeChatId,
   view,
   openChat,
@@ -20,11 +28,36 @@ export function useWorkspacePushLifecycle({
   // Register the worker on every boot so a deployed sw.js replaces the
   // installed one, and route notification taps into chat selection.
   useEffect(() => {
-    void pushSubscriptionApi.reconcileCurrentAccount();
     pushNotificationState.connect((chatId) => {
       if (chatId) openChat(chatId);
     });
   }, [openChat]);
+
+  // Restore what this account already opted into. A backend restart, a deploy,
+  // or a push service retiring an endpoint can leave the browser with nothing
+  // registered, and none of those are the user withdrawing permission.
+  useEffect(() => {
+    if (!account) return;
+    let cancelled = false;
+    let checkedAt = 0;
+
+    const ensure = () => {
+      checkedAt = Date.now();
+      void pushSubscriptionApi.ensureRegistered(account).catch(() => undefined);
+    };
+    const ensureIfStale = () => {
+      if (cancelled || document.visibilityState !== "visible") return;
+      if (Date.now() - checkedAt < REVALIDATE_AFTER_MS) return;
+      ensure();
+    };
+
+    ensure();
+    document.addEventListener("visibilitychange", ensureIfStale);
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", ensureIfStale);
+    };
+  }, [account]);
 
   // Say which chat is on screen, so nothing interrupts the user about the one
   // they are already watching. The worker covers this browser; the server

--- a/frontend/src/transport/webPushTransport.ts
+++ b/frontend/src/transport/webPushTransport.ts
@@ -46,7 +46,7 @@ class WebPushTransport {
    * unsubscribing is exactly what drops the notification permission on Safari
    * and puts the "Allow notifications?" prompt back in front of the user.
    */
-  isStaleForApplicationServerKey(
+  isSignedWithRetiredKey(
     subscription: PushSubscription,
     applicationServerKey: string
   ): boolean {

--- a/frontend/src/transport/webPushTransport.ts
+++ b/frontend/src/transport/webPushTransport.ts
@@ -37,14 +37,23 @@ class WebPushTransport {
     return subscription.unsubscribe();
   }
 
-  matchesApplicationServerKey(
+  /**
+   * Whether this subscription was provably signed with a *different* key than
+   * the server signs with today, which makes it undeliverable.
+   *
+   * A browser that does not expose the applied key answers false: an
+   * unprovable mismatch must never cost a working subscription, because
+   * unsubscribing is exactly what drops the notification permission on Safari
+   * and puts the "Allow notifications?" prompt back in front of the user.
+   */
+  isStaleForApplicationServerKey(
     subscription: PushSubscription,
     applicationServerKey: string
   ): boolean {
     const appliedKey = subscription.options?.applicationServerKey;
     if (!appliedKey) return false;
     return (
-      this.#encodeBase64Url(new Uint8Array(appliedKey)) ===
+      this.#encodeBase64Url(new Uint8Array(appliedKey)) !==
       applicationServerKey.replace(/=+$/, "")
     );
   }


### PR DESCRIPTION
## Summary

Every update (or a backend restart, or a long-idle tab) was destroying this
device's push subscription — on Safari/iOS, destroying the last subscription
also drops the site's notification permission, so the user was re-prompted
to allow notifications after every deploy.

Root cause: the boot-time ownership check and the service worker both treated
"the server couldn't answer" (restarting, offline) identically to "this
endpoint belongs to another account" — and unsubscribed either way. Nothing
ever recreated a lost registration, so restoring meant re-prompting.

## What changed

- **Uncertainty no longer destroys a working device.** Ownership checks now
  return `owned | foreign | unverified`; only a *definitive* "not yours"
  invalidates a subscription. A 401/5xx/offline check leaves it untouched.
- **Silent self-healing.** A missing or stale registration is recreated
  automatically — on boot, when a tab returns after 30+ minutes idle, and
  from the service worker on `pushsubscriptionchange` — without ever
  triggering a new permission prompt (that only ever comes from "Turn on").
- **Per-account opt-in memory**, so restore only applies to accounts that
  actually enabled notifications in that browser (shared-browser safe).
  Stored as **SHA-256 fingerprints in `localStorage`, never plaintext
  addresses** — mirrors the server's existing hashed-filename approach for
  the same reason (no local enumeration of users).
- **No retry storms on a definitive rejection** (e.g. the 20-device cap):
  API errors now carry their HTTP status (`ApiError`), and a 4xx on
  re-registration stops the opt-in from retrying instead of looping
  unsubscribe→resubscribe on every boot.
- Updated `docs/dev/push-notifications/*` to match the new restore/failure
  model.

## Verification

- `tsc -b --force`: clean on every commit.
- Full frontend suite: 129/129 passing (new coverage for the restore policy,
  ownership verdicts, opt-in fingerprinting, and worker resubscribe/gating —
  written because this logic isn't guarded by types).
- `npm run build`: succeeds.

## Commits

9 commits: one behavior fix, six structural refactors (moving the restore
policy's ports/state apart, unifying ownership vocabulary between the app
and the worker, isolating the restore-scheduling hook), and two follow-up
security hardenings (opt-in hashing, rejection-loop guard) — each verified
and committed independently.