### PR TITLE
fix(qrcode): correct format info and alignment pattern spacing

### DIFF
--- a/frontend/src/services/projects/QRGenerator.js
+++ b/frontend/src/services/projects/QRGenerator.js
@@ -156,7 +156,7 @@ function addErrorCorrection(data, version) {
 function alignmentPositions(version) {
   if (version === 1) return [];
   const count = Math.floor(version / 7) + 2;
-  const step = version === 32 ? 26 : Math.ceil((version * 4 + count * 2 + 1) / (count * 2 - 2)) * 2;
+  const step = version === 32 ? 26 : Math.floor((version * 4 + count * 2 + 1) / (count * 2 - 2)) * 2;
   const positions = [6];
   for (let position = version * 4 + 10; positions.length < count; position -= step) positions.splice(1, 0, position);
   return positions;

--- a/frontend/src/services/projects/QRGenerator.js
+++ b/frontend/src/services/projects/QRGenerator.js
@@ -191,7 +191,7 @@ function drawFormat(matrix, reserved, mask) {
   const data = mask; // Medium error correction uses format bits 00.
   let remainder = data;
   for (let index = 0; index < 10; index++) remainder = remainder << 1 ^ (remainder >>> 9) * 0x537;
-  const bits = data << 10 | remainder ^ 0x5412;
+  const bits = (data << 10 | remainder) ^ 0x5412;
   const bit = (index) => (bits >>> index & 1) !== 0;
 
   for (let index = 0; index <= 5; index++) setFunction(matrix, reserved, index, 8, bit(index));

--- a/frontend/src/services/projects/qrCode.test.ts
+++ b/frontend/src/services/projects/qrCode.test.ts
@@ -35,7 +35,7 @@ test("encodes a representative authenticator enrollment URI", () => {
   );
 
   assert.equal(code.size, 41);
-  assert.deepEqual(matrixFingerprint(code), { darkModules: 816, hash: "2b3d6c2d" });
+  assert.deepEqual(matrixFingerprint(code), { darkModules: 866, hash: "ced53afd" });
 });
 
 test("selects numeric, alphanumeric, and UTF-8 byte modes", () => {

--- a/frontend/src/services/projects/qrCode.test.ts
+++ b/frontend/src/services/projects/qrCode.test.ts
@@ -38,6 +38,50 @@ test("encodes a representative authenticator enrollment URI", () => {
   assert.deepEqual(matrixFingerprint(code), { darkModules: 866, hash: "ced53afd" });
 });
 
+// Both format-information copies must be one of the eight ISO/IEC 18004 medium-ECC
+// bit strings, otherwise scanners reject the symbol before reading any data.
+const MEDIUM_FORMAT_BITS = [
+  "101010000010010", "101000100100101", "101111001111100", "101101101001011",
+  "100010111111001", "100000011001110", "100111110010111", "100101010100000",
+];
+
+function readFormatBits(code: QRCodeMatrix, positions: [number, number][]): string {
+  return positions.map(([x, y]) => (code.isDark(x, y) ? "1" : "0")).reverse().join("");
+}
+
+test("writes spec-conformant format information in both copies", () => {
+  for (const value of ["HELLO WORLD", "REMOTE FUTRX 2FA", "012345678901234567890123456789"]) {
+    const code = qrGenerator.createMatrix(value);
+    const last = code.size - 1;
+    const primary: [number, number][] = [
+      [8, 0], [8, 1], [8, 2], [8, 3], [8, 4], [8, 5], [8, 7], [8, 8],
+      [7, 8], [5, 8], [4, 8], [3, 8], [2, 8], [1, 8], [0, 8],
+    ];
+    const secondary: [number, number][] = [
+      [last, 8], [last - 1, 8], [last - 2, 8], [last - 3, 8], [last - 4, 8],
+      [last - 5, 8], [last - 6, 8], [last - 7, 8],
+      [8, code.size - 7], [8, code.size - 6], [8, code.size - 5],
+      [8, code.size - 4], [8, code.size - 3], [8, code.size - 2], [8, last],
+    ];
+
+    const bits = readFormatBits(code, primary);
+    assert.ok(MEDIUM_FORMAT_BITS.includes(bits), `${value} produced format bits ${bits}`);
+    assert.equal(readFormatBits(code, secondary), bits);
+    assert.equal(code.isDark(8, code.size - 8), true);
+  }
+});
+
+test("places version 7 alignment patterns at the coordinates required by the spec", () => {
+  const code = qrGenerator.createMatrix("x".repeat(107));
+
+  assert.equal(code.size, 45);
+  for (const [x, y] of [[22, 22], [22, 38], [38, 22], [6, 22], [22, 6]]) {
+    assert.equal(code.isDark(x, y), true);
+    assert.equal(code.isDark(x - 1, y), false);
+    assert.equal(code.isDark(x - 2, y), true);
+  }
+});
+
 test("selects numeric, alphanumeric, and UTF-8 byte modes", () => {
   assert.equal(qrGenerator.createMatrix("012345678901234567890123456789").size, 21);
   assert.equal(qrGenerator.createMatrix("REMOTE FUTRX 2FA").size, 21);


### PR DESCRIPTION
## Summary
- Fix operator precedence bug in QR format information calculation
- Fix alignment pattern spacing for QR versions 7 and above
- Assert QR format info and alignment against the spec instead of a fingerprint

## Test plan
- [x] Existing/updated unit tests in `frontend/src/services/projects/qrCode.test.ts` cover the format info and alignment pattern behavior