### PR TITLE
fix(lifecycle): raise container launch timeout to 10 minutes

### DIFF
--- a/backend/internal/integration/containers/lifecycle/runtime.go
+++ b/backend/internal/integration/containers/lifecycle/runtime.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	launchTimeout  = 90 * time.Second
+	launchTimeout  = 10 * time.Minute
 	migrateTimeout = 5 * time.Minute
 	startTimeout   = 30 * time.Second
 	stopTimeout    = 30 * time.Second

--- a/backend/internal/integration/containers/lifecycle/runtime.go
+++ b/backend/internal/integration/containers/lifecycle/runtime.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	// TODO: We will need to investigate how to hook into a callback instead of increasing the timeout
 	launchTimeout  = 10 * time.Minute
 	migrateTimeout = 5 * time.Minute
 	startTimeout   = 30 * time.Second


### PR DESCRIPTION
launchTimeout was 90 seconds, which bounds the lxc init call in runtime.go:49. That is not enough to unpack the base image, so every workspace create was SIGKILLed partway through and upgrade-workspaces.sh failed with 0 upgraded, 2 failed.

Raises it to 10 minutes.

launchTimeout has exactly one caller, so nothing else is affected. The value is in line with migrateTimeout and deleteTimeout, both already 5 minutes.

Fixes #96 