### PR TITLE
fix(qa): run the deploy scripts on macOS and Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Git for Windows checks out CRLF by default. These files are executed by bash
+# and read by systemd, Caddy, and systemd-resolved on the Linux QA and
+# production servers, where a trailing CR is a syntax error rather than
+# whitespace — so pin them to LF in every working tree.
+*.sh text eol=lf
+*.tmpl text eol=lf
+*.env text eol=lf
+*.env.example text eol=lf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,10 +108,17 @@ npm run qa:deploy-local                    # app-only deploy of the working tree
 npm run qa:test                            # QA wrapper contract tests
 ```
 
-The npm deployment aliases default to `/workspace/remote.futrx/.qa.env`, where
-the shared QA configuration currently lives. Set
-`QA_ENV_FILE=/path/to/.qa.env` to override it. Calling an `infra/qa/*.sh`
-script directly still defaults to `.qa.env` in that script's worktree.
+The npm deployment aliases default to `./.qa.env` in the repo root, matching
+the `infra/qa/*.sh` scripts' own default of `.qa.env` in their worktree. Set
+`QA_ENV_FILE=/path/to/.qa.env` to point at a shared QA configuration
+elsewhere.
+
+These commands are driven from a Linux, macOS, or Windows workstation. They
+need `bash`, `git`, `ssh`, `scp`, `tar`, and `curl` on `PATH` — on Windows,
+run them from Git Bash, which ships all of them. Hostname resolution for the
+pre-flight check uses whichever of `getent`, `dscacheutil`, `dig`, `host`, or
+`nslookup` the platform provides, and falls back to DNS-over-HTTPS through
+`curl` when none is installed.
 
 There is no CI that exercises the installer against a server. `infra/` changes reach a box only when its operator runs `sudo bash infra/update.sh` over SSH or applies a release tag from the in-app updater (both re-detect the box's hostname from the installed unit). Treat changes to `infra/` with extra care since they modify hosts in place.
 

--- a/infra/qa/common.sh
+++ b/infra/qa/common.sh
@@ -7,13 +7,95 @@ QA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 QA_REPO_ROOT="$(cd "$QA_DIR/../.." >/dev/null 2>&1 && pwd)"
 QA_ENV_FILE="${QA_ENV_FILE:-$QA_REPO_ROOT/.qa.env}"
 
+# Git Bash rewrites arguments that look like absolute Unix paths into Windows
+# paths before handing them to a native executable, which would corrupt the
+# remote /tmp paths these scripts pass to ssh and scp. Both variables are
+# ignored outside MSYS, so exporting them unconditionally costs nothing on
+# Linux or macOS.
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL='*'
+
 qa_fail() {
     printf 'qa: %s\n' "$*" >&2
     exit 1
 }
 
+# Name of the IPv4 resolver available on this operator's machine, or empty.
+# These scripts are driven from Linux, macOS, and Git Bash on Windows, and no
+# single lookup tool ships on all three: getent is glibc-only, dscacheutil is
+# macOS, and a Git Bash install reaches Windows' own nslookup. curl is already
+# a hard requirement above, so DNS-over-HTTPS closes the gap on a machine that
+# has none of them.
+qa_ipv4_resolver() {
+    local candidate
+
+    for candidate in getent dscacheutil dig host nslookup curl; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# qa_resolve_ipv4 <hostname> <resolver>
+# Prints the first IPv4 address for the name, or nothing when it does not
+# resolve. Callers must tolerate both an empty result and a non-zero exit; a
+# name with no A record is a reportable condition here, not a script error.
+qa_resolve_ipv4() {
+    local name="$1" resolver="$2" doh body
+
+    case "$resolver" in
+        getent)
+            getent ahostsv4 "$name" 2>/dev/null | awk 'NR == 1 { print $1 }'
+            ;;
+        dscacheutil)
+            dscacheutil -q host -a name "$name" 2>/dev/null |
+                awk '$1 == "ip_address:" { print $2; exit }'
+            ;;
+        dig)
+            dig +short A "$name" 2>/dev/null |
+                awk '/^([0-9]{1,3}[.]){3}[0-9]{1,3}$/ { print; exit }'
+            ;;
+        host)
+            host -t A "$name" 2>/dev/null | awk '/has address/ { print $NF; exit }'
+            ;;
+        nslookup)
+            # Windows and BIND nslookup both open with the DNS server's own
+            # address, so only read addresses after the answer's Name: line.
+            # Windows prints extra addresses on bare continuation lines under
+            # "Addresses:", which is why every field is scanned.
+            nslookup -type=A "$name" 2>/dev/null | awk '
+                /^Name:/ { answer = 1; next }
+                answer {
+                    for (i = 1; i <= NF; i++) {
+                        if ($i ~ /^([0-9]{1,3}[.]){3}[0-9]{1,3}$/) {
+                            print $i
+                            exit
+                        }
+                    }
+                }
+            '
+            ;;
+        curl)
+            for doh in https://cloudflare-dns.com/dns-query https://dns.google/resolve; do
+                body="$(curl -fsSL --max-time 8 -H 'accept: application/dns-json' \
+                    "${doh}?name=${name}&type=A" 2>/dev/null)" || continue
+                # A reply carrying Status is authoritative even when it lists
+                # no address, so don't retry the next resolver on NXDOMAIN.
+                printf '%s' "$body" | grep -q '"Status"' || continue
+                printf '%s' "$body" |
+                    grep -oE '"data"[[:space:]]*:[[:space:]]*"([0-9]{1,3}[.]){3}[0-9]{1,3}"' |
+                    grep -oE '([0-9]{1,3}[.]){3}[0-9]{1,3}' |
+                    awk 'NR == 1 { print }'
+                return 0
+            done
+            ;;
+    esac
+}
+
 qa_prepare_connection() {
-    local command_name resolved_qa_ip
+    local command_name resolved_qa_ip resolver
 
     if [ ! -r "$QA_ENV_FILE" ]; then
         qa_fail "missing $QA_ENV_FILE; copy .qa.env.example to .qa.env and configure it"
@@ -33,11 +115,17 @@ qa_prepare_connection() {
     touch "$QA_KNOWN_HOSTS_FILE"
     chmod 600 "$QA_KNOWN_HOSTS_FILE"
 
-    for command_name in ssh curl getent; do
+    for command_name in ssh curl; do
         command -v "$command_name" >/dev/null 2>&1 || qa_fail "required command is missing: $command_name"
     done
 
-    resolved_qa_ip="$(getent ahostsv4 "$QA_PUBLIC_HOST" 2>/dev/null | awk 'NR == 1 { print $1 }')"
+    resolver="$(qa_ipv4_resolver || true)"
+    [ -n "$resolver" ] || \
+        qa_fail "required command is missing: one of getent, dscacheutil, dig, host, nslookup, curl"
+
+    # An unresolvable name must reach the check below, not abort the script
+    # through pipefail on the resolver's own non-zero exit.
+    resolved_qa_ip="$(qa_resolve_ipv4 "$QA_PUBLIC_HOST" "$resolver" || true)"
     if [ -z "$resolved_qa_ip" ]; then
         qa_fail "$QA_PUBLIC_HOST does not resolve to an IPv4 address"
     fi

--- a/infra/tests/qa-resolve-test.sh
+++ b/infra/tests/qa-resolve-test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=../qa/common.sh
+. "$TESTS_DIR/../qa/common.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# Every case stubs the resolver with output captured from the real tool, so
+# the suite stays hermetic and runs the same on Linux, macOS, and Git Bash on
+# Windows — none of which has the whole set of resolvers installed.
+
+getent() {
+    printf '%s\n' \
+        '203.0.113.7     STREAM qa.example' \
+        '203.0.113.7     DGRAM' \
+        '203.0.113.8     RAW'
+}
+got="$(qa_resolve_ipv4 qa.example getent)"
+[ "$got" = "203.0.113.7" ] || fail "getent: expected 203.0.113.7, got '$got'"
+
+dscacheutil() {
+    printf '%s\n' \
+        'name: qa.example' \
+        'ipv6_address: 2001:db8::1' \
+        'ip_address: 203.0.113.7' \
+        '' \
+        'name: qa.example' \
+        'ip_address: 203.0.113.8'
+}
+got="$(qa_resolve_ipv4 qa.example dscacheutil)"
+[ "$got" = "203.0.113.7" ] || fail "dscacheutil: expected 203.0.113.7, got '$got'"
+
+# The CNAME line dig prints ahead of the address must not be read as one.
+dig() {
+    printf '%s\n' 'target.example.' '203.0.113.7' '203.0.113.8'
+}
+got="$(qa_resolve_ipv4 qa.example dig)"
+[ "$got" = "203.0.113.7" ] || fail "dig: expected 203.0.113.7, got '$got'"
+
+host() {
+    printf '%s\n' \
+        'qa.example is an alias for target.example.' \
+        'target.example has address 203.0.113.7' \
+        'target.example has IPv6 address 2001:db8::1'
+}
+got="$(qa_resolve_ipv4 qa.example host)"
+[ "$got" = "203.0.113.7" ] || fail "host: expected 203.0.113.7, got '$got'"
+
+# Windows nslookup: the resolver's own address heads the reply and must not be
+# mistaken for the answer, and the addresses continue on unlabelled lines.
+nslookup() {
+    printf '%s\n' \
+        'Server:  UnKnown' \
+        'Address:  192.168.1.1' \
+        '' \
+        'Non-authoritative answer:' \
+        'Name:    qa.example' \
+        'Addresses:  2001:db8::1' \
+        '          203.0.113.7' \
+        '          203.0.113.8'
+}
+got="$(qa_resolve_ipv4 qa.example nslookup)"
+[ "$got" = "203.0.113.7" ] || fail "windows nslookup: expected 203.0.113.7, got '$got'"
+
+# BIND nslookup, as found on Linux and macOS, prints a different shape.
+nslookup() {
+    printf '%s\n' \
+        'Server:		1.1.1.1' \
+        'Address:	1.1.1.1#53' \
+        '' \
+        'Non-authoritative answer:' \
+        'Name:	qa.example' \
+        'Address: 203.0.113.7'
+}
+got="$(qa_resolve_ipv4 qa.example nslookup)"
+[ "$got" = "203.0.113.7" ] || fail "bind nslookup: expected 203.0.113.7, got '$got'"
+
+# The DNS-over-HTTPS fallback: curl is the one lookup tool guaranteed to be
+# present, since the pre-flight already requires it.
+DOH_BODY=""
+DOH_EXIT=0
+# The call count lives in a file: qa_resolve_ipv4 runs in a command
+# substitution, so a counter variable would be lost with its subshell.
+CURL_CALL_LOG="$(mktemp)"
+curl() {
+    printf 'x' >>"$CURL_CALL_LOG"
+    [ "$DOH_EXIT" -eq 0 ] || return "$DOH_EXIT"
+    printf '%s' "$DOH_BODY"
+}
+curl_calls() {
+    wc -c <"$CURL_CALL_LOG" | tr -d '[:space:]'
+}
+
+DOH_BODY='{"Status":0,"Answer":[{"name":"qa.example","type":5,"data":"target.example."},{"name":"target.example","type":1,"data":"203.0.113.7"},{"data":"203.0.113.8"}]}'
+got="$(qa_resolve_ipv4 qa.example curl)"
+[ "$got" = "203.0.113.7" ] || fail "doh: expected 203.0.113.7, got '$got'"
+
+# NXDOMAIN is a definitive answer: no address, and no second resolver queried.
+DOH_BODY='{"Status":3,"Question":[{"name":"nope.example","type":1}]}'
+: >"$CURL_CALL_LOG"
+got="$(qa_resolve_ipv4 nope.example curl || true)"
+[ -z "$got" ] || fail "doh: expected no address for NXDOMAIN, got '$got'"
+[ "$(curl_calls)" -eq 1 ] || fail "doh: NXDOMAIN queried $(curl_calls) endpoints, expected 1"
+
+# Both DoH endpoints unreachable is an empty result, not a hang or a crash.
+DOH_EXIT=7
+: >"$CURL_CALL_LOG"
+got="$(qa_resolve_ipv4 qa.example curl || true)"
+[ -z "$got" ] || fail "doh: expected no address when unreachable, got '$got'"
+[ "$(curl_calls)" -eq 2 ] || fail "doh: tried $(curl_calls) endpoints, expected both"
+
+# A name with no A record is a reportable condition, not a script abort: the
+# resolver exits non-zero and the caller still gets an empty string back.
+getent() { return 2; }
+got="$(qa_resolve_ipv4 nope.example getent || true)"
+[ -z "$got" ] || fail "expected no address for an unresolvable name, got '$got'"
+
+# Resolver selection prefers the platform's native tool and keeps DoH last, so
+# a machine that already resolves names locally keeps doing so.
+unset -f getent dscacheutil dig host nslookup curl
+stub_dir="$(mktemp -d)"
+trap 'rm -rf -- "$stub_dir" "$CURL_CALL_LOG"' EXIT
+resolvers="getent dscacheutil dig host nslookup curl"
+for name in $resolvers; do
+    printf '#!/bin/sh\nexit 0\n' >"$stub_dir/$name"
+    chmod +x "$stub_dir/$name"
+done
+
+for expected in $resolvers; do
+    got="$(PATH="$stub_dir" qa_ipv4_resolver)"
+    [ "$got" = "$expected" ] || fail "expected $expected to win resolver selection, got '$got'"
+    rm -f "$stub_dir/$expected"
+done
+
+if got="$(PATH="$stub_dir" qa_ipv4_resolver)"; then
+    fail "expected no resolver to be reported, got '$got'"
+fi
+
+echo "QA resolver tests passed"

--- a/infra/tests/qa-scripts-test.sh
+++ b/infra/tests/qa-scripts-test.sh
@@ -131,15 +131,16 @@ if grep -Eq 'git (fetch|reset)|infra/(install|update|upgrade-workspaces)[.]sh|FO
     fail "deploy-local.sh changes the installed checkout, host, or workspaces"
 fi
 for package_contract in \
-    '"qa:install": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/install.sh"' \
-    '"qa:update": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/update.sh"' \
-    '"qa:deploy-app": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/deploy-app.sh"' \
-    '"qa:deploy-local": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/deploy-local.sh"' \
+    '"qa:install": "QA_ENV_FILE=${QA_ENV_FILE:-./.qa.env} bash infra/qa/install.sh"' \
+    '"qa:update": "QA_ENV_FILE=${QA_ENV_FILE:-./.qa.env} bash infra/qa/update.sh"' \
+    '"qa:deploy-app": "QA_ENV_FILE=${QA_ENV_FILE:-./.qa.env} bash infra/qa/deploy-app.sh"' \
+    '"qa:deploy-local": "QA_ENV_FILE=${QA_ENV_FILE:-./.qa.env} bash infra/qa/deploy-local.sh"' \
     '"qa:test": "bash infra/tests/qa-scripts-test.sh"'; do
     grep -Fq "$package_contract" "$ROOT_PACKAGE_JSON" || \
         fail "root package is missing QA command: $package_contract"
 done
 
+bash "$TESTS_DIR/qa-resolve-test.sh"
 bash "$TESTS_DIR/lxd-host-test.sh"
 
 echo "QA install/update/app-deploy/local-deploy script tests passed"

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.8.1",
   "private": true,
   "scripts": {
-    "qa:install": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/install.sh",
-    "qa:update": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/update.sh",
-    "qa:deploy-app": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/deploy-app.sh",
-    "qa:deploy-local": "QA_ENV_FILE=${QA_ENV_FILE:-/workspace/remote.futrx/.qa.env} bash infra/qa/deploy-local.sh",
+    "qa:install": "QA_ENV_FILE=${QA_ENV_FILE:-./.qa.env} bash infra/qa/install.sh",
+    "qa:update": "QA_ENV_FILE=${QA_ENV_FILE:-./.qa.env} bash infra/qa/update.sh",
+    "qa:deploy-app": "QA_ENV_FILE=${QA_ENV_FILE:-./.qa.env} bash infra/qa/deploy-app.sh",
+    "qa:deploy-local": "QA_ENV_FILE=${QA_ENV_FILE:-./.qa.env} bash infra/qa/deploy-local.sh",
     "qa:test": "bash infra/tests/qa-scripts-test.sh"
   }
 }


### PR DESCRIPTION
The npm QA aliases defaulted `QA_ENV_FILE` to an absolute
`/workspace/remote.futrx/.qa.env`, so they only worked from the Linux QA
workspace. They now default to `./.qa.env` in the repo root, matching the
default the `infra/qa/*.sh` scripts already use on their own.

That made the scripts reachable from a laptop, where the pre-flight check
failed immediately: it hard-required `getent`, which is glibc-only.
Resolution now picks the first available of `getent`, `dscacheutil`,
`dig`, `host`, and `nslookup`, and falls back to DNS-over-HTTPS through
`curl` — already a hard requirement of the same check — when a machine has
none of them. Native tools stay ahead of DoH so hosts served by a local or
split-horizon resolver keep resolving as before. Parsing `nslookup` needs
care in both dialects: the Windows and BIND variants each open the reply
with the DNS server's own address, and Windows continues the answer on
unlabelled lines.

Two further things would have broken a Windows run before DNS was ever
reached. The repo had no `.gitattributes`, so Git for Windows checks out
CRLF and every `infra/qa/*.sh` would have died on `$'\r'` — with the
`*.tmpl` files shipping CRLF into systemd units and the Caddyfile on the
server. Shell, template, and env files are now pinned to `eol=lf`; no
tracked file contains a CR today, so this changes no content, only
behavior on a Windows checkout. Git Bash also rewrites absolute Unix paths
before handing arguments to a native executable, which would corrupt the
remote `/tmp` archive path `deploy-local.sh` passes to `ssh`, so
`MSYS_NO_PATHCONV` and `MSYS2_ARG_CONV_EXCL` are exported; both are
ignored outside MSYS.

This also fixes a latent bug in the same block. Under `set -euo pipefail`
the old `getent … | awk …` substitution aborted the script whenever a name
did not resolve, making the friendly "does not resolve to an IPv4 address"
error unreachable.

**Tests:** new `infra/tests/qa-resolve-test.sh` covers all six resolvers
against captured real-tool output, including both `nslookup` dialects, DoH
NXDOMAIN and unreachable-endpoint paths, and resolver preference ordering.
It is hermetic, so it runs identically on all three platforms. The QA
suite's `package.json` contract assertions were updated to the new default
path. Verified on macOS: every installed resolver returns the address
matching `QA_SSH_HOST`, and `qa_prepare_connection` completes via
`dscacheutil`. The Windows path is unverified — no Windows machine was
available.