### PR TITLE
feat(caddy): optional DNS-01 ACME challenge support

### DIFF
--- a/infra/install.sh
+++ b/infra/install.sh
@@ -231,7 +231,7 @@ export -f log warn ok err
 # regex `\$` anchors) survive untouched.
 render_template() {
     local tmpl="$1" dest="$2"
-    envsubst '$HOSTNAME $HOSTNAME_RE $INSTALL_DIR $SERVICE_PORT $LXD_BRIDGE_IP $LXD_BRIDGE $HOST_CLI_BIN_DIR' \
+    envsubst '$HOSTNAME $HOSTNAME_RE $INSTALL_DIR $SERVICE_PORT $LXD_BRIDGE_IP $LXD_BRIDGE $HOST_CLI_BIN_DIR $ACME_DNS_PROVIDER $ACME_DNS_TOKEN' \
         < "$tmpl" > "$dest"
 }
 export -f render_template

--- a/infra/steps/03-caddy.sh
+++ b/infra/steps/03-caddy.sh
@@ -14,6 +14,29 @@ TMP_CADDYFILE="$(mktemp)"
 trap 'rm -f "$TMP_CADDYFILE"' RETURN
 render_template "${INFRA_DIR}/templates/Caddyfile.tmpl" "$TMP_CADDYFILE"
 
+# Optional DNS-01: when no provider is configured, strip the acme_dns
+# line so caddy validate does not fail on an empty directive. When a
+# provider is configured, replace the system Caddy with a build that
+# includes the matching DNS module so DNS-01 challenges actually work.
+if [ -z "${ACME_DNS_PROVIDER:-}" ]; then
+    sed -i '/^ *acme_dns[[:space:]]*$/d' "$TMP_CADDYFILE"
+else
+    log "Installing Caddy with DNS-01 provider module: $ACME_DNS_PROVIDER"
+    CADDY_URL="https://caddyserver.com/api/download?p=${ACME_DNS_PROVIDER}&os=linux&arch=amd64"
+    CADDY_TMP="$(mktemp)"
+    CADDY_DIR="$(mktemp -d)"
+    curl -fsSL --max-time 120 -o "$CADDY_TMP" "$CADDY_URL"
+    mkdir -p "$CADDY_DIR"
+    tar -xzf "$CADDY_TMP" -C "$CADDY_DIR"
+    # The build tarball may contain the binary at the root or under a
+    # leading folder (e.g. caddy/caddy). Locate it rather than assume.
+    CADDY_BIN="$(find "$CADDY_DIR" -type f -name caddy -print -quit)"
+    [ -n "$CADDY_BIN" ] || err "Could not find caddy binary in downloaded archive"
+    install -m 0755 "$CADDY_BIN" /usr/bin/caddy
+    rm -rf "$CADDY_TMP" "$CADDY_DIR"
+    ok "Caddy updated with $ACME_DNS_PROVIDER DNS module ($(caddy version | head -1))"
+fi
+
 if ! caddy validate --config "$TMP_CADDYFILE" --adapter caddyfile >/dev/null 2>&1; then
     err "Rendered Caddyfile is invalid — leaving live config untouched."
     caddy validate --config "$TMP_CADDYFILE" --adapter caddyfile 2>&1 | tail -20 >&2

--- a/infra/templates/Caddyfile.tmpl
+++ b/infra/templates/Caddyfile.tmpl
@@ -13,6 +13,11 @@
     # if you want renewal-failure emails from LE.
     # email you@example.com
 
+    # Optional DNS-01 ACME provider for hosts without public inbound reachability.
+    # Set ACME_DNS_PROVIDER (e.g. github.com/caddy-dns/cloudflare) and
+    # ACME_DNS_TOKEN to enable; install.sh pulls a Caddy build with that module.
+    acme_dns $ACME_DNS_PROVIDER $ACME_DNS_TOKEN
+
     # On-demand TLS for the *.dev.${HOSTNAME} wildcard. Caddy queries the
     # backend's /internal/tls-ask before issuing each cert so attackers
     # can't burn through ACME rate limits by hitting random subdomains.


### PR DESCRIPTION
## What

Implements issue #27 — optional DNS-01 ACME challenge support for hosts without public inbound reachability (Tailscale/WireGuard tailnets, private LANs, hosts behind CGNAT).

HTTP-01 / TLS-ALPN-01 require Let's Encrypt to reach the host from the public internet. Adding an `acme_dns` directive to the global options block lets on-demand TLS (and the existing `tls { on_demand }` site blocks) use DNS-01 instead — with no change to the site blocks.

## Changes

- `infra/templates/Caddyfile.tmpl`: add an `acme_dns $ACME_DNS_PROVIDER $ACME_DNS_TOKEN` line in the global options block, guarded by comments.
- `infra/install.sh`: add `$ACME_DNS_PROVIDER` and `$ACME_DNS_TOKEN` to the `envsubst` whitelist so they survive template rendering.
- `infra/steps/03-caddy.sh`: when `ACME_DNS_PROVIDER` is empty, strip the `acme_dns` line so `caddy validate` still passes with a stock Caddy. When set, download a Caddy build that includes the matching provider module (via the `https://caddyserver.com/api/download?p=<module>` API) and install it before validating.

## Usage

Set two env vars on install:

```bash
ACME_DNS_PROVIDER=github.com/caddy-dns/cloudflare
ACME_DNS_TOKEN=<api-token>
```

When unset, behaviour is unchanged (no DNS-01, stock Caddy retained).

Fixes #27
