### PR TITLE
feat: add totp recovery-code alert and regeneration controls (fixes #108)

### DIFF
--- a/frontend/src/state/hooks/auth/useSecuritySettings.ts
+++ b/frontend/src/state/hooks/auth/useSecuritySettings.ts
@@ -10,6 +10,7 @@ export interface TwoFactorSettingsActions {
   beginTwoFactorEnrollment: () => Promise<TwoFactorEnrollment>;
   confirmTwoFactorEnrollment: (enrollmentToken: string, code: string) => Promise<string[]>;
   disableTwoFactor: (code: string) => Promise<void>;
+  regenerateRecoveryCodes: (code: string) => Promise<string[]>;
 }
 
 export interface SecuritySettingsController extends TwoFactorSettingsActions {
@@ -18,6 +19,7 @@ export interface SecuritySettingsController extends TwoFactorSettingsActions {
   error: string | null;
   setSingleSessionEnabled: (enabled: boolean) => Promise<void>;
   setHistoryEnabled: (enabled: boolean) => Promise<void>;
+  setRecoveryCodeAlertEnabled: (enabled: boolean) => Promise<void>;
   acknowledgeAlert: () => Promise<void>;
 }
 
@@ -64,6 +66,15 @@ export function useSecuritySettings(enabled: boolean): SecuritySettingsControlle
     [refresh]
   );
 
+  const regenerateRecoveryCodes = useCallback(
+    async (code: string) => {
+      const recoveryCodes = await securityApi.regenerateRecoveryCodes(code);
+      await refresh();
+      return recoveryCodes;
+    },
+    [refresh]
+  );
+
   const updatePreferences = useCallback(async (input: SecurityPreferencesInput) => {
     setSettings(await securityApi.updatePreferences(input));
   }, []);
@@ -75,6 +86,11 @@ export function useSecuritySettings(enabled: boolean): SecuritySettingsControlle
 
   const setHistoryEnabled = useCallback(
     (enabled: boolean) => updatePreferences({ historyEnabled: enabled }),
+    [updatePreferences]
+  );
+
+  const setRecoveryCodeAlertEnabled = useCallback(
+    (enabled: boolean) => updatePreferences({ recoveryCodeAlertEnabled: enabled }),
     [updatePreferences]
   );
 
@@ -90,8 +106,10 @@ export function useSecuritySettings(enabled: boolean): SecuritySettingsControlle
     beginTwoFactorEnrollment,
     confirmTwoFactorEnrollment,
     disableTwoFactor,
+    regenerateRecoveryCodes,
     setSingleSessionEnabled,
     setHistoryEnabled,
+    setRecoveryCodeAlertEnabled,
     acknowledgeAlert,
   };
 }

--- a/frontend/src/state/hooks/auth/useTwoFactorSettingsFlow.ts
+++ b/frontend/src/state/hooks/auth/useTwoFactorSettingsFlow.ts
@@ -10,6 +10,8 @@ export function useTwoFactorSettingsFlow(actions: TwoFactorSettingsActions) {
   const [recoveryCodes, setRecoveryCodes] = useState<string[] | null>(null);
   const [disableCode, setDisableCode] = useState("");
   const [showDisable, setShowDisable] = useState(false);
+  const [regenerateCode, setRegenerateCode] = useState("");
+  const [showRegenerate, setShowRegenerate] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -58,6 +60,21 @@ export function useTwoFactorSettingsFlow(actions: TwoFactorSettingsActions) {
     }
   }
 
