### PR TITLE
fix(skills): allow selected skills to be removed

### DIFF
--- a/frontend/src/services/workspace/workspaceDataProjector.test.ts
+++ b/frontend/src/services/workspace/workspaceDataProjector.test.ts
@@ -32,3 +32,40 @@ test("detects generic and legacy provider session changes", () => {
   }], current);
   assert.notEqual(legacyChanged, current);
 });
+
+test("detects selected-skill removal from a workspace upsert", () => {
+  const current: ChatMeta[] = [{
+    id: "chat",
+    title: "Chat",
+    createdAt: 1,
+    lastMessageAt: 1,
+    selectedSkills: [{
+      name: "Code Refactorer",
+      command: "code-refactorer",
+      provider: "codex",
+      source: "project",
+    }],
+  }];
+  const { selectedSkills: _selectedSkills, ...withoutSelectedSkills } = current[0];
+
+  const removed = workspaceDataProjector.upsertChat(current, withoutSelectedSkills);
+
+  assert.notEqual(removed, current);
+  assert.equal(removed[0].selectedSkills, undefined);
+});
+
+test("treats omitted and empty selected-skill collections as equivalent", () => {
+  const current: ChatMeta[] = [{
+    id: "chat",
+    title: "Chat",
+    createdAt: 1,
+    lastMessageAt: 1,
+  }];
+
+  const same = workspaceDataProjector.upsertChat(current, {
+    ...current[0],
+    selectedSkills: [],
+  });
+
+  assert.equal(same, current);
+});

--- a/frontend/src/services/workspace/workspaceDataProjector.ts
+++ b/frontend/src/services/workspace/workspaceDataProjector.ts
@@ -95,13 +95,21 @@ class WorkspaceDataProjector {
     const leftSkills = left ?? [];
     const rightSkills = right ?? [];
     if (leftSkills.length !== rightSkills.length) return false;
-    return leftSkills.every((skill, index) => {
-      const candidate = rightSkills[index];
-      return skill.name === candidate.name &&
-        skill.command === candidate.command &&
-        skill.provider === candidate.provider &&
-        skill.source === candidate.source;
-    });
+
+    const key = (skill: SelectedSkill): string => {
+      const provider = (skill.provider ?? "").trim().toLowerCase();
+      const command = (skill.command ?? skill.name).trim().toLowerCase();
+      const source = command === "scheduled-tasks"
+        ? "remote"
+        : (skill.source ?? "").trim().toLowerCase();
+      const name = skill.name.trim();
+      return `${provider}:${source}:${command}:${name}`;
+    };
+
+    for (let index = 0; index < leftSkills.length; index++) {
+      if (key(leftSkills[index]) !== key(rightSkills[index])) return false;
+    }
+    return true;
   }
 
   private sameStringRecord(

--- a/frontend/src/services/workspace/workspaceDataProjector.ts
+++ b/frontend/src/services/workspace/workspaceDataProjector.ts
@@ -1,4 +1,4 @@
-import type { ChatMeta } from "../../models/chat";
+import type { ChatMeta, SelectedSkill } from "../../models/chat";
 import type { ProjectMeta } from "../../models/project";
 
 class WorkspaceDataProjector {
@@ -78,12 +78,30 @@ class WorkspaceDataProjector {
         left.mode !== right.mode ||
         left.reasoningEffort !== right.reasoningEffort ||
         left.serviceTier !== right.serviceTier ||
-        left.projectId !== right.projectId
+        left.projectId !== right.projectId ||
+        !this.sameSelectedSkills(left.selectedSkills, right.selectedSkills)
       ) {
         return false;
       }
     }
     return true;
+  }
+
+  private sameSelectedSkills(
+    left: SelectedSkill[] | undefined,
+    right: SelectedSkill[] | undefined
+  ): boolean {
+    if (left === right) return true;
+    const leftSkills = left ?? [];
+    const rightSkills = right ?? [];
+    if (leftSkills.length !== rightSkills.length) return false;
+    return leftSkills.every((skill, index) => {
+      const candidate = rightSkills[index];
+      return skill.name === candidate.name &&
+        skill.command === candidate.command &&
+        skill.provider === candidate.provider &&
+        skill.source === candidate.source;
+    });
   }
 
   private sameStringRecord(

--- a/frontend/src/state/hooks/chat/chatPreferenceState.test.ts
+++ b/frontend/src/state/hooks/chat/chatPreferenceState.test.ts
@@ -30,6 +30,7 @@ test("preserves normalized skill identity and chat defaults", () => {
       mode: "default",
       reasoningEffort: "high",
       serviceTier: "priority",
+      selectedSkills: [],
     }
   );
 });
@@ -90,6 +91,40 @@ test("prefers live workspace selections from another client", () => {
   assert.equal(resolved.mode, "plan");
   assert.equal(resolved.reasoningEffort, "high");
   assert.equal(resolved.serviceTier, "fast");
+});
+
+test("does not restore stale detail skills after a live workspace removal", () => {
+  const resolved = chatPreferenceState.resolveMeta(
+    {
+      id: "chat",
+      title: "Chat",
+      createdAt: 1,
+      lastMessageAt: 1,
+      provider: "codex",
+    },
+    {
+      id: "chat",
+      title: "Chat",
+      createdAt: 1,
+      lastMessageAt: 1,
+      provider: "codex",
+      selectedSkills: [{
+        name: "Code Refactorer",
+        command: "code-refactorer",
+        provider: "codex",
+        source: "project",
+      }],
+    },
+    {
+      provider: "codex",
+      model: "",
+      mode: "default",
+      reasoningEffort: "",
+      serviceTier: "",
+    },
+  );
+
+  assert.deepEqual(resolved.selectedSkills, []);
 });
 
 test("preserves an explicit per-chat Auto selection", () => {

--- a/frontend/src/state/hooks/chat/chatPreferenceState.ts
+++ b/frontend/src/state/hooks/chat/chatPreferenceState.ts
@@ -14,7 +14,7 @@ class ChatPreferenceState {
     defaults: ChatSettings
   ): ResolvedChatMeta {
     const baseMeta = loadedMeta ?? chat;
-    const selectedSkills = chat.selectedSkills ?? baseMeta.selectedSkills;
+    const selectedSkills = chat.selectedSkills ?? [];
     return {
       ...baseMeta,
       // Workspace chat upserts are the live cross-client source. Prefer their
@@ -26,7 +26,7 @@ class ChatPreferenceState {
       reasoningEffort:
         chat.reasoningEffort ?? baseMeta.reasoningEffort ?? defaults.reasoningEffort,
       serviceTier: chat.serviceTier ?? baseMeta.serviceTier ?? defaults.serviceTier,
-      ...(selectedSkills !== undefined ? { selectedSkills } : {}),
+      selectedSkills,
     };
   }
 


### PR DESCRIPTION
## Summary
- include selected skills in workspace chat equality so skills-only updates are retained
- treat the live workspace selection as authoritative instead of restoring stale chat-detail skills
- add regressions for removal and empty/omitted selection equivalence

## Root cause
The remove PATCH succeeded, but the workspace projector ignored `selectedSkills` when deciding whether a chat changed. It therefore retained the previous chat object, and preference resolution allowed that stale selection to override the cleared detail response.

## Verification
- focused selected-skill reconciliation tests
- full frontend test suite: 150 passed
- production frontend build