### PR TITLE
feat(ci): add GitHub Actions workflow for pull request validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+# Validates pull requests and pushes to main/qa without needing LXD or a server.
+# Backend and frontend unit tests, builds, and infra shell tests only.
+# See CONTRIBUTING.md for the local equivalents of every step below.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, qa]
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: backend (go vet/test/build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      - name: Check gofmt
+        run: |
+          set -euo pipefail
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "unformatted Go files:"
+            echo "$unformatted"
+            exit 1
+          fi
+      - name: Go vet
+        run: go vet ./...
+      - name: Go test
+        run: go test ./...
+      - name: Go build
+        run: go build ./...
+
+  frontend:
+    name: frontend (npm test/build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run frontend tests
+        run: npm test
+      - name: Build frontend
+        run: npm run build
+
+  shell:
+    name: infra shell tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run infra and release classifier tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash infra/tests/health-check-test.sh
+          bash infra/tests/go-toolchain-test.sh
+          bash infra/tests/host-agent-install-test.sh
+          bash infra/tests/dns-resolve-test.sh
+          bash infra/tests/container-forwarding-test.sh
+          bash infra/tests/swap-provision-test.sh
+          bash infra/tests/release-version-test.sh
+          bash infra/tests/deploy-app-script-test.sh
+          bash infra/tests/qa-scripts-test.sh
+          bash .github/scripts/classify-release-test.sh


### PR DESCRIPTION
Closes #76.

## What
Adds lightweight PR/push validation (.github/workflows/ci.yml) that runs without LXD or a server:
- backend: setup-go from ackend/go.mod, gofmt -l check, go vet ./..., go test ./..., go build ./...
- frontend: setup-node 22 with npm cache, 
pm ci, 
pm test, 
pm run build
- shell: the fast infra/tests/* + classify-release-test.sh suite from CONTRIBUTING.md

Triggers on pull_request and pushes to main/qa.

## Why
No automated CI on PRs today - regressions rely on local verification. This gives immediate feedback and blocks broken builds/tests before merge to qa/main.

## Verified locally
- frontend: 
pm ci then 
pm test -> 163/163 pass, 
pm run build succeeds (Preact/Vite -> ackend/public/, gitignored)
- shell: health-check-test.sh, elease-version-test.sh, classify-release-test.sh pass
- Go steps mirror CONTRIBUTING.md (go vet, go test, go build); no local Go toolchain on this machine so backend job will validate in CI