+  async function regenerateRecoveryCodes() {
+    setError(null);
+    setBusy(true);
+    try {
+      const codes = await actions.regenerateRecoveryCodes(regenerateCode);
+      setRecoveryCodes(codes);
+      setShowRegenerate(false);
+      setRegenerateCode("");
+    } catch (cause) {
+      setError((cause as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return {
     busy,
     cancelDisable: () => setShowDisable(false),
@@ -75,7 +92,19 @@ export function useTwoFactorSettingsFlow(actions: TwoFactorSettingsActions) {
     setConfirmCode,
     setDisableCode,
     showDisable,
-    showDisableForm: () => setShowDisable(true),
+    showDisableForm: () => {
+      setShowDisable(true);
+      setShowRegenerate(false);
+    },
     startEnrollment,
+    showRegenerate,
+    showRegenerateForm: () => {
+      setShowRegenerate(true);
+      setShowDisable(false);
+    },
+    cancelRegenerate: () => setShowRegenerate(false),
+    regenerateCode,
+    setRegenerateCode,
+    regenerateRecoveryCodes,
   };
 }

--- a/frontend/src/ui/settings/SecuritySettings.tsx
+++ b/frontend/src/ui/settings/SecuritySettings.tsx
@@ -26,6 +26,14 @@ export function SecuritySettings({ controller }: { controller: SecuritySettingsC
         />
       )}
       <TwoFactorSettings controller={controller} />
+      {settings?.twoFactorEnabled && (
+        <SecurityPreferenceToggle
+          title="Alert on depleted recovery codes"
+          description="Show an alert when you are running low on recovery codes to avoid getting locked out."
+          checked={settings.recoveryCodeAlertEnabled ?? false}
+          onChange={controller.setRecoveryCodeAlertEnabled}
+        />
+      )}
       <SecurityPreferenceToggle
         title="Single active session"
         description="Signing in on a new device immediately signs you out everywhere else."

--- a/frontend/src/ui/settings/security/TwoFactorDisableForm.tsx
+++ b/frontend/src/ui/settings/security/TwoFactorDisableForm.tsx
@@ -1,0 +1,49 @@
+export function TwoFactorDisableForm({
+  code,
+  setCode,
+  onConfirm,
+  onCancel,
+  busy,
+}: {
+  code: string;
+  setCode: (code: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+  busy: boolean;
+}) {
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        onConfirm();
+      }}
+      class="space-y-2"
+    >
+      <label class="block space-y-1.5">
+        <span class="text-xs text-ink-300">Confirm with a current code or a recovery code to disable 2FA</span>
+        <input
+          type="text"
+          value={code}
+          onInput={(event) => setCode((event.currentTarget as HTMLInputElement).value)}
+          class="w-full h-10 rounded-md bg-black/30 border border-white/10 px-3 text-sm text-ink-100 focus:outline-none focus:border-accent-blue"
+        />
+      </label>
+      <div class="flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={busy || !code}
+          class="h-9 px-2.5 rounded bg-accent-red/80 hover:bg-accent-red text-white text-[12.5px] font-medium disabled:opacity-50"
+        >
+          Disable
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          class="h-9 px-2.5 rounded text-ink-300 hover:text-ink-100 hover:bg-white/[0.05] text-[12.5px]"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/ui/settings/security/TwoFactorEnrollForm.tsx
+++ b/frontend/src/ui/settings/security/TwoFactorEnrollForm.tsx
@@ -1,0 +1,69 @@
+import { QrCode } from "../../primitives/QrCode";
+import { Loader } from "../../primitives/icons";
+
+export function TwoFactorEnrollForm({
+  otpauthUrl,
+  secret,
+  confirmCode,
+  setConfirmCode,
+  onConfirm,
+  onCancel,
+  busy,
+}: {
+  otpauthUrl: string;
+  secret: string;
+  confirmCode: string;
+  setConfirmCode: (code: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+  busy: boolean;
+}) {
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        onConfirm();
+      }}
+      class="space-y-3"
+    >
+      <div class="flex flex-col sm:flex-row gap-3">
+        <QrCode value={otpauthUrl} size={160} class="rounded bg-white p-2 flex-none" />
+        <div class="flex-1 min-w-0 space-y-1.5">
+          <div class="text-[12px] text-ink-300">
+            Scan with your authenticator app, or enter this secret manually:
+          </div>
+          <code class="block break-all rounded bg-black/30 border border-white/10 px-2.5 py-2 text-[11.5px] text-ink-100">
+            {secret}
+          </code>
+        </div>
+      </div>
+      <label class="block space-y-1.5">
+        <span class="text-xs text-ink-300">Code from your authenticator app</span>
+        <input
+          type="text"
+          inputMode="numeric"
+          value={confirmCode}
+          onInput={(event) => setConfirmCode((event.currentTarget as HTMLInputElement).value)}
+          class="w-full h-10 rounded-md bg-black/30 border border-white/10 px-3 text-sm text-ink-100 focus:outline-none focus:border-accent-blue"
+        />
+      </label>
+      <div class="flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={busy}
+          class="h-10 px-3 rounded-md bg-accent-blue/80 hover:bg-accent-blue text-white text-[13px] font-medium disabled:opacity-50 inline-flex items-center gap-2"
+        >
+          {busy && <Loader class="w-3.5 h-3.5 animate-spin" />}
+          Confirm
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          class="h-10 px-3 rounded-md text-ink-300 hover:text-ink-100 hover:bg-white/[0.05] text-[13px]"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/ui/settings/security/TwoFactorRecoveryCodes.tsx
+++ b/frontend/src/ui/settings/security/TwoFactorRecoveryCodes.tsx
@@ -1,0 +1,29 @@
+export function TwoFactorRecoveryCodes({
+  codes,
+  onDismiss,
+}: {
+  codes: string[];
+  onDismiss: () => void;
+}) {
+  return (
+    <div class="rounded-md border border-accent-yellow/30 bg-accent-yellow/[0.08] p-3 space-y-2">
+      <div class="text-[13px] font-medium text-ink-50">
+        Save these recovery codes now — they won't be shown again.
+      </div>
+      <div class="grid grid-cols-2 gap-1.5 font-mono text-[12.5px] text-ink-100">
+        {codes.map((code) => (
+          <div key={code} class="bg-black/30 border border-white/10 rounded px-2 py-1">
+            {code}
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        class="h-8 px-2.5 rounded bg-white/[0.08] hover:bg-white/[0.12] text-ink-100 text-[12px] font-medium"
+      >
+        I've saved these codes
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/ui/settings/security/TwoFactorRegenerateForm.tsx
+++ b/frontend/src/ui/settings/security/TwoFactorRegenerateForm.tsx
@@ -1,0 +1,52 @@
+import { Loader } from "../../primitives/icons";
+
+export function TwoFactorRegenerateForm({
+  code,
+  setCode,
+  onConfirm,
+  onCancel,
+  busy,
+}: {
+  code: string;
+  setCode: (code: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+  busy: boolean;
+}) {
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        onConfirm();
+      }}
+      class="space-y-2"
+    >
+      <label class="block space-y-1.5">
+        <span class="text-xs text-ink-300">Confirm with a current code or a recovery code to regenerate</span>
+        <input
+          type="text"
+          value={code}
+          onInput={(event) => setCode((event.currentTarget as HTMLInputElement).value)}
+          class="w-full h-10 rounded-md bg-black/30 border border-white/10 px-3 text-sm text-ink-100 focus:outline-none focus:border-accent-blue"
+        />
+      </label>
+      <div class="flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={busy || !code}
+          class="h-9 px-2.5 rounded bg-accent-blue/80 hover:bg-accent-blue text-white text-[12.5px] font-medium disabled:opacity-50 inline-flex items-center gap-2"
+        >
+          {busy && <Loader class="w-3.5 h-3.5 animate-spin" />}
+          Regenerate codes
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          class="h-9 px-2.5 rounded text-ink-300 hover:text-ink-100 hover:bg-white/[0.05] text-[12.5px]"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/ui/settings/security/TwoFactorSettings.tsx
+++ b/frontend/src/ui/settings/security/TwoFactorSettings.tsx
@@ -116,11 +116,18 @@ export function TwoFactorSettings({ controller }: { controller: SecuritySettings
           </form>
         )}
 
-        {twoFactorEnabled && !flow.showDisable && (
+        {twoFactorEnabled && !flow.showDisable && !flow.showRegenerate && (
           <div class="flex items-center gap-2">
             <span class="text-[12.5px] text-ink-300">
               {settings?.recoveryCodesRemaining ?? 0} recovery codes remaining.
             </span>
+            <button
+              type="button"
+              onClick={flow.showRegenerateForm}
+              class="h-9 px-2.5 rounded bg-white/[0.08] hover:bg-white/[0.12] text-ink-100 text-[12.5px] font-medium inline-flex items-center gap-1.5"
+            >
+              Regenerate codes
+            </button>
             <button
               type="button"
               onClick={flow.showDisableForm}
@@ -140,7 +147,7 @@ export function TwoFactorSettings({ controller }: { controller: SecuritySettings
             class="space-y-2"
           >
             <label class="block space-y-1.5">
-              <span class="text-xs text-ink-300">Confirm with a current code or a recovery code</span>
+              <span class="text-xs text-ink-300">Confirm with a current code or a recovery code to disable 2FA</span>
               <input
                 type="text"
                 value={flow.disableCode}
@@ -151,7 +158,7 @@ export function TwoFactorSettings({ controller }: { controller: SecuritySettings
             <div class="flex items-center gap-2">
               <button
                 type="submit"
-                disabled={flow.busy}
+                disabled={flow.busy || !flow.disableCode}
                 class="h-9 px-2.5 rounded bg-accent-red/80 hover:bg-accent-red text-white text-[12.5px] font-medium disabled:opacity-50"
               >
                 Disable
@@ -159,6 +166,43 @@ export function TwoFactorSettings({ controller }: { controller: SecuritySettings
               <button
                 type="button"
                 onClick={flow.cancelDisable}
+                class="h-9 px-2.5 rounded text-ink-300 hover:text-ink-100 hover:bg-white/[0.05] text-[12.5px]"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        )}
+
+        {flow.showRegenerate && (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              void flow.regenerateRecoveryCodes();
+            }}
+            class="space-y-2"
+          >
+            <label class="block space-y-1.5">
+              <span class="text-xs text-ink-300">Confirm with a current code or a recovery code to regenerate</span>
+              <input
+                type="text"
+                value={flow.regenerateCode}
+                onInput={(event) => flow.setRegenerateCode((event.currentTarget as HTMLInputElement).value)}
+                class="w-full h-10 rounded-md bg-black/30 border border-white/10 px-3 text-sm text-ink-100 focus:outline-none focus:border-accent-blue"
+              />
+            </label>
+            <div class="flex items-center gap-2">
+              <button
+                type="submit"
+                disabled={flow.busy || !flow.regenerateCode}
+                class="h-9 px-2.5 rounded bg-accent-blue/80 hover:bg-accent-blue text-white text-[12.5px] font-medium disabled:opacity-50 inline-flex items-center gap-2"
+              >
+                {flow.busy && <Loader class="w-3.5 h-3.5 animate-spin" />}
+                Regenerate codes
+              </button>
+              <button
+                type="button"
+                onClick={flow.cancelRegenerate}
                 class="h-9 px-2.5 rounded text-ink-300 hover:text-ink-100 hover:bg-white/[0.05] text-[12.5px]"
               >
                 Cancel

--- a/frontend/src/ui/settings/security/TwoFactorSettings.tsx
+++ b/frontend/src/ui/settings/security/TwoFactorSettings.tsx
@@ -1,7 +1,10 @@
 import type { SecuritySettingsController } from "../../../state/hooks/auth/useSecuritySettings";
 import { useTwoFactorSettingsFlow } from "../../../state/hooks/auth/useTwoFactorSettingsFlow";
 import { Check, Key, Loader, ShieldCheck } from "../../primitives/icons";
-import { QrCode } from "../../primitives/QrCode";
+import { TwoFactorRecoveryCodes } from "./TwoFactorRecoveryCodes";
+import { TwoFactorEnrollForm } from "./TwoFactorEnrollForm";
+import { TwoFactorDisableForm } from "./TwoFactorDisableForm";
+import { TwoFactorRegenerateForm } from "./TwoFactorRegenerateForm";
 
 export function TwoFactorSettings({ controller }: { controller: SecuritySettingsController }) {
   const { settings } = controller;
@@ -34,25 +37,10 @@ export function TwoFactorSettings({ controller }: { controller: SecuritySettings
 
       <div class="p-3.5 space-y-3">
         {flow.recoveryCodes && (
-          <div class="rounded-md border border-accent-yellow/30 bg-accent-yellow/[0.08] p-3 space-y-2">
-            <div class="text-[13px] font-medium text-ink-50">
-              Save these recovery codes now — they won't be shown again.
-            </div>
-            <div class="grid grid-cols-2 gap-1.5 font-mono text-[12.5px] text-ink-100">
-              {flow.recoveryCodes.map((code) => (
-                <div key={code} class="bg-black/30 border border-white/10 rounded px-2 py-1">
-                  {code}
-                </div>
-              ))}
-            </div>
-            <button
-              type="button"
-              onClick={flow.dismissRecoveryCodes}
-              class="h-8 px-2.5 rounded bg-white/[0.08] hover:bg-white/[0.12] text-ink-100 text-[12px] font-medium"
-            >
-              I've saved these codes
-            </button>
-          </div>
+          <TwoFactorRecoveryCodes
+            codes={flow.recoveryCodes}
+            onDismiss={flow.dismissRecoveryCodes}
+          />
         )}
 
         {!twoFactorEnabled && !flow.enrolling && !flow.recoveryCodes && (
@@ -68,52 +56,15 @@ export function TwoFactorSettings({ controller }: { controller: SecuritySettings
         )}
 
         {flow.enrolling && (
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              void flow.confirmEnrollment();
-            }}
-            class="space-y-3"
-          >
-            <div class="flex flex-col sm:flex-row gap-3">
-              <QrCode value={flow.otpauthUrl} size={160} class="rounded bg-white p-2 flex-none" />
-              <div class="flex-1 min-w-0 space-y-1.5">
-                <div class="text-[12px] text-ink-300">
-                  Scan with your authenticator app, or enter this secret manually:
-                </div>
-                <code class="block break-all rounded bg-black/30 border border-white/10 px-2.5 py-2 text-[11.5px] text-ink-100">
-                  {flow.secret}
-                </code>
-              </div>
-            </div>
-            <label class="block space-y-1.5">
-              <span class="text-xs text-ink-300">Code from your authenticator app</span>
-              <input
-                type="text"
-                inputMode="numeric"
-                value={flow.confirmCode}
-                onInput={(event) => flow.setConfirmCode((event.currentTarget as HTMLInputElement).value)}
-                class="w-full h-10 rounded-md bg-black/30 border border-white/10 px-3 text-sm text-ink-100 focus:outline-none focus:border-accent-blue"
-              />
-            </label>
-            <div class="flex items-center gap-2">
-              <button
-                type="submit"
-                disabled={flow.busy}
-                class="h-10 px-3 rounded-md bg-accent-blue/80 hover:bg-accent-blue text-white text-[13px] font-medium disabled:opacity-50 inline-flex items-center gap-2"
-              >
-                {flow.busy && <Loader class="w-3.5 h-3.5 animate-spin" />}
-                Confirm
-              </button>
-              <button
-                type="button"
-                onClick={flow.cancelEnrollment}
-                class="h-10 px-3 rounded-md text-ink-300 hover:text-ink-100 hover:bg-white/[0.05] text-[13px]"
-              >
-                Cancel
-              </button>
-            </div>
-          </form>
+          <TwoFactorEnrollForm
+            otpauthUrl={flow.otpauthUrl}
+            secret={flow.secret}
+            confirmCode={flow.confirmCode}
+            setConfirmCode={flow.setConfirmCode}
+            onConfirm={() => void flow.confirmEnrollment()}
+            onCancel={flow.cancelEnrollment}
+            busy={flow.busy}
+          />
         )}
 
         {twoFactorEnabled && !flow.showDisable && !flow.showRegenerate && (
@@ -139,76 +90,23 @@ export function TwoFactorSettings({ controller }: { controller: SecuritySettings
         )}
 
         {flow.showDisable && (
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              void flow.disableTwoFactor();
-            }}
-            class="space-y-2"
-          >
-            <label class="block space-y-1.5">
-              <span class="text-xs text-ink-300">Confirm with a current code or a recovery code to disable 2FA</span>
-              <input
-                type="text"
-                value={flow.disableCode}
-                onInput={(event) => flow.setDisableCode((event.currentTarget as HTMLInputElement).value)}
-                class="w-full h-10 rounded-md bg-black/30 border border-white/10 px-3 text-sm text-ink-100 focus:outline-none focus:border-accent-blue"
-              />
-            </label>
-            <div class="flex items-center gap-2">
-              <button
-                type="submit"
-                disabled={flow.busy || !flow.disableCode}
-                class="h-9 px-2.5 rounded bg-accent-red/80 hover:bg-accent-red text-white text-[12.5px] font-medium disabled:opacity-50"
-              >
-                Disable
-              </button>
-              <button
-                type="button"
-                onClick={flow.cancelDisable}
-                class="h-9 px-2.5 rounded text-ink-300 hover:text-ink-100 hover:bg-white/[0.05] text-[12.5px]"
-              >
-                Cancel
-              </button>
-            </div>
-          </form>
+          <TwoFactorDisableForm
+            code={flow.disableCode}
+            setCode={flow.setDisableCode}
+            onConfirm={() => void flow.disableTwoFactor()}
+            onCancel={flow.cancelDisable}
+            busy={flow.busy}
+          />
         )}
 
         {flow.showRegenerate && (
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              void flow.regenerateRecoveryCodes();
-            }}
-            class="space-y-2"
-          >
-            <label class="block space-y-1.5">
-              <span class="text-xs text-ink-300">Confirm with a current code or a recovery code to regenerate</span>
-              <input
-                type="text"
-                value={flow.regenerateCode}
-                onInput={(event) => flow.setRegenerateCode((event.currentTarget as HTMLInputElement).value)}
-                class="w-full h-10 rounded-md bg-black/30 border border-white/10 px-3 text-sm text-ink-100 focus:outline-none focus:border-accent-blue"
-              />
-            </label>
-            <div class="flex items-center gap-2">
-              <button
-                type="submit"
-                disabled={flow.busy || !flow.regenerateCode}
-                class="h-9 px-2.5 rounded bg-accent-blue/80 hover:bg-accent-blue text-white text-[12.5px] font-medium disabled:opacity-50 inline-flex items-center gap-2"
-              >
-                {flow.busy && <Loader class="w-3.5 h-3.5 animate-spin" />}
-                Regenerate codes
-              </button>
-              <button
-                type="button"
-                onClick={flow.cancelRegenerate}
-                class="h-9 px-2.5 rounded text-ink-300 hover:text-ink-100 hover:bg-white/[0.05] text-[12.5px]"
-              >
-                Cancel
-              </button>
-            </div>
-          </form>
+          <TwoFactorRegenerateForm
+            code={flow.regenerateCode}
+            setCode={flow.setRegenerateCode}
+            onConfirm={() => void flow.regenerateRecoveryCodes()}
+            onCancel={flow.cancelRegenerate}
+            busy={flow.busy}
+          />
         )}
 
         {flow.error && <div class="text-xs text-accent-red">{flow.error}</div>}


### PR DESCRIPTION
This PR introduces a TOTP 2FA flow and UI for local administrators.

Fixes #108

It includes:
- The recovery-code alert toggle
- Proof-gated regeneration 
- Displaying newly generated codes once