### PR TITLE
feat(updates): allow retrying failed updates

### DIFF
--- a/backend/internal/service/selfupdate/service.go
+++ b/backend/internal/service/selfupdate/service.go
@@ -19,6 +19,7 @@ var (
 	ErrUpdateInProgress = errors.New("an update is already running")
 	ErrNoReleaseTag     = errors.New("no release tags found on origin")
 	ErrUnknownTag       = errors.New("tag does not exist on origin")
+	ErrNoFailedUpdate   = errors.New("there is no failed update to retry")
 )
 
 type Service struct {
@@ -97,11 +98,57 @@ func (s *Service) Apply(ctx context.Context, startedBy, tag string) (Status, err
 	if run := s.runs.status(s.host.ProcessAlive); run != nil && run.State == "running" {
 		return s.statusLocked(), ErrUpdateInProgress
 	}
+	return s.startLocked(startedBy, tag, classifyUpdate(s.currentVersion, tag))
+}
+
+// Retry repeats the most recent failed run with the same target and update
+// kind. Preserving the kind matters when the application was upgraded before
+// a later infrastructure step failed: reclassifying against the now-current
+// version could incorrectly turn the retry into an application-only deploy.
+func (s *Service) Retry(ctx context.Context, startedBy string) (Status, error) {
+	s.mu.Lock()
+	previous := s.runs.status(s.host.ProcessAlive)
+	if previous == nil || previous.State != "failed" {
+		status := s.statusLocked()
+		s.mu.Unlock()
+		return status, ErrNoFailedUpdate
+	}
+	s.mu.Unlock()
+
+	tags, err := s.host.ListRemoteTags(ctx, s.installDir)
+	if err != nil {
+		return s.Status(ctx), fmt.Errorf("list origin tags: %w", err)
+	}
+	if !containsTag(tags, previous.Target) {
+		return s.Status(ctx), fmt.Errorf("%w: %s", ErrUnknownTag, previous.Target)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	run := s.runs.status(s.host.ProcessAlive)
+	if run != nil && run.State == "running" {
+		return s.statusLocked(), ErrUpdateInProgress
+	}
+	if run == nil || run.State != "failed" || run.Target != previous.Target || run.UpdateKind != previous.UpdateKind {
+		return s.statusLocked(), ErrNoFailedUpdate
+	}
+	kind := run.UpdateKind
+	if kind == "" {
+		// Older run records predate update-kind persistence. Infrastructure is
+		// the conservative retry path when the original choice is unavailable.
+		kind = UpdateKindInfrastructure
+	}
+	if kind != UpdateKindApplication && kind != UpdateKindInfrastructure {
+		return s.statusLocked(), ErrNoFailedUpdate
+	}
+	return s.startLocked(startedBy, run.Target, kind)
+}
+
+func (s *Service) startLocked(startedBy, tag string, kind UpdateKind) (Status, error) {
 	// A fresh run replaces the previous run's records.
 	if err := s.runs.reset(); err != nil {
 		return s.statusLocked(), err
 	}
-	kind := classifyUpdate(s.currentVersion, tag)
 	message := "Preparing the infrastructure update"
 	if kind == UpdateKindApplication {
 		message = "Preparing the application update"

--- a/backend/internal/service/selfupdate/service_test.go
+++ b/backend/internal/service/selfupdate/service_test.go
@@ -14,6 +14,7 @@ type fakeHost struct {
 	kinds    []string
 	pid      int
 	alive    bool
+	alivePID int
 	startErr error
 }
 
@@ -30,7 +31,12 @@ func (f *fakeHost) StartUpdater(launch UpdaterLaunch) (int, error) {
 	return f.pid, nil
 }
 
-func (f *fakeHost) ProcessAlive(int) bool { return f.alive }
+func (f *fakeHost) ProcessAlive(pid int) bool {
+	if f.alivePID != 0 {
+		return pid == f.alivePID
+	}
+	return f.alive
+}
 
 func TestParseReleaseTag(t *testing.T) {
 	cases := []struct {
@@ -254,5 +260,69 @@ func TestApplyValidatesTag(t *testing.T) {
 	host.tags = []string{"nightly"}
 	if _, err := svc.Apply(context.Background(), "a@b.c", ""); !errors.Is(err, ErrNoReleaseTag) {
 		t.Fatalf("Apply(no releases) err = %v, want ErrNoReleaseTag", err)
+	}
+}
+
+func TestRetryPreservesFailedInfrastructureUpdateKind(t *testing.T) {
+	host := &fakeHost{tags: []string{"0.12.0"}, pid: 4242}
+	svc := New("0.11.0", "/opt/x", t.TempDir(), host)
+	if _, err := svc.Apply(context.Background(), "first@example.com", "0.12.0"); err != nil {
+		t.Fatal(err)
+	}
+	host.alive = false
+
+	// The application may already report the target version after the updater
+	// restarted it, even though a later base-image step failed.
+	svc.currentVersion = "0.12.0"
+	host.pid = 5252
+	host.alivePID = 5252
+	status, err := svc.Retry(context.Background(), "retry@example.com")
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if len(host.started) != 2 || host.started[1] != "0.12.0" {
+		t.Fatalf("started = %v, want second launch for 0.12.0", host.started)
+	}
+	if len(host.kinds) != 2 || host.kinds[1] != string(UpdateKindInfrastructure) {
+		t.Fatalf("update kinds = %v, want retry to preserve infrastructure", host.kinds)
+	}
+	if status.Run == nil || status.Run.State != "running" || status.Run.StartedBy != "retry@example.com" {
+		t.Fatalf("run = %+v, want retried running status", status.Run)
+	}
+}
+
+func TestRetryRequiresFailedRun(t *testing.T) {
+	host := &fakeHost{tags: []string{"0.12.0"}, pid: 4242, alive: true}
+	svc := New("0.11.0", "/opt/x", t.TempDir(), host)
+	if _, err := svc.Retry(context.Background(), "admin@example.com"); !errors.Is(err, ErrNoFailedUpdate) {
+		t.Fatalf("Retry(no run) err = %v, want ErrNoFailedUpdate", err)
+	}
+	if _, err := svc.Apply(context.Background(), "admin@example.com", "0.12.0"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Retry(context.Background(), "admin@example.com"); !errors.Is(err, ErrNoFailedUpdate) {
+		t.Fatalf("Retry(running run) err = %v, want ErrNoFailedUpdate", err)
+	}
+}
+
+func TestRetryUsesConservativeKindForLegacyFailedRun(t *testing.T) {
+	host := &fakeHost{tags: []string{"0.12.0"}, pid: 5252, alivePID: 5252}
+	svc := New("0.12.0", "/opt/x", t.TempDir(), host)
+	if err := svc.runs.reset(); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.runs.writeRecord(runRecord{Target: "0.12.0", PID: 4242}); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := svc.Retry(context.Background(), "admin@example.com")
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if len(host.kinds) != 1 || host.kinds[0] != string(UpdateKindInfrastructure) {
+		t.Fatalf("update kinds = %v, want conservative infrastructure retry", host.kinds)
+	}
+	if status.Run == nil || status.Run.UpdateKind != UpdateKindInfrastructure {
+		t.Fatalf("run = %+v, want infrastructure retry", status.Run)
 	}
 }

--- a/backend/internal/transport/http/handlers/self_update_handler.go
+++ b/backend/internal/transport/http/handlers/self_update_handler.go
@@ -10,8 +10,8 @@ import (
 )
 
 // SelfUpdateHandler exposes the admin-only release update flow: read the
-// current status, check origin for newer release tags, and start the safe
-// application or infrastructure path toward one.
+// current status, check origin for newer release tags, start the safe
+// application or infrastructure path toward one, and retry failed runs.
 type SelfUpdateHandler struct {
 	updates *serviceselfupdate.Service
 	auth    *serviceauth.Service
@@ -25,6 +25,7 @@ func (h *SelfUpdateHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/admin/update/status", h.handleStatus)
 	mux.HandleFunc("/api/admin/update/check", h.handleCheck)
 	mux.HandleFunc("/api/admin/update/apply", h.handleApply)
+	mux.HandleFunc("/api/admin/update/retry", h.handleRetry)
 }
 
 func (h *SelfUpdateHandler) requireAdmin(w http.ResponseWriter, r *http.Request) (string, bool) {
@@ -85,8 +86,26 @@ func (h *SelfUpdateHandler) handleApply(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	status, err := h.updates.Apply(r.Context(), email, body.Tag)
+	h.sendApplyResult(w, status, err)
+}
+
+func (h *SelfUpdateHandler) handleRetry(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		httptransport.SendErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	email, ok := h.requireAdmin(w, r)
+	if !ok {
+		return
+	}
+	status, err := h.updates.Retry(r.Context(), email)
+	h.sendApplyResult(w, status, err)
+}
+
+func (h *SelfUpdateHandler) sendApplyResult(w http.ResponseWriter, status serviceselfupdate.Status, err error) {
 	switch {
-	case errors.Is(err, serviceselfupdate.ErrUpdateInProgress):
+	case errors.Is(err, serviceselfupdate.ErrUpdateInProgress),
+		errors.Is(err, serviceselfupdate.ErrNoFailedUpdate):
 		httptransport.SendErr(w, http.StatusConflict, err.Error())
 	case errors.Is(err, serviceselfupdate.ErrNoReleaseTag),
 		errors.Is(err, serviceselfupdate.ErrUnknownTag):

--- a/frontend/src/api/selfUpdateApi.ts
+++ b/frontend/src/api/selfUpdateApi.ts
@@ -11,4 +11,5 @@ export const selfUpdateApi = {
       API_ROUTES.selfUpdate.apply,
       tag ? { tag } : {}
     ),
+  retry: () => requestJson<SelfUpdateStatus>("POST", API_ROUTES.selfUpdate.retry),
 };

--- a/frontend/src/app/containers/SettingsContainer.tsx
+++ b/frontend/src/app/containers/SettingsContainer.tsx
@@ -64,6 +64,7 @@ export function SettingsContainer({
       selfUpdateLoading={selfUpdate.loading}
       selfUpdateChecking={selfUpdate.checking}
       selfUpdateApplying={selfUpdate.applying}
+      selfUpdateRetrying={selfUpdate.retrying}
       selfUpdateRestarting={selfUpdate.restarting}
       selfUpdateError={selfUpdate.error}
       userDirectory={userDirectory}
@@ -82,6 +83,7 @@ export function SettingsContainer({
       onRefreshServerInfo={serverInfo.refresh}
       onCheckForUpdates={selfUpdate.check}
       onApplyUpdate={selfUpdate.apply}
+      onRetryUpdate={selfUpdate.retry}
       onAppearanceThemeChange={(theme) => void userSettings.setTheme(theme)}
       security={security}
     />

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -116,6 +116,7 @@ export const API_ROUTES = {
     status: "/api/admin/update/status",
     check: "/api/admin/update/check",
     apply: "/api/admin/update/apply",
+    retry: "/api/admin/update/retry",
   },
   skills: (query: string) => `/api/skills?${query}`,
   agentCapabilities: (query: string) =>

--- a/frontend/src/state/hooks/server/useSelfUpdate.ts
+++ b/frontend/src/state/hooks/server/useSelfUpdate.ts
@@ -8,6 +8,7 @@ export function useSelfUpdate(enabled: boolean) {
   const [loading, setLoading] = useState(false);
   const [checking, setChecking] = useState(false);
   const [applying, setApplying] = useState(false);
+  const [retrying, setRetrying] = useState(false);
   const [restarting, setRestarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const requestInFlight = useRef(false);
@@ -42,6 +43,21 @@ export function useSelfUpdate(enabled: boolean) {
     } finally {
       requestInFlight.current = false;
       setApplying(false);
+    }
+  }, []);
+
+  const retry = useCallback(async () => {
+    if (requestInFlight.current) return;
+    requestInFlight.current = true;
+    setRetrying(true);
+    try {
+      setStatus(await selfUpdateApi.retry());
+      setError(null);
+    } catch (cause) {
+      setError((cause as Error).message);
+    } finally {
+      requestInFlight.current = false;
+      setRetrying(false);
     }
   }, []);
 
@@ -89,5 +105,5 @@ export function useSelfUpdate(enabled: boolean) {
     return () => window.clearInterval(interval);
   }, [enabled, running]);
 
-  return { status, loading, checking, applying, restarting, error, check, apply };
+  return { status, loading, checking, applying, retrying, restarting, error, check, apply, retry };
 }

--- a/frontend/src/ui/settings/SettingsPage.tsx
+++ b/frontend/src/ui/settings/SettingsPage.tsx
@@ -107,6 +107,7 @@ export function SettingsPage({
   selfUpdateLoading,
   selfUpdateChecking,
   selfUpdateApplying,
+  selfUpdateRetrying,
   selfUpdateRestarting,
   selfUpdateError,
   userDirectory,
@@ -126,6 +127,7 @@ export function SettingsPage({
   onRefreshServerInfo,
   onCheckForUpdates,
   onApplyUpdate,
+  onRetryUpdate,
   onAppearanceThemeChange,
 }: {
   activeTab: SettingsTab;
@@ -140,6 +142,7 @@ export function SettingsPage({
   selfUpdateLoading: boolean;
   selfUpdateChecking: boolean;
   selfUpdateApplying: boolean;
+  selfUpdateRetrying: boolean;
   selfUpdateRestarting: boolean;
   selfUpdateError: string | null;
   userDirectory: UserDirectory;
@@ -159,6 +162,7 @@ export function SettingsPage({
   onRefreshServerInfo: () => Promise<void>;
   onCheckForUpdates: () => Promise<void>;
   onApplyUpdate: (tag?: string) => Promise<void>;
+  onRetryUpdate: () => Promise<void>;
   onAppearanceThemeChange: (theme: AppearanceTheme) => void;
 }) {
   const activeTabDetails = tabs.find((tab) => tab.id === activeTab) ?? tabs[0];
@@ -282,10 +286,12 @@ export function SettingsPage({
                   loading={selfUpdateLoading}
                   checking={selfUpdateChecking}
                   applying={selfUpdateApplying}
+                  retrying={selfUpdateRetrying}
                   restarting={selfUpdateRestarting}
                   error={selfUpdateError}
                   onCheck={onCheckForUpdates}
                   onApply={onApplyUpdate}
+                  onRetry={onRetryUpdate}
                 />
               ) : (
                 <SettingsNotice>

--- a/frontend/src/ui/settings/UpdatesSettings.tsx
+++ b/frontend/src/ui/settings/UpdatesSettings.tsx
@@ -8,19 +8,23 @@ export function UpdatesSettings({
   loading,
   checking,
   applying,
+  retrying,
   restarting,
   error,
   onCheck,
   onApply,
+  onRetry,
 }: {
   status: SelfUpdateStatus | null;
   loading: boolean;
   checking: boolean;
   applying: boolean;
+  retrying: boolean;
   restarting: boolean;
   error: string | null;
   onCheck: () => Promise<void>;
   onApply: (tag?: string) => Promise<void>;
+  onRetry: () => Promise<void>;
 }) {
   if (loading && status == null) {
     return (
@@ -37,6 +41,7 @@ export function UpdatesSettings({
   const updateAvailable = !runActive && lastCheck?.updateAvailable === true && latestTag !== "";
   const updateKind = lastCheck?.updateKind ?? "infrastructure";
   const infrastructureUpdate = updateKind === "infrastructure";
+  const startingUpdate = applying || retrying;
 
   return (
     <div class="space-y-4">
@@ -106,7 +111,7 @@ export function UpdatesSettings({
           <button
             type="button"
             onClick={() => void onApply(latestTag)}
-            disabled={applying}
+            disabled={startingUpdate}
             class="btn btn-primary mt-3 disabled:opacity-50"
           >
             {applying
@@ -120,7 +125,15 @@ export function UpdatesSettings({
         </section>
       )}
 
-      {run && <UpdateRunCard run={run} restarting={restarting} />}
+      {run && (
+        <UpdateRunCard
+          run={run}
+          restarting={restarting}
+          retrying={retrying}
+          retryDisabled={startingUpdate}
+          onRetry={onRetry}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/ui/settings/updates/UpdateRunCard.tsx
+++ b/frontend/src/ui/settings/updates/UpdateRunCard.tsx
@@ -1,13 +1,19 @@
 import type { SelfUpdateProgress, SelfUpdateRun } from "../../../models/selfUpdate";
-import { AlertCircle, Loader } from "../../primitives/icons";
+import { AlertCircle, Loader, RotateCcw } from "../../primitives/icons";
 import { formatUpdateRelativeTime, formatUpdateTime } from "./updateTime";
 
 export function UpdateRunCard({
   run,
   restarting,
+  retrying,
+  retryDisabled,
+  onRetry,
 }: {
   run: SelfUpdateRun;
   restarting: boolean;
+  retrying: boolean;
+  retryDisabled: boolean;
+  onRetry: () => Promise<void>;
 }) {
   return (
     <section class="rounded-card border border-line bg-surface overflow-hidden">
@@ -54,6 +60,17 @@ export function UpdateRunCard({
             class="btn btn-primary btn-sm mt-2.5 font-medium"
           >
             Reload to use the new version
+          </button>
+        )}
+        {run.state === "failed" && (
+          <button
+            type="button"
+            onClick={() => void onRetry()}
+            disabled={retryDisabled}
+            class="btn btn-primary btn-sm mt-2.5 inline-flex items-center gap-1.5 font-medium disabled:opacity-50"
+          >
+            <RotateCcw class={`w-3.5 h-3.5 ${retrying ? "animate-spin" : ""}`} />
+            {retrying ? "Retrying update…" : "Retry update"}
           </button>
         )}
       </header>


### PR DESCRIPTION
## Summary

- expose a **Retry update** action on failed update runs
- add an admin-only retry endpoint and frontend request state
- preserve the failed run's target and update kind so partially completed infrastructure updates retry full convergence
- use the conservative infrastructure path for legacy run records without stored update-kind metadata

## Testing

- `npm test` — 244 tests passed
- `npm run build`
- `go test ./internal/service/selfupdate ./internal/transport/http/handlers ./internal/integration/updatecli`
- `go build -o /tmp/remote-retry-update ./cmd/remote`
- `git diff --check`

## QA baseline note

`go test ./...` is currently blocked by a pre-existing stray `B N` line in `backend/internal/service/auth/service_test.go:85` on `origin/qa`. This PR does not modify that file.