### PR TITLE
fix(browser): probe both per-arch Chromium paths for aarch64

### DIFF
--- a/backend/internal/integration/containers/browser/assets/agent-browser-smoke-test.sh
+++ b/backend/internal/integration/containers/browser/assets/agent-browser-smoke-test.sh
@@ -1,7 +1,12 @@
 # Sanity check the GUI toolchain and select the browser pinned by versions.env.
 which Xvfb x11vnc websockify openbox xdotool setsid
+# Playwright's per-arch Chromium layout: the binary lives under
+# chrome-linux64/ on x86_64 hosts and chrome-linux/ on aarch64. Probe both so
+# aarch64 installs (which succeed via Playwright's arm64 build) are found
+# instead of reported as "not installed".
 CHROME=""
-for browser_bin in /root/.cache/ms-playwright/chromium-*/chrome-linux64/chrome; do
+for browser_bin in /root/.cache/ms-playwright/chromium-*/chrome-linux64/chrome \
+                   /root/.cache/ms-playwright/chromium-*/chrome-linux/chrome; do
     [ -x "$browser_bin" ] || continue
     if "$browser_bin" --version 2>/dev/null | grep -Fq "$PW_CFT_VERSION"; then
         CHROME="$browser_bin"

--- a/backend/internal/integration/containers/browser/assets/gui-up.sh
+++ b/backend/internal/integration/containers/browser/assets/gui-up.sh
@@ -28,8 +28,12 @@ export DISPLAY=":$DISPLAY_NUM"
 # chrome "network," rule (baked by AgentBrowserInstallScript since 2026-07-08;
 # Ubuntu's stock chrome profile otherwise denies all its sockets inside
 # nested LXD AppArmor namespaces — CreatePlatformSocket EPERM).
+# Playwright's per-arch Chromium layout: the binary lives under
+# chrome-linux64/ on x86_64 hosts and chrome-linux/ on aarch64. Probe both so
+# aarch64 installs (which succeed via Playwright's arm64 build) are found.
 CHROME=""
-for browser_bin in /root/.cache/ms-playwright/chromium-*/chrome-linux64/chrome; do
+for browser_bin in /root/.cache/ms-playwright/chromium-*/chrome-linux64/chrome \
+                   /root/.cache/ms-playwright/chromium-*/chrome-linux/chrome; do
   [ -x "$browser_bin" ] || continue
   if "$browser_bin" --version 2>/dev/null | grep -Fq "$EXPECTED_CHROME_VERSION"; then
     CHROME="$browser_bin"

--- a/backend/internal/integration/containers/browser/install.go
+++ b/backend/internal/integration/containers/browser/install.go
@@ -59,7 +59,9 @@ func (r browserAssetRenderer) launcherScript() []byte {
 }
 
 func (r browserAssetRenderer) stackCheck() string {
-	return `command -v Xvfb >/dev/null 2>&1 && for browser_bin in /root/.cache/ms-playwright/chromium-*/chrome-linux64/chrome; do [ -x "$browser_bin" ] || continue; "$browser_bin" --version 2>/dev/null | grep -Fq '` + r.pin("PW_CFT_VERSION") + `' && exit 0; done; exit 1`
+	// Playwright's Chromium lives under chrome-linux64/ on x86_64 and
+	// chrome-linux/ on aarch64; probe both so arm64 installs resolve.
+	return `command -v Xvfb >/dev/null 2>&1 && for browser_bin in /root/.cache/ms-playwright/chromium-*/chrome-linux64/chrome /root/.cache/ms-playwright/chromium-*/chrome-linux/chrome; do [ -x "$browser_bin" ] || continue; "$browser_bin" --version 2>/dev/null | grep -Fq '` + r.pin("PW_CFT_VERSION") + `' && exit 0; done; exit 1`
 }
 
 func renderedGUIUpScript() []byte {


### PR DESCRIPTION
## What

On AArch64 machines the agent-browser install reports the pinned Chrome as missing/incompatible even when Playwright's arm64 Chromium build installs fine.

Root cause: Playwright's per-arch layout puts the binary under `chrome-linux64/` on x86_64 but `chrome-linux/` on aarch64. Three places probed `chrome-linux64/chrome` only:

- `backend/.../browser/assets/gui-up.sh` (launcher discovery)
- `backend/.../browser/assets/agent-browser-smoke-test.sh` (install verification)
- `backend/.../browser/install.go` (`stackCheck()`)

This change probes both layouts in all three, with a comment explaining the per-arch layout. Behavior on x86_64 is unchanged (the `chrome-linux64` glob still matches first).

Fixes #80.

## Verification

- `bash -n` passes on all three shell assets (`gui-up.sh`, `agent-browser-smoke-test.sh`, `agent-browser-install.sh` untouched but re-checked).
- `backend/.../browser/browser_test.go` builds its provision expectation from `browserStackCheck()` itself, so no test update was needed.
- No Go toolchain on this machine, so `go build/vet/test` for the `browser` package still needs a CI run.
