### PR TITLE
fix(workspaces): publish base image without compression

### DIFF
--- a/backend/internal/integration/containers/baseimage/client.go
+++ b/backend/internal/integration/containers/baseimage/client.go
@@ -44,12 +44,20 @@ func (c *Client) PublishImage(
 	alias,
 	description string,
 ) (string, error) {
+	// --compression none: LXD's default gzip pack of the multi-GB rootfs is
+	// far slower than the publish timeout on single-vCPU hosts, killing the
+	// build (see #40). The published image only ever lives on this host via
+	// `lxd launch`, so compression buys nothing except CPU time and slower
+	// starts. Disabling it brings publish from a multi-hour gzip pack down to
+	// ~1 minute even on one core.
 	return c.runner.Run(
 		ctx,
 		"publish",
 		containerName,
 		"--alias",
 		alias,
+		"--compression",
+		"none",
 		"description="+description,
 	)
 }

--- a/backend/internal/integration/containers/baseimage/client_test.go
+++ b/backend/internal/integration/containers/baseimage/client_test.go
@@ -65,7 +65,7 @@ func TestClientTranslatesImageOperations(t *testing.T) {
 			invoke: func(client *Client) (string, error) {
 				return client.PublishImage(context.Background(), "builder", "remote-base", "base description")
 			},
-			wantArgs: []string{"publish", "builder", "--alias", "remote-base", "description=base description"},
+			wantArgs: []string{"publish", "builder", "--alias", "remote-base", "--compression", "none", "description=base description"},
 		},
 	}
 


### PR DESCRIPTION
Closes #40.

## What
Stage 6 of the base-image build ('Publishing the reusable workspace image') died on 1-vCPU hosts: LXD's default gzip pack of the multi-GB rootfs reached only ~4% in 5 minutes (extrapolated ~2h), tripping \aseImagePublishTimeout\ on every retry so the installer never converged.

\Client.PublishImage\ now passes \--compression none\ to \lxc publish\ (\ackend/internal/integration/containers/baseimage/client.go\). The image never leaves the host, so compression buys nothing but CPU time - the reporter verified uncompressed publish finishes in ~1m10s on the same box. This implements suggestion 2 from the issue and is surgical: it does not change the daemon-wide \images.compression_algorithm\ setting, so users' other images are unaffected. The publish timeout (already 15m) is left as-is since it is plenty with compression off.

Test expectation updated in \client_test.go\.

## Verified locally (portable Go 1.25.13, matching \ackend/go.mod\)
- \gofmt -l\ clean on both touched files
- \go vet\ clean on both affected packages
- \go test -count=1 ./internal/integration/containers/baseimage/\ -> PASS (incl. updated \publish_image\ case)
- \go test -count=1 ./internal/service/container/image/\ -> ok
