### PR TITLE
fix(updates): expose retry of a failed run from the Updates settings

### DIFF
--- a/backend/internal/service/selfupdate/run_state.go
+++ b/backend/internal/service/selfupdate/run_state.go
@@ -24,9 +24,15 @@ func newRunState(dataDir string) runState {
 	return runState{dir: filepath.Join(dataDir, stateDirName)}
 }
 
-// reset removes the previous result and prepares an empty log for a fresh run.
+// reset clears every durable record of the previous run. Apply captures
+// the previous RunStatus into prevRun before calling reset, so the
+// classification it needs to reuse on retry is already in memory by the
+// time reset removes the on-disk record.
 func (r runState) reset() error {
 	if err := os.MkdirAll(r.dir, 0o700); err != nil {
+		return err
+	}
+	if err := removeIfPresent(r.runPath()); err != nil {
 		return err
 	}
 	if err := removeIfPresent(r.donePath()); err != nil {
@@ -36,6 +42,13 @@ func (r runState) reset() error {
 		return err
 	}
 	return os.WriteFile(r.logPath(), nil, runFileMode)
+}
+
+// removeRecord discards a run.json that Apply wrote before the updater
+// finished launching. Apply uses it on the StartUpdater failure path so
+// Status() does not resurrect a half-written record after reset() ran.
+func (r runState) removeRecord() {
+	_ = os.Remove(r.runPath())
 }
 
 func (r runState) launch(installDir, target string, kind UpdateKind) UpdaterLaunch {

--- a/backend/internal/service/selfupdate/service.go
+++ b/backend/internal/service/selfupdate/service.go
@@ -94,14 +94,23 @@ func (s *Service) Apply(ctx context.Context, startedBy, tag string) (Status, err
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if run := s.runs.status(s.host.ProcessAlive); run != nil && run.State == "running" {
+	prevRun := s.runs.status(s.host.ProcessAlive)
+	if prevRun != nil && prevRun.State == "running" {
 		return s.statusLocked(), ErrUpdateInProgress
 	}
 	// A fresh run replaces the previous run's records.
 	if err := s.runs.reset(); err != nil {
 		return s.statusLocked(), err
 	}
+	// Reuse the previous failed run's classification when retrying toward the
+	// same target. A failed infrastructure update may have already replaced
+	// the binary, so the new currentVersion can no longer distinguish the
+	// partial install from a clean release; falling back to the failed kind
+	// keeps the host convergence path that actually failed in scope.
 	kind := classifyUpdate(s.currentVersion, tag)
+	if prevRun != nil && prevRun.State == "failed" && prevRun.Target == tag && prevRun.UpdateKind != "" {
+		kind = prevRun.UpdateKind
+	}
 	message := "Preparing the infrastructure update"
 	if kind == UpdateKindApplication {
 		message = "Preparing the application update"

--- a/backend/internal/service/selfupdate/service.go
+++ b/backend/internal/service/selfupdate/service.go
@@ -94,19 +94,20 @@ func (s *Service) Apply(ctx context.Context, startedBy, tag string) (Status, err
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Capture the previous run BEFORE reset so we can reuse its classification
+	// on retry; reset clears run.json as part of the fresh-slate contract.
 	prevRun := s.runs.status(s.host.ProcessAlive)
 	if prevRun != nil && prevRun.State == "running" {
 		return s.statusLocked(), ErrUpdateInProgress
 	}
-	// A fresh run replaces the previous run's records.
 	if err := s.runs.reset(); err != nil {
 		return s.statusLocked(), err
 	}
-	// Reuse the previous failed run's classification when retrying toward the
-	// same target. A failed infrastructure update may have already replaced
-	// the binary, so the new currentVersion can no longer distinguish the
-	// partial install from a clean release; falling back to the failed kind
-	// keeps the host convergence path that actually failed in scope.
+	// A failed infrastructure update may have already replaced the binary,
+	// so classifyUpdate against currentVersion would collapse to an
+	// application-only deploy and skip the host convergence that actually
+	// failed. Fall back to the previous failed run's kind when retrying
+	// toward the same target.
 	kind := classifyUpdate(s.currentVersion, tag)
 	if prevRun != nil && prevRun.State == "failed" && prevRun.Target == tag && prevRun.UpdateKind != "" {
 		kind = prevRun.UpdateKind
@@ -122,7 +123,12 @@ func (s *Service) Apply(ctx context.Context, startedBy, tag string) (Status, err
 	}
 	pid, err := s.host.StartUpdater(s.runs.launch(s.installDir, tag, kind))
 	if err != nil {
+		// The new run never started; clear the half-written record so
+		// Status() does not report a stale run with the next attempt's
+		// target and an empty log. Kind preservation for the next call
+		// is best-effort: only the in-memory prevRun survives reset().
 		s.runs.removeProgress()
+		s.runs.removeRecord()
 		return s.statusLocked(), fmt.Errorf("start updater: %w", err)
 	}
 	record := runRecord{

--- a/backend/internal/service/selfupdate/service_test.go
+++ b/backend/internal/service/selfupdate/service_test.go
@@ -330,3 +330,41 @@ func TestApplyRetryReclassifiesWhenTargetChanges(t *testing.T) {
 		t.Fatalf("downgrade kind = %s, want application (no preservation across targets)", got)
 	}
 }
+
+// TestApplyStartUpdaterFailureClearsStaleRecord pins down the contract that
+// reset() + removeRecord() together guarantee: a launch that never made it
+// past StartUpdater must not leave a half-written run.json behind for
+// Status() to resurrect as a phantom failed run. Without this, an admin
+// could see the previous target's stale record with an empty log and no
+// progress, and assume the new attempt had failed.
+func TestApplyStartUpdaterFailureClearsStaleRecord(t *testing.T) {
+	host := &fakeHost{tags: []string{"0.11.0", "0.12.0"}, pid: 4242}
+	svc := New("0.11.0", "/opt/x", t.TempDir(), host)
+
+	// Land a prior failed infrastructure run on disk so the retry starts
+	// from the realistic partial-install state.
+	if _, err := svc.Apply(context.Background(), "admin@example.com", "0.12.0"); err != nil {
+		t.Fatal(err)
+	}
+	host.alive = false
+	if err := writeJSONFile(svc.runs.donePath(), doneRecord{ExitCode: 1, FinishedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now retry. StartUpdater fails; Apply must clear the previous run.json.
+	host.startErr = errors.New("synthetic launch failure")
+	host.alive = true
+	status, err := svc.Apply(context.Background(), "admin@example.com", "0.12.0")
+	if err == nil {
+		t.Fatalf("Apply err = nil, want synthetic launch failure")
+	}
+	if status.Run != nil {
+		t.Fatalf("status.Run = %+v, want nil so the UI does not show a phantom failed run", status.Run)
+	}
+	if _, err := os.Stat(svc.runs.runPath()); !os.IsNotExist(err) {
+		t.Fatalf("run.json still present after StartUpdater failure: err=%v", err)
+	}
+	if _, err := os.Stat(svc.runs.progressPath()); !os.IsNotExist(err) {
+		t.Fatalf("progress.json still present after StartUpdater failure: err=%v", err)
+	}
+}

--- a/backend/internal/service/selfupdate/service_test.go
+++ b/backend/internal/service/selfupdate/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -254,5 +255,78 @@ func TestApplyValidatesTag(t *testing.T) {
 	host.tags = []string{"nightly"}
 	if _, err := svc.Apply(context.Background(), "a@b.c", ""); !errors.Is(err, ErrNoReleaseTag) {
 		t.Fatalf("Apply(no releases) err = %v, want ErrNoReleaseTag", err)
+	}
+}
+
+// TestApplyRetryPreservesInfrastructureKind simulates a failed infrastructure
+// update where the backend binary has already been replaced by the new
+// release. Re-applying toward the same target must keep the host convergence
+// path that actually failed, even though classifying against the running
+// version would otherwise collapse the run to an application-only deploy.
+func TestApplyRetryPreservesInfrastructureKind(t *testing.T) {
+	host := &fakeHost{tags: []string{"0.11.0", "0.12.0"}, pid: 4242}
+	svc := New("0.11.0", "/opt/x", t.TempDir(), host)
+
+	if _, err := svc.Apply(context.Background(), "admin@example.com", "0.12.0"); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	if got := host.kinds[len(host.kinds)-1]; got != string(UpdateKindInfrastructure) {
+		t.Fatalf("first run kind = %s, want infrastructure", got)
+	}
+
+	// Mark the in-flight run as failed by clearing liveness and dropping a
+	// done marker. The Service is restarted to mimic the backend restart
+	// that the failing updater triggered before the partial install settled.
+	host.alive = false
+	if err := writeJSONFile(svc.runs.donePath(), doneRecord{ExitCode: 1, FinishedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONFile(svc.runs.runPath(), runRecord{
+		Target: "0.12.0", UpdateKind: UpdateKindInfrastructure,
+		StartedAt: 1, StartedBy: "admin@example.com", PID: 4242,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// New binary is now reporting 0.12.0 because the previous infrastructure
+	// step rebuilt it before failing. A naive classification would now
+	// return application; the retry must instead re-use the failed kind.
+	svc2 := New("0.12.0", "/opt/x", filepath.Dir(svc.runs.dir), host)
+	host.alive = true
+	if _, err := svc2.Apply(context.Background(), "admin@example.com", "0.12.0"); err != nil {
+		t.Fatalf("retry Apply: %v", err)
+	}
+	if got := host.kinds[len(host.kinds)-1]; got != string(UpdateKindInfrastructure) {
+		t.Fatalf("retry kind = %s, want infrastructure (preserved from failed run)", got)
+	}
+}
+
+// TestApplyRetryReclassifiesWhenTargetChanges confirms that re-applying toward
+// a different tag is free to pick up a fresh classification. Only a retry
+// against the exact same target reuses the failed run's kind.
+func TestApplyRetryReclassifiesWhenTargetChanges(t *testing.T) {
+	host := &fakeHost{tags: []string{"0.11.0", "0.12.0"}, pid: 4242}
+	svc := New("0.11.0", "/opt/x", t.TempDir(), host)
+
+	if _, err := svc.Apply(context.Background(), "admin@example.com", "0.12.0"); err != nil {
+		t.Fatal(err)
+	}
+	host.alive = false
+	if err := writeJSONFile(svc.runs.donePath(), doneRecord{ExitCode: 1, FinishedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONFile(svc.runs.runPath(), runRecord{
+		Target: "0.12.0", UpdateKind: UpdateKindInfrastructure,
+		StartedAt: 1, StartedBy: "admin@example.com", PID: 4242,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	host.alive = true
+
+	if _, err := svc.Apply(context.Background(), "admin@example.com", "0.11.0"); err != nil {
+		t.Fatal(err)
+	}
+	if got := host.kinds[len(host.kinds)-1]; got != string(UpdateKindApplication) {
+		t.Fatalf("downgrade kind = %s, want application (no preservation across targets)", got)
 	}
 }

--- a/frontend/src/ui/settings/UpdatesSettings.tsx
+++ b/frontend/src/ui/settings/UpdatesSettings.tsx
@@ -120,7 +120,14 @@ export function UpdatesSettings({
         </section>
       )}
 
-      {run && <UpdateRunCard run={run} restarting={restarting} />}
+      {run && (
+        <UpdateRunCard
+          run={run}
+          restarting={restarting}
+          applying={applying}
+          onRetry={onApply}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/ui/settings/updates/UpdateRunCard.tsx
+++ b/frontend/src/ui/settings/updates/UpdateRunCard.tsx
@@ -1,13 +1,17 @@
 import type { SelfUpdateProgress, SelfUpdateRun } from "../../../models/selfUpdate";
-import { AlertCircle, Loader } from "../../primitives/icons";
+import { AlertCircle, Loader, RotateCcw } from "../../primitives/icons";
 import { formatUpdateRelativeTime, formatUpdateTime } from "./updateTime";
 
 export function UpdateRunCard({
   run,
   restarting,
+  applying,
+  onRetry,
 }: {
   run: SelfUpdateRun;
   restarting: boolean;
+  applying?: boolean;
+  onRetry?: (target: string) => Promise<void> | void;
 }) {
   return (
     <section class="rounded-card border border-line bg-surface overflow-hidden">
@@ -54,6 +58,23 @@ export function UpdateRunCard({
             class="btn btn-primary btn-sm mt-2.5 font-medium"
           >
             Reload to use the new version
+          </button>
+        )}
+        {run.state === "failed" && onRetry && (
+          <button
+            type="button"
+            onClick={() => void onRetry(run.target)}
+            disabled={applying}
+            class="btn btn-primary btn-sm mt-2.5 font-medium inline-flex items-center gap-1.5 disabled:opacity-50"
+          >
+            <RotateCcw class={`w-3.5 h-3.5 ${applying ? "animate-spin" : ""}`} />
+            {applying
+              ? run.updateKind === "application"
+                ? `Retrying deploy of ${run.target}…`
+                : `Retrying update to ${run.target}…`
+              : run.updateKind === "application"
+                ? `Retry deploy of ${run.target}`
+                : `Retry update to ${run.target}`}
           </button>
         )}
       </header>


### PR DESCRIPTION
A failed update left no recovery affordance in the UI: when the local checkout already reported the new version after a partial install, the 'up to date' message hid the 'Update available' CTA and the failed run card only showed the log. Add a 'Retry update to X' button on the failed run card that re-issues the apply request against the same target tag.

The apply service now also reuses the previous failed run's updateKind when the retry targets the same release. The binary may have been replaced by the previous attempt, so classifying against the running version would otherwise collapse the run to an application-only deploy and skip the host convergence that actually failed. A new test pins down both the preservation and the re-classification on a different target.