### PR TITLE
feat(infra): support custom Caddy snippets for DNS-01 and private hosts (#27)

### DIFF
--- a/docs/04-operations/09-deployment-and-operations.md
+++ b/docs/04-operations/09-deployment-and-operations.md
@@ -116,6 +116,15 @@ flowchart TD
 
 Caddy validates its rendered configuration before replacing the live file. On-demand certificate requests are accepted only for existing project slugs and permitted hostname formats.
 
+### Custom Caddy configuration (`/etc/caddy/conf.d/`)
+
+To support setups such as private LANs, Tailscale tailnets, or DNS-01 ACME challenges (e.g. `acme_dns cloudflare <token>`) without maintaining a fork of `Caddyfile.tmpl`, Remote automatically imports optional custom Caddy snippets:
+
+- `/etc/caddy/conf.d/global/*.caddy`: Imported inside Caddy's global options block. Use this for global ACME DNS plugins, custom certificates, or global TLS options.
+- `/etc/caddy/conf.d/sites/*.caddy`: Imported as additional top-level site blocks. Use this for extra domain names, custom reverse proxies, or dedicated subdomains.
+
+Files in these directories persist across host convergence, updates, and `infra/install.sh` runs.
+
 ## Base-image build
 
 ```mermaid

--- a/infra/steps/03-caddy.sh
+++ b/infra/steps/03-caddy.sh
@@ -8,6 +8,10 @@
 set -euo pipefail
 
 log "Rendering /etc/caddy/Caddyfile for $HOSTNAME"
+# Ensure user snippet directories exist so Caddy can safely import them.
+mkdir -p /etc/caddy/conf.d/global /etc/caddy/conf.d/sites
+chmod 0755 /etc/caddy/conf.d /etc/caddy/conf.d/global /etc/caddy/conf.d/sites 2>/dev/null || true
+
 # Render to a temp file first, validate, then atomically replace. This way a
 # bad template doesn't blow away a working live config.
 TMP_CADDYFILE="$(mktemp)"

--- a/infra/templates/Caddyfile.tmpl
+++ b/infra/templates/Caddyfile.tmpl
@@ -19,6 +19,10 @@
     on_demand_tls {
         ask http://127.0.0.1:${SERVICE_PORT}/internal/tls-ask
     }
+
+    # Optional user-provided global directives (e.g. acme_dns, cert issuers, etc.)
+    # Survives installer/update runs without requiring template edits or forks.
+    import /etc/caddy/conf.d/global/*.caddy
 }
 
 ${HOSTNAME} {
@@ -152,3 +156,7 @@ code.${HOSTNAME} {
     }
     respond "Use <slug>--<port>.dev.${HOSTNAME} (e.g. myproj--3000.dev.${HOSTNAME})" 400
 }
+
+# Optional user-provided site blocks (e.g. custom hostnames, wildcards, or reverse proxies).
+# Survives installer/update runs without requiring template edits or forks.
+import /etc/caddy/conf.d/sites/*.caddy


### PR DESCRIPTION
Resolves #27\n\n### Summary\n\nAllows hosts without public inbound reachability (Tailscale, WireGuard, private LANs, CGNAT) or deployments requiring DNS-01 ACME challenges (e.g. cme_dns cloudflare <token>) to persist their custom Caddy configuration without maintaining a fork of Caddyfile.tmpl.\n\n### Changes\n\n- infra/templates/Caddyfile.tmpl: \n  - Added import /etc/caddy/conf.d/global/*.caddy in global options block for ACME DNS providers and global TLS directives.\n  - Added import /etc/caddy/conf.d/sites/*.caddy for custom site blocks and reverse proxy endpoints.\n- infra/steps/03-caddy.sh: Automatically ensures /etc/caddy/conf.d/global and /etc/caddy/conf.d/sites exist with proper permissions before template rendering and validation.\n- docs/04-operations/09-deployment-and-operations.md: Documented custom snippet persistence across updates and re-installations.