### PR TITLE
fix(secrets): preserve draft state across tab navigation

### DIFF
--- a/frontend/src/ui/projects/ProjectContainersPage.tsx
+++ b/frontend/src/ui/projects/ProjectContainersPage.tsx
@@ -1,4 +1,5 @@
 import type { ComponentChildren, ComponentType } from "preact";
+import { useCallback, useState } from "preact/hooks";
 import type {
   AccessRecord,
   ProjectContainerRecord,
@@ -10,7 +11,10 @@ import {
   ContainerStateBadge,
   ProjectInfoSection,
 } from "./project-containers/ProjectInfoSection";
-import { ProjectSecretsSection } from "./project-containers/ProjectSecretsSection";
+import {
+  ProjectSecretsSection,
+  type SecretDraft,
+} from "./project-containers/ProjectSecretsSection";
 import { ProjectSharingSection } from "./project-containers/ProjectSharingSection";
 import { ProjectResourceLimits } from "./project-containers/ProjectResourceLimits";
 import { ProjectUsageLine } from "./project-containers/ProjectUsageLine";
@@ -18,6 +22,7 @@ import { formatRelativeTime as fmtRelative } from "./project-containers/projectC
 import type { ContainerLimits, ProjectContainerInfo, ProjectMeta } from "../../models/project";
 import type { UsageSummary } from "../../models/usage";
 import { ChevronLeft, Info, Key, Loader, Menu, RotateCcw, Settings, Users } from "../primitives/icons";
+import { useConfirm } from "../../state/context/ConfirmContext";
 
 export type ProjectSettingsTab = "info" | "settings" | "secrets" | "sharing";
 
@@ -108,7 +113,35 @@ export function ProjectContainersPage({
   onRestartProject: () => Promise<void>;
   onDeleteProject: () => Promise<void>;
 }) {
+  const confirm = useConfirm();
   const activeTabDetails = tabs.find((tab) => tab.id === activeTab) ?? tabs[0];
+
+  // Draft state for the "Add new secret" form — owned here so it survives tab
+  // switches. SecretEditor is a conditionally-rendered subtree that would
+  // otherwise be unmounted (and lose its local state) on every navigation.
+  const [secretDraft, setSecretDraft] = useState<SecretDraft>({ key: "", value: "" });
+
+  const hasDraft = secretDraft.key.trim() !== "" || secretDraft.value !== "";
+
+  // Guard tab navigation: if there is a non-empty draft and the user is leaving
+  // the Secrets tab, ask for confirmation before silently discarding it.
+  const handleTabChange = useCallback(
+    async (next: ProjectSettingsTab) => {
+      if (next === activeTab) return;
+      if (activeTab === "secrets" && hasDraft) {
+        const ok = await confirm({
+          title: "Discard unsaved secret?",
+          message: `You have an unsaved draft for "${secretDraft.key || "(no key)"}". Switching tabs will keep the draft — it will be here when you return.`,
+          confirmLabel: "Switch anyway",
+          cancelLabel: "Stay on Secrets",
+          tone: "neutral",
+        });
+        if (!ok) return;
+      }
+      onTabChange(next);
+    },
+    [activeTab, hasDraft, secretDraft.key, confirm, onTabChange]
+  );
 
   return (
     <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
@@ -151,12 +184,12 @@ export function ProjectContainersPage({
       <div class="flex-1 min-h-0 flex flex-col md:flex-row overflow-hidden">
         <ProjectSettingsNavigation
           activeTab={activeTab}
-          onTabChange={onTabChange}
+          onTabChange={handleTabChange}
           className="theme-submenu-surface hidden md:flex w-56 flex-none border-r border-line bg-inset p-3"
         />
         <ProjectSettingsNavigation
           activeTab={activeTab}
-          onTabChange={onTabChange}
+          onTabChange={handleTabChange}
           mobile
           className="theme-submenu-surface md:hidden flex-none border-b border-line bg-inset px-3 py-2 overflow-x-auto no-scrollbar"
         />
@@ -231,6 +264,10 @@ export function ProjectContainersPage({
                   >
                     <ProjectSecretsSection
                       record={secretsRecord}
+                      draft={secretDraft}
+                      onDraftChange={(patch) =>
+                        setSecretDraft((prev) => ({ ...prev, ...patch }))
+                      }
                       onSave={onSaveSecret}
                       onDelete={onDeleteSecret}
                     />
@@ -266,7 +303,7 @@ function ProjectSettingsNavigation({
   className,
 }: {
   activeTab: ProjectSettingsTab;
-  onTabChange: (tab: ProjectSettingsTab) => void;
+  onTabChange: (tab: ProjectSettingsTab) => void | Promise<void>;
   mobile?: boolean;
   className: string;
 }) {

--- a/frontend/src/ui/projects/project-containers/ProjectSecretsSection.tsx
+++ b/frontend/src/ui/projects/project-containers/ProjectSecretsSection.tsx
@@ -10,12 +10,23 @@ import {
   lineSummary,
 } from "./projectContainerFormat";
 
+/** Draft state for the "Add new secret" form, lifted to survive tab switches. */
+export interface SecretDraft {
+  key: string;
+  value: string;
+}
+
 export function ProjectSecretsSection({
   record,
+  draft,
+  onDraftChange,
   onSave,
   onDelete,
 }: {
   record: SecretsRecord;
+  /** Lifted draft state — persists when the user switches away from this tab. */
+  draft: SecretDraft;
+  onDraftChange: (patch: Partial<SecretDraft>) => void;
   onSave: (key: string, value: string) => Promise<void>;
   onDelete: (key: string) => Promise<void>;
 }) {
@@ -27,7 +38,7 @@ export function ProjectSecretsSection({
           <div class="text-accent-red break-words">{record.error}</div>
         </div>
       )}
-      <SecretEditor onSave={onSave} />
+      <SecretEditor draft={draft} onDraftChange={onDraftChange} onSave={onSave} />
       <SecretsList list={record.data ?? []} loading={record.loading && !record.data} onSave={onSave} onDelete={onDelete} />
       <p class="text-[11.5px] text-ink-400 leading-relaxed">
         Secrets are passed to the selected agent CLI as <span class="font-mono">--env KEY=VALUE</span> on every prompt run. They never land in the container's filesystem and are not synced back from it.
@@ -37,18 +48,21 @@ export function ProjectSecretsSection({
 }
 
 function SecretEditor({
+  draft,
+  onDraftChange,
   onSave,
 }: {
+  /** Lifted draft state — caller owns this so it survives tab navigation. */
+  draft: SecretDraft;
+  onDraftChange: (patch: Partial<SecretDraft>) => void;
   onSave: (key: string, value: string) => Promise<void>;
 }) {
-  const [key, setKey] = useState("");
-  const [value, setValue] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   const submit = async (event: Event) => {
     event.preventDefault();
-    const normalizedKey = key.trim();
+    const normalizedKey = draft.key.trim();
     if (!normalizedKey) {
       setErr("Key is required.");
       return;
@@ -60,9 +74,9 @@ function SecretEditor({
     setErr(null);
     setSubmitting(true);
     try {
-      await onSave(normalizedKey, value);
-      setKey("");
-      setValue("");
+      await onSave(normalizedKey, draft.value);
+      // Clear the draft on success so the form resets.
+      onDraftChange({ key: "", value: "" });
     } catch (error) {
       setErr((error as Error).message);
     } finally {
@@ -70,18 +84,20 @@ function SecretEditor({
     }
   };
 
+  const hasDraft = draft.key.trim() !== "" || draft.value !== "";
+
   return (
     <form onSubmit={submit} class="rounded-md border border-line bg-tint p-2.5 space-y-2">
       <div class="grid gap-2 sm:grid-cols-[1fr_2fr_auto] items-start">
         <input
-          value={key}
-          onInput={(event) => setKey((event.target as HTMLInputElement).value)}
+          value={draft.key}
+          onInput={(event) => onDraftChange({ key: (event.target as HTMLInputElement).value })}
           placeholder="KEY"
           class="h-9 px-2.5 rounded border border-line bg-inset text-[13px] font-mono text-ink-50 placeholder-ink-400 focus:outline-none focus:border-accent-blue/50"
         />
         <textarea
-          value={value}
-          onInput={(event) => setValue((event.target as HTMLTextAreaElement).value)}
+          value={draft.value}
+          onInput={(event) => onDraftChange({ value: (event.target as HTMLTextAreaElement).value })}
           placeholder="value (multi-line OK — paste PEM keys, JSON, etc.)"
           rows={1}
           spellcheck={false}
@@ -98,6 +114,11 @@ function SecretEditor({
         </button>
       </div>
       {err && <div class="text-[11.5px] text-accent-red">{err}</div>}
+      {hasDraft && !err && (
+        <p class="text-[11px] text-ink-400">
+          Draft preserved — switch tabs freely and return to finish.
+        </p>
+      )}
     </form>
   );
 }


### PR DESCRIPTION
## Summary

Closes #135

When a user types into the "Add new secret" form (KEY / value) and then switches to Chat or Terminal to retrieve a value, the SecretEditor was unmounted — losing the in-progress draft without warning.

## Root cause

The Secrets tab is conditionally rendered (`activeTab === 'secrets' &&`) so the `SecretEditor` subtree is unmounted on every tab switch. Because `key` and `value` lived in local `useState` inside `SecretEditor`, they were reset to empty strings on every remount.

## Changes

### `ProjectSecretsSection.tsx`
- Exported a new `SecretDraft` interface (`{ key: string; value: string }`).
- `ProjectSecretsSection` now accepts `draft` and `onDraftChange` props.
- `SecretEditor` is now **controlled**: reads from `draft` and writes back through `onDraftChange` instead of owning its own state.
- Clears the draft via `onDraftChange({ key: '', value: '' })` on successful save.
- Shows a subtle hint ("Draft preserved — switch tabs freely and return to finish.") when the form has content.

### `ProjectContainersPage.tsx`
- Added `useState<SecretDraft>` that **outlives tab switches** because it lives in the page component, not in the conditionally-rendered secrets subtree.
- Calls `useConfirm` to **guard tab navigation**: when the user tries to leave the Secrets tab while a draft is present, they are shown a dialog and can choose to stay.
- Updated `ProjectSettingsNavigation.onTabChange` type to `void | Promise<void>` so async handlers are accepted without a TS error.

## Acceptance criteria coverage

| Criterion | Status |
|-----------|--------|
| Unsaved edits remain intact when switching tabs | ✅ Draft state lifted to page |
| No unexpected reload or form clear | ✅ State is never in the unmounted subtree |
| Draft is cleared after a successful save | ✅ `onDraftChange({ key: '', value: '' })` on save |
| Navigation with unsaved changes shows a warning | ✅ `useConfirm` dialog |
| Values never logged or stored insecurely | ✅ Only in React state, never serialised |
