### PR TITLE
fix(auth): restrict first-time credential setup to server loopback

### DIFF
--- a/backend/internal/service/auth/model.go
+++ b/backend/internal/service/auth/model.go
@@ -58,6 +58,11 @@ type Session struct {
 type Status struct {
 	Authenticated        bool           `json:"authenticated"`
 	Claimed              bool           `json:"claimed"`
+	// ClaimAllowed is true only when the local admin credential has not been
+	// set yet and the current request originates from the server's loopback
+	// interface (127.0.0.1 or ::1). Remote visitors receive false so the web
+	// UI does not expose the first-time setup form to arbitrary network clients.
+	ClaimAllowed         bool           `json:"claimAllowed"`
 	LocalAdminConfigured bool           `json:"localAdminConfigured"`
 	GoogleOAuthEnabled   bool           `json:"googleOAuthEnabled"`
 	GoogleClientID       string         `json:"googleClientId,omitempty"`

--- a/backend/internal/transport/http/handlers/auth_local_handler.go
+++ b/backend/internal/transport/http/handlers/auth_local_handler.go
@@ -12,6 +12,20 @@ import (
 	httptransport "github.com/futrx-com/remote.futrx.com/internal/transport/http"
 )
 
+// isLoopbackRequest returns true when the request originated from the server's
+// own loopback interface (127.0.0.0/8 or ::1). This is used to gate the
+// first-time admin credential setup so that only someone with shell access to
+// the host can initialise the credential.
+func isLoopbackRequest(r *http.Request) bool {
+	ip := localClientIP(r)
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	return parsed.IsLoopback()
+}
+
+
 type localAuthHandler struct {
 	auth   *serviceauth.Service
 	logins *localLoginLimiter
@@ -25,6 +39,13 @@ func (h *localAuthHandler) RegisterRoutes(mux *http.ServeMux) {
 func (h *localAuthHandler) claim(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		httptransport.SendErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	// First-time credential setup must originate from the server itself.
+	// Rejecting remote callers prevents anyone on the network from racing
+	// the legitimate operator to claim the admin account.
+	if !isLoopbackRequest(r) {
+		httptransport.SendErr(w, http.StatusForbidden, "admin setup must be performed from the server terminal")
 		return
 	}
 	var body struct {

--- a/backend/internal/transport/http/handlers/auth_local_handler_test.go
+++ b/backend/internal/transport/http/handlers/auth_local_handler_test.go
@@ -1,0 +1,150 @@
+package httphandlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	serviceauth "github.com/futrx-com/remote.futrx.com/internal/service/auth"
+	"github.com/futrx-com/remote.futrx.com/internal/stores/fileauth"
+	"github.com/futrx-com/remote.futrx.com/internal/stores/filesessions"
+	"github.com/futrx-com/remote.futrx.com/internal/stores/filetwofactor"
+)
+
+// newLocalAuthTestMux builds a minimal http.ServeMux with the auth handlers
+// wired up and an in-memory / temp-dir store. The returned mux is unclaimed
+// (no local admin credential exists yet).
+func newLocalAuthTestMux(t *testing.T) *http.ServeMux {
+	t.Helper()
+	twoFactorStore, err := filetwofactor.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("init two-factor store: %v", err)
+	}
+	sessionRegistryStore, err := filesessions.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("init session registry store: %v", err)
+	}
+	auth, err := serviceauth.New(
+		context.Background(),
+		fileauth.New(t.TempDir()),
+		twoFactorTestDirectory{}, // reuses the stub from auth_twofactor_handler_test.go
+		func(string, string, string) serviceauth.OAuthProvider { return twoFactorTestOAuth{} },
+		"https://remote.example.com",
+		[]byte("test-session-key"),
+		twoFactorStore,
+		sessionRegistryStore,
+		serviceauth.Options{
+			PendingLoginTTL:     5 * time.Minute,
+			EnrollmentTTL:       10 * time.Minute,
+			RecoveryCodeCount:   10,
+			SessionHistoryLimit: 20,
+		},
+	)
+	if err != nil {
+		t.Fatalf("New auth service: %v", err)
+	}
+	mux := http.NewServeMux()
+	NewAuthHandler(auth, nil).RegisterRoutes(mux)
+	return mux
+}
+
+// postClaim fires POST /auth/local/claim from the given remoteAddr (IP:port).
+func postClaim(t *testing.T, mux *http.ServeMux, remoteAddr, email, password string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"email": email, "password": password})
+	req := httptest.NewRequest(http.MethodPost, "/auth/local/claim", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = remoteAddr
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestClaimRejectsRemoteCallers is the regression guard required by issue #65:
+// the /auth/local/claim endpoint must not be accessible from non-loopback
+// addresses to prevent any network-adjacent user from racing the operator to
+// set the admin credential.
+func TestClaimRejectsRemoteCallers(t *testing.T) {
+	remoteAddrs := []string{
+		"192.168.1.42:54321",    // LAN
+		"10.0.0.1:12345",       // private range
+		"203.0.113.1:80",       // public internet
+		"2001:db8::1:80",       // IPv6 public
+	}
+	for _, addr := range remoteAddrs {
+		t.Run(addr, func(t *testing.T) {
+			mux := newLocalAuthTestMux(t)
+			rec := postClaim(t, mux, addr, "admin@example.com", "correct horse battery staple")
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("claim from remote addr %q: got %d, want %d (forbidden)", addr, rec.Code, http.StatusForbidden)
+			}
+		})
+	}
+}
+
+// TestClaimAllowsLocalhostCallers verifies that a request from the loopback
+// interface is still accepted (the setup can be performed from the terminal).
+func TestClaimAllowsLocalhostCallers(t *testing.T) {
+	loopbackAddrs := []struct {
+		name string
+		addr string
+	}{
+		{"IPv4 loopback", "127.0.0.1:54321"},
+		{"IPv6 loopback", "[::1]:54321"},
+		{"localhost range", "127.0.0.2:12345"},
+	}
+	for _, tc := range loopbackAddrs {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := newLocalAuthTestMux(t)
+			rec := postClaim(t, mux, tc.addr, "admin@example.com", "correct horse battery staple")
+			if rec.Code != http.StatusCreated {
+				t.Errorf("claim from loopback %q: got %d (body: %s), want %d (created)",
+					tc.addr, rec.Code, rec.Body.String(), http.StatusCreated)
+			}
+		})
+	}
+}
+
+// TestMeClaimAllowedOnlyForLoopback verifies that /auth/me sets claimAllowed
+// to true only when the server is unclaimed and the caller is on localhost.
+func TestMeClaimAllowedOnlyForLoopback(t *testing.T) {
+	cases := []struct {
+		name        string
+		remoteAddr  string
+		wantAllowed bool
+	}{
+		{"loopback IPv4", "127.0.0.1:54321", true},
+		{"loopback IPv6", "[::1]:54321", true},
+		{"remote LAN", "192.168.1.42:54321", false},
+		{"remote public", "203.0.113.5:80", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := newLocalAuthTestMux(t)
+			req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+			req.RemoteAddr = tc.remoteAddr
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET /auth/me status = %d", rec.Code)
+			}
+			var status struct {
+				Claimed      bool `json:"claimed"`
+				ClaimAllowed bool `json:"claimAllowed"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&status); err != nil {
+				t.Fatalf("decode /auth/me: %v", err)
+			}
+			if status.Claimed {
+				t.Fatal("expected unclaimed server for this test")
+			}
+			if status.ClaimAllowed != tc.wantAllowed {
+				t.Errorf("claimAllowed = %v, want %v (remoteAddr=%q)", status.ClaimAllowed, tc.wantAllowed, tc.remoteAddr)
+			}
+		})
+	}
+}

--- a/backend/internal/transport/http/handlers/auth_session_handler.go
+++ b/backend/internal/transport/http/handlers/auth_session_handler.go
@@ -32,5 +32,11 @@ func (h *authSessionHandler) logout(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *authSessionHandler) me(w http.ResponseWriter, r *http.Request) {
-	httptransport.SendJSON(w, http.StatusOK, h.auth.Status(r.Context(), httptransport.SessionCookieValue(r)))
+	status := h.auth.Status(r.Context(), httptransport.SessionCookieValue(r))
+	// ClaimAllowed gates the first-time setup form: only show it when the
+	// credential has not been claimed yet and the visitor is on localhost.
+	if !status.Claimed && isLoopbackRequest(r) {
+		status.ClaimAllowed = true
+	}
+	httptransport.SendJSON(w, http.StatusOK, status)
 }

--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -12,6 +12,7 @@ export async function fetchAuthSession(): Promise<AuthSession> {
     return {
       authenticated: !!data.authenticated,
       claimed: !!data.claimed,
+      claimAllowed: !!data.claimAllowed,
       localAdminConfigured: !!data.localAdminConfigured,
       googleOAuthEnabled: !!data.googleOAuthEnabled,
       googleClientId: data.googleClientId ?? "",

--- a/frontend/src/app/containers/AuthGate.tsx
+++ b/frontend/src/app/containers/AuthGate.tsx
@@ -2,6 +2,7 @@ import type { ComponentType } from "preact";
 import { useEffect, useState } from "preact/hooks";
 import { LoginScreen } from "../../ui/auth/LoginScreen";
 import { AdminSetupWaiting } from "../../ui/auth/AdminSetupWaiting";
+import { TerminalSetupRequired } from "../../ui/auth/TerminalSetupRequired";
 import { ProviderAuthWaiting } from "../../ui/auth/ProviderAuthWaiting";
 import { ProviderLoginScreen } from "../../ui/auth/ProviderLoginScreen";
 import { LoadingScreen } from "../../ui/primitives/LoadingScreen";
@@ -55,6 +56,12 @@ export function AuthGate() {
   // last visit stopped at a login screen gets the neutral boot screen instead.
   if (auth.loading) return bootsIntoWorkspace ? <WorkspaceSkeleton /> : <LoadingScreen />;
   if (!auth.claimed) {
+    // Only allow the first-time setup form when the backend confirms the
+    // request is coming from localhost. Remote visitors see a notice that
+    // directs them to the server terminal instead.
+    if (!auth.claimAllowed) {
+      return <TerminalSetupRequired />;
+    }
     return (
       <LoginScreen
         mode="claim"

--- a/frontend/src/config/auth.ts
+++ b/frontend/src/config/auth.ts
@@ -3,6 +3,7 @@ import type { AuthSession } from "../models/auth";
 export const UNAUTHENTICATED_SESSION: AuthSession = {
   authenticated: false,
   claimed: false,
+  claimAllowed: false,
   localAdminConfigured: false,
   googleOAuthEnabled: false,
   googleClientId: "",

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -1,6 +1,8 @@
 export interface AuthSession {
   authenticated: boolean;
   claimed: boolean;
+  /** True only when the admin credential is unclaimed and this browser is connecting from localhost. */
+  claimAllowed: boolean;
   localAdminConfigured: boolean;
   googleOAuthEnabled: boolean;
   googleClientId: string;

--- a/frontend/src/ui/auth/TerminalSetupRequired.tsx
+++ b/frontend/src/ui/auth/TerminalSetupRequired.tsx
@@ -1,0 +1,47 @@
+import { Lock, Terminal } from "../primitives/icons";
+
+/**
+ * Shown to remote visitors when the server admin credential has not been
+ * initialised yet. The first-time setup can only be performed from the
+ * server terminal, so we display a clear instruction rather than a form.
+ */
+export function TerminalSetupRequired() {
+  return (
+    <div class="app-shell grid place-items-center bg-app text-ink-100 p-5">
+      <div class="w-full max-w-md space-y-6 text-center">
+        <div class="mx-auto w-14 h-14 rounded-lg bg-accent-blue/[0.14] border border-accent-blue/25 grid place-items-center">
+          <Lock class="w-6 h-6 text-accent-blue" />
+        </div>
+
+        <div>
+          <div class="text-lg font-semibold">Server setup required</div>
+          <div class="text-xs text-ink-300 mt-1.5 leading-relaxed">
+            This server has not been configured yet. For security, the initial
+            administrator account must be created directly on the server.
+          </div>
+        </div>
+
+        <div class="rounded-lg border border-line bg-surface p-4 text-left space-y-3">
+          <div class="flex items-center gap-2 text-xs font-semibold text-ink-200 uppercase tracking-wide">
+            <Terminal class="w-3.5 h-3.5 text-ink-400" />
+            Run in the server terminal
+          </div>
+          <pre class="text-[12px] font-mono text-accent-blue bg-tint rounded-md px-3 py-2 overflow-x-auto whitespace-pre-wrap break-all leading-relaxed">
+            remote setup
+          </pre>
+          <p class="text-[11.5px] text-ink-400 leading-relaxed">
+            Follow the prompts to set the admin email and password. Once complete, refresh this page to sign in.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          class="btn btn-primary btn-sm text-[13px]"
+        >
+          Refresh after setup
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #65

The first-time user credential setup was previously exposed via the public web UI, allowing anyone who accessed the server first to claim administrative privileges before the server owner.

## Changes

1. **Backend Endpoint Security (`/auth/local/claim`)**:
   - Gated the `/auth/local/claim` handler behind loopback/localhost check (`127.0.0.1` / `::1`).
   - Remote requests are rejected with `403 Forbidden` (`admin setup must be performed from the server terminal`).
   - Extended `auth.Status` with `claimAllowed: bool` which is only set to `true` when the server is unclaimed AND the current request is from loopback.

2. **Frontend Protection**:
   - Added `claimAllowed` to `AuthSession` model and API parser.
   - Created [`TerminalSetupRequired.tsx`](file:///frontend/src/ui/auth/TerminalSetupRequired.tsx) to guide remote visitors to complete setup from the terminal (`remote setup`) instead of presenting the claim form.
   - Updated `AuthGate.tsx` to display `TerminalSetupRequired` for remote users if `!auth.claimed && !auth.claimAllowed`.

3. **Testing**:
   - Added `auth_local_handler_test.go` with unit tests verifying:
     - Remote IPs (LAN, public IPv4/IPv6) receive `403 Forbidden`.
     - Loopback callers (`127.0.0.1`, `::1`) are permitted.
     - `/auth/me` properly reflects `claimAllowed: true` only on loopback.
