### PR TITLE
Chat History Improvements: materialize bounded transcript pages

### DIFF
--- a/backend/internal/config/constants/chat.go
+++ b/backend/internal/config/constants/chat.go
@@ -12,6 +12,15 @@ const (
 	// MaxChatTranscriptByteLimit prevents callers from turning one history read
 	// back into an unbounded allocation.
 	MaxChatTranscriptByteLimit = 8 * 1024 * 1024
+	// ChatTranscriptInlineFieldBytes bounds oversized fields in stored previews.
+	ChatTranscriptInlineFieldBytes = 32 * 1024
+	// DefaultChatTranscriptContentPageBytes sizes lazy full-content reads.
+	DefaultChatTranscriptContentPageBytes = 256 * 1024
+	// MaxChatTranscriptContentPageBytes caps a single full-content chunk.
+	MaxChatTranscriptContentPageBytes = 1024 * 1024
+	// ChatIndexCheckpointBytes bounds index backfill batches before advancing
+	// to the next complete event record.
+	ChatIndexCheckpointBytes int64 = 32 * 1024 * 1024
 	// StartupChatIndexWarmupChatLimit bounds the recent chats indexed during
 	// startup. It counts chats, not transcript turns.
 	StartupChatIndexWarmupChatLimit = 10

--- a/backend/internal/config/constants/chat.go
+++ b/backend/internal/config/constants/chat.go
@@ -6,6 +6,12 @@ const (
 	DefaultChatTranscriptTurnLimit = 20
 	// MaxChatTranscriptTurnLimit caps transcript page sizes.
 	MaxChatTranscriptTurnLimit = 100
+	// DefaultChatTranscriptByteLimit bounds a history response independently
+	// of turn size. Large turns are continued with the existing sequence cursor.
+	DefaultChatTranscriptByteLimit = 4 * 1024 * 1024
+	// MaxChatTranscriptByteLimit prevents callers from turning one history read
+	// back into an unbounded allocation.
+	MaxChatTranscriptByteLimit = 8 * 1024 * 1024
 	// StartupChatIndexWarmupChatLimit bounds the recent chats indexed during
 	// startup. It counts chats, not transcript turns.
 	StartupChatIndexWarmupChatLimit = 10

--- a/backend/internal/service/chat/errors.go
+++ b/backend/internal/service/chat/errors.go
@@ -3,10 +3,12 @@ package chat
 import "errors"
 
 var (
-	ErrInvalidID              = errors.New("invalid chat id")
-	ErrInvalidProvider        = errors.New("invalid chat provider")
-	ErrInvalidTmuxSession     = errors.New("invalid tmux session")
-	ErrInvalidRewindTimestamp = errors.New("invalid rewind timestamp")
-	ErrChatRunning            = errors.New("chat has an active run")
-	ErrNotFound               = errors.New("chat not found")
+	ErrInvalidID                       = errors.New("invalid chat id")
+	ErrInvalidProvider                 = errors.New("invalid chat provider")
+	ErrInvalidTmuxSession              = errors.New("invalid tmux session")
+	ErrInvalidRewindTimestamp          = errors.New("invalid rewind timestamp")
+	ErrChatRunning                     = errors.New("chat has an active run")
+	ErrNotFound                        = errors.New("chat not found")
+	ErrTranscriptContentNotFound       = errors.New("transcript content not found")
+	ErrTranscriptProjectionUnavailable = errors.New("transcript projection unavailable")
 )

--- a/backend/internal/service/chat/model.go
+++ b/backend/internal/service/chat/model.go
@@ -65,6 +65,9 @@ type Event struct {
 	Name                 string          `json:"name,omitempty"`
 	Input                json.RawMessage `json:"input,omitempty"`
 	Output               string          `json:"output,omitempty"`
+	OutputRef            string          `json:"outputRef,omitempty"`
+	OutputBytes          int64           `json:"outputBytes,omitempty"`
+	OutputTruncated      bool            `json:"outputTruncated,omitempty"`
 	IsError              bool            `json:"isError,omitempty"`
 	ToolName             string          `json:"toolName,omitempty"`
 	Subtype              string          `json:"subtype,omitempty"`

--- a/backend/internal/service/chat/ports.go
+++ b/backend/internal/service/chat/ports.go
@@ -34,6 +34,19 @@ type TranscriptEventWindowSource interface {
 	) (TranscriptEventWindow, error)
 }
 
+// TranscriptProjectionSource serves the durable, compact read model directly.
+// The canonical JSONL stream remains the source of truth and fallback.
+type TranscriptProjectionSource interface {
+	ReadTranscriptPage(ctx context.Context, id ID, query TranscriptPageQuery) (TranscriptPage, error)
+	ReadTranscriptContent(
+		ctx context.Context,
+		id ID,
+		contentID string,
+		afterBytes int64,
+		limitBytes int,
+	) (TranscriptContentPage, error)
+}
+
 // CopiedEventAppender persists historical events without treating them as new
 // user-visible activity. Fork uses this port while ordinary producers append
 // through Repository.

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -11,15 +11,16 @@ import (
 )
 
 type Service struct {
-	repo             Repository
-	transcriptEvents TranscriptEventSource
-	transcriptWindow TranscriptEventWindowSource
-	copiedEvents     CopiedEventAppender
-	projects         ProjectResolver
-	tmux             TmuxResolver
-	runs             RunController
-	sessions         SessionPolicy
-	providers        ProviderPolicy
+	repo                 Repository
+	transcriptEvents     TranscriptEventSource
+	transcriptWindow     TranscriptEventWindowSource
+	transcriptProjection TranscriptProjectionSource
+	copiedEvents         CopiedEventAppender
+	projects             ProjectResolver
+	tmux                 TmuxResolver
+	runs                 RunController
+	sessions             SessionPolicy
+	providers            ProviderPolicy
 }
 
 // SessionPolicy supplies provider-native behavior from the agent module

--- a/backend/internal/service/chat/transcript.go
+++ b/backend/internal/service/chat/transcript.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"errors"
 	"strconv"
 
 	configconstants "github.com/futrx-com/remote.futrx.com/internal/config/constants"
@@ -37,6 +38,7 @@ func WithTranscriptEventWindowSource(source TranscriptEventWindowSource) Option 
 type TranscriptPageQuery struct {
 	Limit     int
 	BeforeSeq int64
+	ByteLimit int
 }
 
 // TranscriptTurn is a read projection of one prompt run. Events retain the
@@ -51,10 +53,38 @@ type TranscriptTurn struct {
 
 // TranscriptPage is the bounded turn projection returned to history clients.
 type TranscriptPage struct {
-	Turns      []TranscriptTurn `json:"turns"`
-	NextBefore int64            `json:"nextBefore,omitempty"`
-	LastSeq    int64            `json:"lastSeq"`
-	HasMore    bool             `json:"hasMore"`
+	Turns      []TranscriptTurn         `json:"turns"`
+	NextBefore int64                    `json:"nextBefore,omitempty"`
+	LastSeq    int64                    `json:"lastSeq"`
+	HasMore    bool                     `json:"hasMore"`
+	Indexing   *TranscriptIndexProgress `json:"indexing,omitempty"`
+}
+
+// TranscriptIndexProgress lets clients keep the live stream connected while
+// a legacy JSONL file is projected in resumable background batches.
+type TranscriptIndexProgress struct {
+	IndexedBytes int64 `json:"indexedBytes"`
+	TotalBytes   int64 `json:"totalBytes"`
+	TailSeqKnown bool  `json:"tailSeqKnown"`
+}
+
+// TranscriptContentPage is one valid UTF-8 chunk of an oversized transcript
+// field. ContentID is opaque and scoped to the chat by the service boundary.
+type TranscriptContentPage struct {
+	ContentID  string `json:"contentId"`
+	Content    string `json:"content"`
+	NextAfter  int64  `json:"nextAfter,omitempty"`
+	TotalBytes int64  `json:"totalBytes"`
+	Complete   bool   `json:"complete"`
+}
+
+// WithTranscriptProjectionSource selects the compact durable read model when
+// storage provides it, while retaining the scanner/window fallback for tests
+// and recovery.
+func WithTranscriptProjectionSource(source TranscriptProjectionSource) Option {
+	return func(service *Service) {
+		service.transcriptProjection = source
+	}
 }
 
 // TranscriptPage projects the raw append-only stream into complete prompt
@@ -67,6 +97,12 @@ func (s *Service) TranscriptPage(
 ) (TranscriptPage, error) {
 	if !ValidID(id) {
 		return TranscriptPage{}, ErrInvalidID
+	}
+	if s.transcriptProjection != nil {
+		page, err := s.transcriptProjection.ReadTranscriptPage(ctx, id, query)
+		if err == nil || !errors.Is(err, ErrTranscriptProjectionUnavailable) {
+			return page, err
+		}
 	}
 
 	projection := newTranscriptProjection(query)
@@ -91,6 +127,26 @@ func (s *Service) TranscriptPage(
 		return TranscriptPage{}, err
 	}
 	return projection.page(), nil
+}
+
+// TranscriptContent retrieves an oversized projected field without exposing a
+// filesystem path or requiring the client to download its containing event.
+func (s *Service) TranscriptContent(
+	ctx context.Context,
+	id ID,
+	contentID string,
+	afterBytes int64,
+	limitBytes int,
+) (TranscriptContentPage, error) {
+	if !ValidID(id) {
+		return TranscriptContentPage{}, ErrInvalidID
+	}
+	if s.transcriptProjection == nil {
+		return TranscriptContentPage{}, ErrTranscriptProjectionUnavailable
+	}
+	return s.transcriptProjection.ReadTranscriptContent(
+		ctx, id, contentID, afterBytes, limitBytes,
+	)
 }
 
 type transcriptProjection struct {

--- a/backend/internal/service/services.go
+++ b/backend/internal/service/services.go
@@ -44,6 +44,7 @@ type ChatStore interface {
 	servicechat.Repository
 	servicechat.TranscriptEventSource
 	servicechat.TranscriptEventWindowSource
+	servicechat.TranscriptProjectionSource
 }
 
 // PushStore persists Web Push registrations and the server's long-lived VAPID
@@ -194,6 +195,7 @@ func New(ctx context.Context, deps Dependencies) (Services, error) {
 		runs,
 		servicechat.WithTranscriptEventSource(deps.Chats),
 		servicechat.WithTranscriptEventWindowSource(deps.Chats),
+		servicechat.WithTranscriptProjectionSource(deps.Chats),
 		servicechat.WithCopiedEventAppender(chats),
 		servicechat.WithSessionPolicy(agentRuntime),
 		servicechat.WithProviderPolicy(agentRuntime),

--- a/backend/internal/stores/filechat/event_index_schema.go
+++ b/backend/internal/stores/filechat/event_index_schema.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	chatEventIndexSchemaVersion = 1
+	chatEventIndexSchemaVersion = 2
 
 	chatEventIndexStateTable      = "chat_event_index_state"
 	chatEventOffsetsTable         = "chat_event_offsets"
@@ -14,6 +14,9 @@ const (
 	chatEventOffsetsByOffsetIndex = "chat_event_offsets_by_offset"
 	chatTranscriptTurnsTable      = "chat_transcript_turns"
 	chatTranscriptTurnsBySeqIndex = "chat_transcript_turns_by_start_seq"
+	chatTranscriptItemsTable      = "chat_transcript_items"
+	chatTranscriptItemsBySeqIndex = "chat_transcript_items_by_start_seq"
+	chatTranscriptContentTable    = "chat_transcript_content_refs"
 )
 
 type chatEventIndexSchemaObject struct {
@@ -81,9 +84,47 @@ var chatEventIndexSchema = [...]chatEventIndexSchemaObject{
 		statement: `CREATE INDEX ` + chatTranscriptTurnsBySeqIndex + `
 			ON ` + chatTranscriptTurnsTable + ` (chat_id, start_seq)`,
 	},
+	{
+		kind: "table",
+		name: chatTranscriptItemsTable,
+		statement: `CREATE TABLE ` + chatTranscriptItemsTable + ` (
+			chat_id TEXT NOT NULL,
+			turn_ordinal INTEGER NOT NULL,
+			item_key TEXT NOT NULL,
+			start_seq INTEGER NOT NULL,
+			end_seq INTEGER NOT NULL,
+			payload_json BLOB NOT NULL,
+			payload_bytes INTEGER NOT NULL,
+			PRIMARY KEY (chat_id, turn_ordinal, item_key)
+		) WITHOUT ROWID`,
+	},
+	{
+		kind: "index",
+		name: chatTranscriptItemsBySeqIndex,
+		statement: `CREATE INDEX ` + chatTranscriptItemsBySeqIndex + `
+			ON ` + chatTranscriptItemsTable + ` (chat_id, start_seq)`,
+	},
+	{
+		kind: "table",
+		name: chatTranscriptContentTable,
+		statement: `CREATE TABLE ` + chatTranscriptContentTable + ` (
+			chat_id TEXT NOT NULL,
+			content_id TEXT NOT NULL,
+			turn_ordinal INTEGER NOT NULL,
+			item_key TEXT NOT NULL,
+			field_kind TEXT NOT NULL,
+			field_key TEXT NOT NULL,
+			source_offset INTEGER NOT NULL,
+			source_length INTEGER NOT NULL,
+			content_bytes INTEGER NOT NULL,
+			PRIMARY KEY (chat_id, content_id)
+		) WITHOUT ROWID`,
+	},
 }
 
 var chatEventIndexTableDropOrder = [...]string{
+	chatTranscriptContentTable,
+	chatTranscriptItemsTable,
 	chatEventOffsetsTable,
 	chatTranscriptTurnsTable,
 	chatEventIndexStateTable,

--- a/backend/internal/stores/filechat/event_index_state.go
+++ b/backend/internal/stores/filechat/event_index_state.go
@@ -96,6 +96,8 @@ func writeChatIndexState(
 
 func deleteChatIndexRows(ctx context.Context, tx *sql.Tx, id servicechat.ID) error {
 	for _, table := range []string{
+		"chat_transcript_content_refs",
+		"chat_transcript_items",
 		"chat_event_offsets",
 		"chat_transcript_turns",
 		"chat_event_index_state",

--- a/backend/internal/stores/filechat/event_index_sync.go
+++ b/backend/internal/stores/filechat/event_index_sync.go
@@ -7,10 +7,9 @@ import (
 	"io"
 	"os"
 
+	configconstants "github.com/futrx-com/remote.futrx.com/internal/config/constants"
 	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
 )
-
-const chatIndexCheckpointBytes int64 = 32 * 1024 * 1024
 
 func (index *chatEventIndex) lastEventSeq(
 	ctx context.Context,
@@ -152,7 +151,7 @@ func (index *chatEventIndex) syncChatWithGrowth(
 }
 
 func chatIndexCheckpoint(eventsPath string, indexedBytes, fileSize int64) (int64, error) {
-	target := indexedBytes + chatIndexCheckpointBytes
+	target := indexedBytes + configconstants.ChatIndexCheckpointBytes
 	if target >= fileSize {
 		return fileSize, nil
 	}

--- a/backend/internal/stores/filechat/event_index_sync.go
+++ b/backend/internal/stores/filechat/event_index_sync.go
@@ -1,12 +1,16 @@
 package filechat
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"io"
 	"os"
 
 	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
 )
+
+const chatIndexCheckpointBytes int64 = 32 * 1024 * 1024
 
 func (index *chatEventIndex) lastEventSeq(
 	ctx context.Context,
@@ -37,7 +41,8 @@ func (index *chatEventIndex) refreshAfterFallback(
 
 // syncChat validates the durable snapshot against the authoritative JSONL
 // file. Appends extend the committed rows; rewrites and truncations rebuild
-// them. No new state becomes visible until the whole observed range commits.
+// them. Large legacy files publish resumable checkpoints; transcript readers
+// only serve the projection after the observed file is fully indexed.
 func (index *chatEventIndex) syncChat(
 	ctx context.Context,
 	id servicechat.ID,
@@ -88,41 +93,82 @@ func (index *chatEventIndex) syncChatWithGrowth(
 		return state, nil
 	}
 
-	tx, err := index.db.BeginTx(ctx, nil)
-	if err != nil {
-		return chatIndexState{}, err
-	}
-	defer func() { _ = tx.Rollback() }()
 	if rebuild {
-		if err := deleteChatIndexRows(ctx, tx, id); err != nil {
-			return chatIndexState{}, err
-		}
-		state = newChatIndexState()
-	}
-
-	turn, err := readLastIndexedTurn(ctx, tx, id)
-	if err != nil {
-		return chatIndexState{}, err
-	}
-	if fileSize > state.indexedBytes {
-		writer := newChatIndexWriter(ctx, tx, id, state, turn)
-		state, err = writer.indexTail(eventsPath, fileSize)
+		tx, err := index.db.BeginTx(ctx, nil)
 		if err != nil {
 			return chatIndexState{}, err
 		}
+		if err := deleteChatIndexRows(ctx, tx, id); err != nil {
+			_ = tx.Rollback()
+			return chatIndexState{}, err
+		}
+		state = newChatIndexState()
+		state.fileMtimeNS = fileMtimeNS
+		if err := writeChatIndexState(ctx, tx, id, state); err != nil {
+			_ = tx.Rollback()
+			return chatIndexState{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return chatIndexState{}, err
+		}
 	}
-	state.indexedBytes = fileSize
-	state.fileMtimeNS = fileMtimeNS
-	if err := writeChatIndexState(ctx, tx, id, state); err != nil {
-		return chatIndexState{}, err
-	}
-	if err := tx.Commit(); err != nil {
-		return chatIndexState{}, err
+
+	for state.indexedBytes < fileSize {
+		if err := ctx.Err(); err != nil {
+			return state, err
+		}
+		checkpoint, err := chatIndexCheckpoint(eventsPath, state.indexedBytes, fileSize)
+		if err != nil {
+			return state, err
+		}
+		tx, err := index.db.BeginTx(ctx, nil)
+		if err != nil {
+			return state, err
+		}
+		turn, err := readLastIndexedTurn(ctx, tx, id)
+		if err != nil {
+			_ = tx.Rollback()
+			return state, err
+		}
+		writer := newChatIndexWriter(ctx, tx, id, state, turn)
+		state, err = writer.indexTail(eventsPath, checkpoint)
+		if err != nil {
+			_ = tx.Rollback()
+			return state, err
+		}
+		state.fileMtimeNS = fileMtimeNS
+		if err := writeChatIndexState(ctx, tx, id, state); err != nil {
+			_ = tx.Rollback()
+			return state, err
+		}
+		if err := tx.Commit(); err != nil {
+			return state, err
+		}
 	}
 	if err := index.restrictFiles(); err != nil {
-		return chatIndexState{}, err
+		return state, err
 	}
 	return state, nil
+}
+
+func chatIndexCheckpoint(eventsPath string, indexedBytes, fileSize int64) (int64, error) {
+	target := indexedBytes + chatIndexCheckpointBytes
+	if target >= fileSize {
+		return fileSize, nil
+	}
+	file, err := os.Open(eventsPath)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+	if _, err := file.Seek(target, io.SeekStart); err != nil {
+		return 0, err
+	}
+	raw, err := bufio.NewReader(file).ReadBytes('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return 0, err
+	}
+	return target + int64(len(raw)), nil
 }
 
 func (index *chatEventIndex) rebuildChat(

--- a/backend/internal/stores/filechat/event_index_writer.go
+++ b/backend/internal/stores/filechat/event_index_writer.go
@@ -14,15 +14,15 @@ import (
 )
 
 type chatIndexWriter struct {
-	ctx                    context.Context
-	tx                     *sql.Tx
-	chatID                 servicechat.ID
-	state                  chatIndexState
-	turn                   indexedTurnState
-	eventOffsets           *sql.Stmt
-	insertTurn             *sql.Stmt
-	updateTurn             *sql.Stmt
-	pendingTranscriptItems map[string]pendingTranscriptItem
+	ctx          context.Context
+	tx           *sql.Tx
+	chatID       servicechat.ID
+	state        chatIndexState
+	turn         indexedTurnState
+	eventOffsets *sql.Stmt
+	insertTurn   *sql.Stmt
+	updateTurn   *sql.Stmt
+	transcript   *transcriptProjectionWriter
 }
 
 func newChatIndexWriter(
@@ -33,12 +33,12 @@ func newChatIndexWriter(
 	turn indexedTurnState,
 ) *chatIndexWriter {
 	return &chatIndexWriter{
-		ctx:                    ctx,
-		tx:                     tx,
-		chatID:                 chatID,
-		state:                  state,
-		turn:                   turn,
-		pendingTranscriptItems: make(map[string]pendingTranscriptItem),
+		ctx:        ctx,
+		tx:         tx,
+		chatID:     chatID,
+		state:      state,
+		turn:       turn,
+		transcript: newTranscriptProjectionWriter(ctx, tx, chatID),
 	}
 }
 
@@ -133,7 +133,7 @@ func (writer *chatIndexWriter) indexTail(
 	if offset != observedSize {
 		return chatIndexState{}, io.ErrUnexpectedEOF
 	}
-	if err := writer.flushPendingTranscriptItems(); err != nil {
+	if err := writer.transcript.flush(); err != nil {
 		return chatIndexState{}, err
 	}
 	writer.state.indexedBytes = offset
@@ -171,7 +171,9 @@ func (writer *chatIndexWriter) indexRecord(raw []byte, startOffset, endOffset in
 	if err := writer.indexTranscriptTurn(event, startOffset, endOffset); err != nil {
 		return err
 	}
-	return writer.indexTranscriptItem(event, startOffset, endOffset)
+	return writer.transcript.indexItem(
+		event, writer.state.eventOrdinal, writer.turn.ordinal, startOffset, endOffset,
+	)
 }
 
 func (writer *chatIndexWriter) indexTranscriptTurn(

--- a/backend/internal/stores/filechat/event_index_writer.go
+++ b/backend/internal/stores/filechat/event_index_writer.go
@@ -14,14 +14,15 @@ import (
 )
 
 type chatIndexWriter struct {
-	ctx          context.Context
-	tx           *sql.Tx
-	chatID       servicechat.ID
-	state        chatIndexState
-	turn         indexedTurnState
-	eventOffsets *sql.Stmt
-	insertTurn   *sql.Stmt
-	updateTurn   *sql.Stmt
+	ctx                    context.Context
+	tx                     *sql.Tx
+	chatID                 servicechat.ID
+	state                  chatIndexState
+	turn                   indexedTurnState
+	eventOffsets           *sql.Stmt
+	insertTurn             *sql.Stmt
+	updateTurn             *sql.Stmt
+	pendingTranscriptItems map[string]pendingTranscriptItem
 }
 
 func newChatIndexWriter(
@@ -32,11 +33,12 @@ func newChatIndexWriter(
 	turn indexedTurnState,
 ) *chatIndexWriter {
 	return &chatIndexWriter{
-		ctx:    ctx,
-		tx:     tx,
-		chatID: chatID,
-		state:  state,
-		turn:   turn,
+		ctx:                    ctx,
+		tx:                     tx,
+		chatID:                 chatID,
+		state:                  state,
+		turn:                   turn,
+		pendingTranscriptItems: make(map[string]pendingTranscriptItem),
 	}
 }
 
@@ -131,6 +133,9 @@ func (writer *chatIndexWriter) indexTail(
 	if offset != observedSize {
 		return chatIndexState{}, io.ErrUnexpectedEOF
 	}
+	if err := writer.flushPendingTranscriptItems(); err != nil {
+		return chatIndexState{}, err
+	}
 	writer.state.indexedBytes = offset
 	return writer.state, nil
 }
@@ -163,7 +168,10 @@ func (writer *chatIndexWriter) indexRecord(raw []byte, startOffset, endOffset in
 	); err != nil {
 		return err
 	}
-	return writer.indexTranscriptTurn(event, startOffset, endOffset)
+	if err := writer.indexTranscriptTurn(event, startOffset, endOffset); err != nil {
+		return err
+	}
+	return writer.indexTranscriptItem(event, startOffset, endOffset)
 }
 
 func (writer *chatIndexWriter) indexTranscriptTurn(

--- a/backend/internal/stores/filechat/store.go
+++ b/backend/internal/stores/filechat/store.go
@@ -21,16 +21,22 @@ import (
 var _ servicechat.Repository = (*Store)(nil)
 var _ servicechat.TranscriptEventSource = (*Store)(nil)
 var _ servicechat.TranscriptEventWindowSource = (*Store)(nil)
+var _ servicechat.TranscriptProjectionSource = (*Store)(nil)
 
 // Store manages chat dirs on disk. Single writer per chat via a per-id mutex
 // map; concurrent access across different chats is fine.
 type Store struct {
-	root   string
-	index  *chatEventIndex
-	mu     sync.Mutex
-	locks  map[servicechat.ID]*sync.Mutex
-	metaMu sync.RWMutex
-	metas  map[servicechat.ID]servicechat.Meta
+	root         string
+	index        *chatEventIndex
+	mu           sync.Mutex
+	locks        map[servicechat.ID]*sync.Mutex
+	metaMu       sync.RWMutex
+	metas        map[servicechat.ID]servicechat.Meta
+	indexContext context.Context
+	indexCancel  context.CancelFunc
+	indexWG      sync.WaitGroup
+	indexingMu   sync.Mutex
+	indexing     map[servicechat.ID]struct{}
 }
 
 func New(root string) (*Store, error) {
@@ -42,13 +48,18 @@ func New(root string) (*Store, error) {
 		log.Printf("chat event index unavailable; using canonical JSONL scans: %v", err)
 		index = unavailableChatEventIndex(root, err)
 	}
+	indexContext, indexCancel := context.WithCancel(context.Background())
 	store := &Store{
-		root:  root,
-		index: index,
-		locks: map[servicechat.ID]*sync.Mutex{},
-		metas: map[servicechat.ID]servicechat.Meta{},
+		root:         root,
+		index:        index,
+		locks:        map[servicechat.ID]*sync.Mutex{},
+		metas:        map[servicechat.ID]servicechat.Meta{},
+		indexContext: indexContext,
+		indexCancel:  indexCancel,
+		indexing:     map[servicechat.ID]struct{}{},
 	}
 	if err := store.loadMetaIndex(); err != nil {
+		indexCancel()
 		_ = index.close()
 		return nil, err
 	}
@@ -58,6 +69,8 @@ func New(root string) (*Store, error) {
 // Close releases the derived chat event index. Callers that create a bounded
 // Store lifetime (notably commands and tests) should call it explicitly.
 func (s *Store) Close() error {
+	s.indexCancel()
+	s.indexWG.Wait()
 	return s.index.close()
 }
 

--- a/backend/internal/stores/filechat/transcript_content_reader.go
+++ b/backend/internal/stores/filechat/transcript_content_reader.go
@@ -1,0 +1,207 @@
+package filechat
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"unicode/utf8"
+
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+)
+
+const (
+	defaultTranscriptContentPageBytes = 256 * 1024
+	maxTranscriptContentPageBytes     = 1024 * 1024
+)
+
+func (s *Store) ReadTranscriptContent(
+	ctx context.Context,
+	id servicechat.ID,
+	contentID string,
+	afterBytes int64,
+	limitBytes int,
+) (servicechat.TranscriptContentPage, error) {
+	if !servicechat.ValidID(id) {
+		return servicechat.TranscriptContentPage{}, servicechat.ErrInvalidID
+	}
+	if contentID == "" || afterBytes < 0 {
+		return servicechat.TranscriptContentPage{}, servicechat.ErrTranscriptContentNotFound
+	}
+	if err := s.index.availabilityError(); err != nil {
+		return servicechat.TranscriptContentPage{}, fmt.Errorf(
+			"%w: %v", servicechat.ErrTranscriptProjectionUnavailable, err,
+		)
+	}
+	if limitBytes <= 0 {
+		limitBytes = defaultTranscriptContentPageBytes
+	}
+	if limitBytes < utf8.UTFMax {
+		limitBytes = utf8.UTFMax
+	}
+	if limitBytes > maxTranscriptContentPageBytes {
+		limitBytes = maxTranscriptContentPageBytes
+	}
+
+	ref, err := s.index.readTranscriptContentRef(ctx, id, contentID)
+	if err != nil {
+		return servicechat.TranscriptContentPage{}, err
+	}
+	event, err := readProjectedSourceEvent(ctx, s.eventsPath(id), ref.sourceOffset, ref.sourceLength)
+	if err != nil {
+		return servicechat.TranscriptContentPage{}, err
+	}
+	content, err := extractTranscriptContent(event, ref.fieldKind, ref.fieldKey)
+	if err != nil {
+		return servicechat.TranscriptContentPage{}, err
+	}
+	if int64(len(content)) != ref.contentBytes {
+		return servicechat.TranscriptContentPage{}, fmt.Errorf(
+			"%w: projected content changed", errInvalidChatEventIndex,
+		)
+	}
+	return transcriptContentChunk(contentID, content, afterBytes, limitBytes)
+}
+
+func (index *chatEventIndex) readTranscriptContentRef(
+	ctx context.Context,
+	id servicechat.ID,
+	contentID string,
+) (transcriptContentRef, error) {
+	ref := transcriptContentRef{id: contentID}
+	err := index.db.QueryRowContext(ctx, `
+		SELECT field_kind, field_key, source_offset, source_length, content_bytes
+		FROM chat_transcript_content_refs
+		WHERE chat_id = ? AND content_id = ?`, id, contentID,
+	).Scan(&ref.fieldKind, &ref.fieldKey, &ref.sourceOffset, &ref.sourceLength, &ref.contentBytes)
+	if errors.Is(err, sql.ErrNoRows) {
+		return transcriptContentRef{}, servicechat.ErrTranscriptContentNotFound
+	}
+	return ref, err
+}
+
+func transcriptContentChunk(
+	contentID string,
+	content string,
+	afterBytes int64,
+	limitBytes int,
+) (servicechat.TranscriptContentPage, error) {
+	if afterBytes > int64(len(content)) {
+		return servicechat.TranscriptContentPage{}, servicechat.ErrTranscriptContentNotFound
+	}
+	start := int(afterBytes)
+	for start < len(content) && !utf8.RuneStart(content[start]) {
+		start++
+	}
+	end := start + limitBytes
+	if end > len(content) {
+		end = len(content)
+	}
+	for end > start && end < len(content) && !utf8.RuneStart(content[end]) {
+		end--
+	}
+	complete := end == len(content)
+	var nextAfter int64
+	if !complete {
+		nextAfter = int64(end)
+	}
+	return servicechat.TranscriptContentPage{
+		ContentID:  contentID,
+		Content:    content[start:end],
+		NextAfter:  nextAfter,
+		TotalBytes: int64(len(content)),
+		Complete:   complete,
+	}, nil
+}
+
+func readProjectedSourceEvent(
+	ctx context.Context,
+	eventsPath string,
+	offset int64,
+	length int64,
+) (servicechat.Event, error) {
+	if offset < 0 || length <= 0 || length > maxEventRecordBytes+2 {
+		return servicechat.Event{}, fmt.Errorf("%w: content source range", errInvalidChatEventIndex)
+	}
+	file, err := os.Open(eventsPath)
+	if err != nil {
+		return servicechat.Event{}, err
+	}
+	defer file.Close()
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		return servicechat.Event{}, err
+	}
+	raw := make([]byte, int(length))
+	if _, err := io.ReadFull(file, raw); err != nil {
+		return servicechat.Event{}, indexedReadError(err)
+	}
+	if err := ctx.Err(); err != nil {
+		return servicechat.Event{}, err
+	}
+	raw = bytes.TrimSuffix(raw, []byte{'\n'})
+	raw = bytes.TrimSuffix(raw, []byte{'\r'})
+	event, err := decodeStoredEvent(raw, 0)
+	if err != nil {
+		return servicechat.Event{}, fmt.Errorf("%w: decode content source: %v", errInvalidChatEventIndex, err)
+	}
+	return event, nil
+}
+
+func extractTranscriptContent(event servicechat.Event, fieldKind, fieldKey string) (string, error) {
+	switch fieldKind {
+	case "tool_output":
+		return event.Output, nil
+	case "tool_input":
+		return string(event.Input), nil
+	}
+	var data map[string]any
+	if json.Unmarshal(event.Data, &data) != nil {
+		return "", fmt.Errorf("%w: invalid collaboration data", errInvalidChatEventIndex)
+	}
+	switch fieldKind {
+	case "collaboration_tool_output", "collaboration_tool_input":
+		index, err := strconv.Atoi(fieldKey)
+		tools, ok := data["tools"].([]any)
+		if err != nil || !ok || index < 0 || index >= len(tools) {
+			return "", fmt.Errorf("%w: collaboration tool reference", errInvalidChatEventIndex)
+		}
+		tool, ok := tools[index].(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("%w: collaboration tool payload", errInvalidChatEventIndex)
+		}
+		if fieldKind == "collaboration_tool_output" {
+			output, ok := tool["output"].(string)
+			if !ok {
+				return "", fmt.Errorf("%w: collaboration tool output", errInvalidChatEventIndex)
+			}
+			return output, nil
+		}
+		input, ok := tool["input"]
+		if !ok {
+			return "", fmt.Errorf("%w: collaboration tool input", errInvalidChatEventIndex)
+		}
+		encoded, err := json.Marshal(input)
+		return string(encoded), err
+	case "collaboration_agent_message":
+		states, ok := data["agentsStates"].(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("%w: collaboration states", errInvalidChatEventIndex)
+		}
+		state, ok := states[fieldKey].(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("%w: collaboration state", errInvalidChatEventIndex)
+		}
+		message, ok := state["message"].(string)
+		if !ok {
+			return "", fmt.Errorf("%w: collaboration message", errInvalidChatEventIndex)
+		}
+		return message, nil
+	default:
+		return "", servicechat.ErrTranscriptContentNotFound
+	}
+}

--- a/backend/internal/stores/filechat/transcript_content_reader.go
+++ b/backend/internal/stores/filechat/transcript_content_reader.go
@@ -12,12 +12,8 @@ import (
 	"strconv"
 	"unicode/utf8"
 
+	configconstants "github.com/futrx-com/remote.futrx.com/internal/config/constants"
 	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
-)
-
-const (
-	defaultTranscriptContentPageBytes = 256 * 1024
-	maxTranscriptContentPageBytes     = 1024 * 1024
 )
 
 func (s *Store) ReadTranscriptContent(
@@ -39,13 +35,13 @@ func (s *Store) ReadTranscriptContent(
 		)
 	}
 	if limitBytes <= 0 {
-		limitBytes = defaultTranscriptContentPageBytes
+		limitBytes = configconstants.DefaultChatTranscriptContentPageBytes
 	}
 	if limitBytes < utf8.UTFMax {
 		limitBytes = utf8.UTFMax
 	}
-	if limitBytes > maxTranscriptContentPageBytes {
-		limitBytes = maxTranscriptContentPageBytes
+	if limitBytes > configconstants.MaxChatTranscriptContentPageBytes {
+		limitBytes = configconstants.MaxChatTranscriptContentPageBytes
 	}
 
 	ref, err := s.index.readTranscriptContentRef(ctx, id, contentID)

--- a/backend/internal/stores/filechat/transcript_page_buffer.go
+++ b/backend/internal/stores/filechat/transcript_page_buffer.go
@@ -1,0 +1,102 @@
+package filechat
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+)
+
+type projectedTranscriptItem struct {
+	turnOrdinal  int64
+	turnID       string
+	turnStart    int64
+	startSeq     int64
+	endSeq       int64
+	payload      []servicechat.Event
+	payloadBytes int
+}
+
+// transcriptPageBuffer owns the budget and selected items for one reverse read.
+// It decodes accepted payloads only, then assembles turns in display order.
+type transcriptPageBuffer struct {
+	turnLimit int
+	byteLimit int
+	usedBytes int
+	hasMore   bool
+	items     []projectedTranscriptItem
+	turns     map[int64]struct{}
+}
+
+func newTranscriptPageBuffer(turnLimit, byteLimit int) *transcriptPageBuffer {
+	return &transcriptPageBuffer{
+		turnLimit: turnLimit,
+		byteLimit: byteLimit,
+		items:     make([]projectedTranscriptItem, 0, 64),
+		turns:     make(map[int64]struct{}, turnLimit),
+	}
+}
+
+func (buffer *transcriptPageBuffer) appendItem(item projectedTranscriptItem, payloadJSON []byte) (bool, error) {
+	_, knownTurn := buffer.turns[item.turnOrdinal]
+	if (!knownTurn && len(buffer.turns) == buffer.turnLimit) ||
+		(len(buffer.items) > 0 && buffer.usedBytes+item.payloadBytes > buffer.byteLimit) {
+		buffer.hasMore = true
+		return false, nil
+	}
+	if err := json.Unmarshal(payloadJSON, &item.payload); err != nil {
+		return false, fmt.Errorf("%w: decode projected item: %v", errInvalidChatEventIndex, err)
+	}
+	buffer.items = append(buffer.items, item)
+	buffer.turns[item.turnOrdinal] = struct{}{}
+	buffer.usedBytes += item.payloadBytes
+	return true, nil
+}
+
+func (buffer *transcriptPageBuffer) page(lastSeq int64) servicechat.TranscriptPage {
+	for left, right := 0, len(buffer.items)-1; left < right; left, right = left+1, right-1 {
+		buffer.items[left], buffer.items[right] = buffer.items[right], buffer.items[left]
+	}
+	projectedTurns := make([]servicechat.TranscriptTurn, 0, len(buffer.turns))
+	var lastTurnOrdinal int64 = -1
+	for _, item := range buffer.items {
+		last := len(projectedTurns) - 1
+		if last < 0 || lastTurnOrdinal != item.turnOrdinal {
+			projectedTurns = append(projectedTurns, servicechat.TranscriptTurn{
+				ID:       projectedTurnID(item),
+				StartSeq: item.startSeq,
+				EndSeq:   item.endSeq,
+				Events:   append([]servicechat.Event(nil), item.payload...),
+			})
+			lastTurnOrdinal = item.turnOrdinal
+			continue
+		}
+		projectedTurns[last].EndSeq = item.endSeq
+		projectedTurns[last].Events = append(projectedTurns[last].Events, item.payload...)
+	}
+	for index := range projectedTurns {
+		sort.SliceStable(projectedTurns[index].Events, func(left, right int) bool {
+			return projectedTurns[index].Events[left].Seq < projectedTurns[index].Events[right].Seq
+		})
+	}
+
+	var nextBefore int64
+	if buffer.hasMore && len(buffer.items) > 0 {
+		nextBefore = buffer.items[0].startSeq
+	}
+	return servicechat.TranscriptPage{
+		Turns:      projectedTurns,
+		NextBefore: nextBefore,
+		LastSeq:    lastSeq,
+		HasMore:    buffer.hasMore,
+	}
+}
+
+func projectedTurnID(item projectedTranscriptItem) string {
+	if item.turnID != "" {
+		return item.turnID
+	}
+	return "legacy-" + strconv.FormatInt(item.turnStart, 10)
+}

--- a/backend/internal/stores/filechat/transcript_projection_encoding.go
+++ b/backend/internal/stores/filechat/transcript_projection_encoding.go
@@ -1,0 +1,184 @@
+package filechat
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+)
+
+const transcriptInlineFieldBytes = 32 * 1024
+
+type transcriptContentRef struct {
+	id           string
+	fieldKind    string
+	fieldKey     string
+	sourceOffset int64
+	sourceLength int64
+	contentBytes int64
+}
+
+type transcriptItemMode uint8
+
+const (
+	transcriptItemSingle transcriptItemMode = iota
+	transcriptItemReplace
+	transcriptItemAppend
+)
+
+func transcriptItemIdentity(event servicechat.Event, ordinal int64) (string, transcriptItemMode, bool) {
+	switch event.Type {
+	case "provider_event", "usage_update", "session", "sync", "system", "permission_request":
+		return "", transcriptItemSingle, false
+	case "collaboration":
+		if event.Name == "wait" {
+			return "", transcriptItemSingle, false
+		}
+		if event.ID != "" {
+			return "collaboration:" + event.ID, transcriptItemReplace, true
+		}
+	case "turn_status":
+		return "turn-status", transcriptItemReplace, true
+	case "tool_use_start", "tool_use_end":
+		if event.ID != "" {
+			return "tool:" + event.ID, transcriptItemAppend, true
+		}
+	case "interaction_request", "interaction_resolved":
+		if event.ID != "" {
+			return "interaction:" + event.ID, transcriptItemAppend, true
+		}
+	}
+	return "event:" + strconv.FormatInt(ordinal, 10), transcriptItemSingle, true
+}
+
+func compactTranscriptEvent(
+	chatID servicechat.ID,
+	event servicechat.Event,
+	itemKey string,
+	sourceOffset int64,
+	sourceLength int64,
+	turnOrdinal int64,
+) (servicechat.Event, []transcriptContentRef) {
+	event.Native = nil
+	makeRef := func(fieldKind, fieldKey string, contentBytes int) transcriptContentRef {
+		sum := sha256.Sum256([]byte(strings.Join([]string{
+			string(chatID),
+			strconv.FormatInt(turnOrdinal, 10),
+			itemKey,
+			fieldKind,
+			fieldKey,
+		}, "\x00")))
+		return transcriptContentRef{
+			id:           hex.EncodeToString(sum[:16]),
+			fieldKind:    fieldKind,
+			fieldKey:     fieldKey,
+			sourceOffset: sourceOffset,
+			sourceLength: sourceLength,
+			contentBytes: int64(contentBytes),
+		}
+	}
+
+	var refs []transcriptContentRef
+	switch event.Type {
+	case "tool_use_start":
+		if len(event.Input) > transcriptInlineFieldBytes {
+			ref := makeRef("tool_input", "", len(event.Input))
+			refs = append(refs, ref)
+			preview, _ := json.Marshal(map[string]any{
+				"preview":    utf8Prefix(string(event.Input), transcriptInlineFieldBytes),
+				"truncated":  true,
+				"contentRef": ref.id,
+			})
+			event.Input = preview
+		}
+	case "tool_use_end":
+		if len(event.Output) > transcriptInlineFieldBytes {
+			fullBytes := len(event.Output)
+			ref := makeRef("tool_output", "", fullBytes)
+			refs = append(refs, ref)
+			event.Output = utf8Prefix(event.Output, transcriptInlineFieldBytes)
+			event.OutputRef = ref.id
+			event.OutputBytes = int64(fullBytes)
+			event.OutputTruncated = true
+		}
+	case "collaboration":
+		event.Data, refs = compactCollaborationData(event.Data, makeRef)
+	}
+	return event, refs
+}
+
+func compactCollaborationData(
+	raw json.RawMessage,
+	makeRef func(string, string, int) transcriptContentRef,
+) (json.RawMessage, []transcriptContentRef) {
+	var data map[string]any
+	if len(raw) == 0 || json.Unmarshal(raw, &data) != nil {
+		return raw, nil
+	}
+	var refs []transcriptContentRef
+	if tools, ok := data["tools"].([]any); ok {
+		for index, value := range tools {
+			tool, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			key := strconv.Itoa(index)
+			if output, ok := tool["output"].(string); ok && len(output) > transcriptInlineFieldBytes {
+				ref := makeRef("collaboration_tool_output", key, len(output))
+				refs = append(refs, ref)
+				tool["output"] = utf8Prefix(output, transcriptInlineFieldBytes)
+				tool["outputRef"] = ref.id
+				tool["outputBytes"] = len(output)
+				tool["outputTruncated"] = true
+			}
+			if input, exists := tool["input"]; exists {
+				encoded, err := json.Marshal(input)
+				if err == nil && len(encoded) > transcriptInlineFieldBytes {
+					ref := makeRef("collaboration_tool_input", key, len(encoded))
+					refs = append(refs, ref)
+					tool["input"] = map[string]any{
+						"preview":    utf8Prefix(string(encoded), transcriptInlineFieldBytes),
+						"truncated":  true,
+						"contentRef": ref.id,
+					}
+				}
+			}
+		}
+	}
+	if states, ok := data["agentsStates"].(map[string]any); ok {
+		for threadID, value := range states {
+			state, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			if message, ok := state["message"].(string); ok && len(message) > transcriptInlineFieldBytes {
+				ref := makeRef("collaboration_agent_message", threadID, len(message))
+				refs = append(refs, ref)
+				state["message"] = utf8Prefix(message, transcriptInlineFieldBytes)
+				state["messageRef"] = ref.id
+				state["messageBytes"] = len(message)
+				state["messageTruncated"] = true
+			}
+		}
+	}
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return raw, nil
+	}
+	return encoded, refs
+}
+
+func utf8Prefix(value string, limit int) string {
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	end := limit
+	for end > 0 && !utf8.RuneStart(value[end]) {
+		end--
+	}
+	return value[:end]
+}

--- a/backend/internal/stores/filechat/transcript_projection_encoding.go
+++ b/backend/internal/stores/filechat/transcript_projection_encoding.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	configconstants "github.com/futrx-com/remote.futrx.com/internal/config/constants"
 	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
 )
-
-const transcriptInlineFieldBytes = 32 * 1024
 
 type transcriptContentRef struct {
 	id           string
@@ -85,22 +84,22 @@ func compactTranscriptEvent(
 	var refs []transcriptContentRef
 	switch event.Type {
 	case "tool_use_start":
-		if len(event.Input) > transcriptInlineFieldBytes {
+		if len(event.Input) > configconstants.ChatTranscriptInlineFieldBytes {
 			ref := makeRef("tool_input", "", len(event.Input))
 			refs = append(refs, ref)
 			preview, _ := json.Marshal(map[string]any{
-				"preview":    utf8Prefix(string(event.Input), transcriptInlineFieldBytes),
+				"preview":    utf8Prefix(string(event.Input), configconstants.ChatTranscriptInlineFieldBytes),
 				"truncated":  true,
 				"contentRef": ref.id,
 			})
 			event.Input = preview
 		}
 	case "tool_use_end":
-		if len(event.Output) > transcriptInlineFieldBytes {
+		if len(event.Output) > configconstants.ChatTranscriptInlineFieldBytes {
 			fullBytes := len(event.Output)
 			ref := makeRef("tool_output", "", fullBytes)
 			refs = append(refs, ref)
-			event.Output = utf8Prefix(event.Output, transcriptInlineFieldBytes)
+			event.Output = utf8Prefix(event.Output, configconstants.ChatTranscriptInlineFieldBytes)
 			event.OutputRef = ref.id
 			event.OutputBytes = int64(fullBytes)
 			event.OutputTruncated = true
@@ -127,21 +126,21 @@ func compactCollaborationData(
 				continue
 			}
 			key := strconv.Itoa(index)
-			if output, ok := tool["output"].(string); ok && len(output) > transcriptInlineFieldBytes {
+			if output, ok := tool["output"].(string); ok && len(output) > configconstants.ChatTranscriptInlineFieldBytes {
 				ref := makeRef("collaboration_tool_output", key, len(output))
 				refs = append(refs, ref)
-				tool["output"] = utf8Prefix(output, transcriptInlineFieldBytes)
+				tool["output"] = utf8Prefix(output, configconstants.ChatTranscriptInlineFieldBytes)
 				tool["outputRef"] = ref.id
 				tool["outputBytes"] = len(output)
 				tool["outputTruncated"] = true
 			}
 			if input, exists := tool["input"]; exists {
 				encoded, err := json.Marshal(input)
-				if err == nil && len(encoded) > transcriptInlineFieldBytes {
+				if err == nil && len(encoded) > configconstants.ChatTranscriptInlineFieldBytes {
 					ref := makeRef("collaboration_tool_input", key, len(encoded))
 					refs = append(refs, ref)
 					tool["input"] = map[string]any{
-						"preview":    utf8Prefix(string(encoded), transcriptInlineFieldBytes),
+						"preview":    utf8Prefix(string(encoded), configconstants.ChatTranscriptInlineFieldBytes),
 						"truncated":  true,
 						"contentRef": ref.id,
 					}
@@ -155,10 +154,10 @@ func compactCollaborationData(
 			if !ok {
 				continue
 			}
-			if message, ok := state["message"].(string); ok && len(message) > transcriptInlineFieldBytes {
+			if message, ok := state["message"].(string); ok && len(message) > configconstants.ChatTranscriptInlineFieldBytes {
 				ref := makeRef("collaboration_agent_message", threadID, len(message))
 				refs = append(refs, ref)
-				state["message"] = utf8Prefix(message, transcriptInlineFieldBytes)
+				state["message"] = utf8Prefix(message, configconstants.ChatTranscriptInlineFieldBytes)
 				state["messageRef"] = ref.id
 				state["messageBytes"] = len(message)
 				state["messageTruncated"] = true

--- a/backend/internal/stores/filechat/transcript_projection_reader.go
+++ b/backend/internal/stores/filechat/transcript_projection_reader.go
@@ -3,7 +3,6 @@ package filechat
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,15 +11,9 @@ import (
 	"os"
 	"sort"
 	"strconv"
-	"unicode/utf8"
 
 	configconstants "github.com/futrx-com/remote.futrx.com/internal/config/constants"
 	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
-)
-
-const (
-	defaultTranscriptContentPageBytes = 256 * 1024
-	maxTranscriptContentPageBytes     = 1024 * 1024
 )
 
 type projectedTranscriptItem struct {
@@ -269,173 +262,4 @@ func projectedTurnID(item projectedTranscriptItem) string {
 		return item.turnID
 	}
 	return "legacy-" + strconv.FormatInt(item.turnStart, 10)
-}
-
-func (s *Store) ReadTranscriptContent(
-	ctx context.Context,
-	id servicechat.ID,
-	contentID string,
-	afterBytes int64,
-	limitBytes int,
-) (servicechat.TranscriptContentPage, error) {
-	if !servicechat.ValidID(id) {
-		return servicechat.TranscriptContentPage{}, servicechat.ErrInvalidID
-	}
-	if contentID == "" || afterBytes < 0 {
-		return servicechat.TranscriptContentPage{}, servicechat.ErrTranscriptContentNotFound
-	}
-	if err := s.index.availabilityError(); err != nil {
-		return servicechat.TranscriptContentPage{}, fmt.Errorf(
-			"%w: %v", servicechat.ErrTranscriptProjectionUnavailable, err,
-		)
-	}
-	if limitBytes <= 0 {
-		limitBytes = defaultTranscriptContentPageBytes
-	}
-	if limitBytes < utf8.UTFMax {
-		limitBytes = utf8.UTFMax
-	}
-	if limitBytes > maxTranscriptContentPageBytes {
-		limitBytes = maxTranscriptContentPageBytes
-	}
-
-	var fieldKind, fieldKey string
-	var sourceOffset, sourceLength, recordedBytes int64
-	err := s.index.db.QueryRowContext(ctx, `
-		SELECT field_kind, field_key, source_offset, source_length, content_bytes
-		FROM chat_transcript_content_refs
-		WHERE chat_id = ? AND content_id = ?`, id, contentID,
-	).Scan(&fieldKind, &fieldKey, &sourceOffset, &sourceLength, &recordedBytes)
-	if errors.Is(err, sql.ErrNoRows) {
-		return servicechat.TranscriptContentPage{}, servicechat.ErrTranscriptContentNotFound
-	}
-	if err != nil {
-		return servicechat.TranscriptContentPage{}, err
-	}
-	event, err := readProjectedSourceEvent(ctx, s.eventsPath(id), sourceOffset, sourceLength)
-	if err != nil {
-		return servicechat.TranscriptContentPage{}, err
-	}
-	content, err := extractTranscriptContent(event, fieldKind, fieldKey)
-	if err != nil {
-		return servicechat.TranscriptContentPage{}, err
-	}
-	if int64(len(content)) != recordedBytes {
-		return servicechat.TranscriptContentPage{}, fmt.Errorf(
-			"%w: projected content changed", errInvalidChatEventIndex,
-		)
-	}
-	if afterBytes > int64(len(content)) {
-		return servicechat.TranscriptContentPage{}, servicechat.ErrTranscriptContentNotFound
-	}
-	start := int(afterBytes)
-	for start < len(content) && !utf8.RuneStart(content[start]) {
-		start++
-	}
-	end := start + limitBytes
-	if end > len(content) {
-		end = len(content)
-	}
-	for end > start && end < len(content) && !utf8.RuneStart(content[end]) {
-		end--
-	}
-	complete := end == len(content)
-	var nextAfter int64
-	if !complete {
-		nextAfter = int64(end)
-	}
-	return servicechat.TranscriptContentPage{
-		ContentID:  contentID,
-		Content:    content[start:end],
-		NextAfter:  nextAfter,
-		TotalBytes: int64(len(content)),
-		Complete:   complete,
-	}, nil
-}
-
-func readProjectedSourceEvent(
-	ctx context.Context,
-	eventsPath string,
-	offset int64,
-	length int64,
-) (servicechat.Event, error) {
-	if offset < 0 || length <= 0 || length > maxEventRecordBytes+2 {
-		return servicechat.Event{}, fmt.Errorf("%w: content source range", errInvalidChatEventIndex)
-	}
-	file, err := os.Open(eventsPath)
-	if err != nil {
-		return servicechat.Event{}, err
-	}
-	defer file.Close()
-	if _, err := file.Seek(offset, io.SeekStart); err != nil {
-		return servicechat.Event{}, err
-	}
-	raw := make([]byte, int(length))
-	if _, err := io.ReadFull(file, raw); err != nil {
-		return servicechat.Event{}, indexedReadError(err)
-	}
-	if err := ctx.Err(); err != nil {
-		return servicechat.Event{}, err
-	}
-	raw = bytes.TrimSuffix(raw, []byte{'\n'})
-	raw = bytes.TrimSuffix(raw, []byte{'\r'})
-	event, err := decodeStoredEvent(raw, 0)
-	if err != nil {
-		return servicechat.Event{}, fmt.Errorf("%w: decode content source: %v", errInvalidChatEventIndex, err)
-	}
-	return event, nil
-}
-
-func extractTranscriptContent(event servicechat.Event, fieldKind, fieldKey string) (string, error) {
-	switch fieldKind {
-	case "tool_output":
-		return event.Output, nil
-	case "tool_input":
-		return string(event.Input), nil
-	}
-	var data map[string]any
-	if json.Unmarshal(event.Data, &data) != nil {
-		return "", fmt.Errorf("%w: invalid collaboration data", errInvalidChatEventIndex)
-	}
-	switch fieldKind {
-	case "collaboration_tool_output", "collaboration_tool_input":
-		index, err := strconv.Atoi(fieldKey)
-		tools, ok := data["tools"].([]any)
-		if err != nil || !ok || index < 0 || index >= len(tools) {
-			return "", fmt.Errorf("%w: collaboration tool reference", errInvalidChatEventIndex)
-		}
-		tool, ok := tools[index].(map[string]any)
-		if !ok {
-			return "", fmt.Errorf("%w: collaboration tool payload", errInvalidChatEventIndex)
-		}
-		if fieldKind == "collaboration_tool_output" {
-			output, ok := tool["output"].(string)
-			if !ok {
-				return "", fmt.Errorf("%w: collaboration tool output", errInvalidChatEventIndex)
-			}
-			return output, nil
-		}
-		input, ok := tool["input"]
-		if !ok {
-			return "", fmt.Errorf("%w: collaboration tool input", errInvalidChatEventIndex)
-		}
-		encoded, err := json.Marshal(input)
-		return string(encoded), err
-	case "collaboration_agent_message":
-		states, ok := data["agentsStates"].(map[string]any)
-		if !ok {
-			return "", fmt.Errorf("%w: collaboration states", errInvalidChatEventIndex)
-		}
-		state, ok := states[fieldKey].(map[string]any)
-		if !ok {
-			return "", fmt.Errorf("%w: collaboration state", errInvalidChatEventIndex)
-		}
-		message, ok := state["message"].(string)
-		if !ok {
-			return "", fmt.Errorf("%w: collaboration message", errInvalidChatEventIndex)
-		}
-		return message, nil
-	default:
-		return "", servicechat.ErrTranscriptContentNotFound
-	}
 }

--- a/backend/internal/stores/filechat/transcript_projection_reader.go
+++ b/backend/internal/stores/filechat/transcript_projection_reader.go
@@ -3,28 +3,15 @@ package filechat
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
-	"sort"
-	"strconv"
 
 	configconstants "github.com/futrx-com/remote.futrx.com/internal/config/constants"
 	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
 )
-
-type projectedTranscriptItem struct {
-	turnOrdinal  int64
-	turnID       string
-	turnStart    int64
-	startSeq     int64
-	endSeq       int64
-	payload      []servicechat.Event
-	payloadBytes int
-}
 
 // ReadTranscriptPage serves only complete materialized snapshots. Missing or
 // stale legacy projections are rebuilt in the background and exposed as byte
@@ -182,10 +169,7 @@ func (index *chatEventIndex) readProjectedTranscriptPage(
 	}
 	defer rows.Close()
 
-	items := make([]projectedTranscriptItem, 0, 64)
-	turns := make(map[int64]struct{}, turnLimit)
-	usedBytes := 0
-	hasMore := false
+	pageBuffer := newTranscriptPageBuffer(turnLimit, byteLimit)
 	for rows.Next() {
 		var item projectedTranscriptItem
 		var payloadJSON []byte
@@ -200,66 +184,17 @@ func (index *chatEventIndex) readProjectedTranscriptPage(
 		); err != nil {
 			return servicechat.TranscriptPage{}, err
 		}
-		_, knownTurn := turns[item.turnOrdinal]
-		if (!knownTurn && len(turns) == turnLimit) ||
-			(len(items) > 0 && usedBytes+item.payloadBytes > byteLimit) {
-			hasMore = true
+		appended, err := pageBuffer.appendItem(item, payloadJSON)
+		if err != nil {
+			return servicechat.TranscriptPage{}, err
+		}
+		if !appended {
 			break
 		}
-		if err := json.Unmarshal(payloadJSON, &item.payload); err != nil {
-			return servicechat.TranscriptPage{}, fmt.Errorf(
-				"%w: decode projected item: %v", errInvalidChatEventIndex, err,
-			)
-		}
-		items = append(items, item)
-		turns[item.turnOrdinal] = struct{}{}
-		usedBytes += item.payloadBytes
 	}
 	if err := rows.Err(); err != nil {
 		return servicechat.TranscriptPage{}, err
 	}
 
-	for left, right := 0, len(items)-1; left < right; left, right = left+1, right-1 {
-		items[left], items[right] = items[right], items[left]
-	}
-	projectedTurns := make([]servicechat.TranscriptTurn, 0, len(turns))
-	var lastTurnOrdinal int64 = -1
-	for _, item := range items {
-		last := len(projectedTurns) - 1
-		if last < 0 || lastTurnOrdinal != item.turnOrdinal {
-			projectedTurns = append(projectedTurns, servicechat.TranscriptTurn{
-				ID:       projectedTurnID(item),
-				StartSeq: item.startSeq,
-				EndSeq:   item.endSeq,
-				Events:   append([]servicechat.Event(nil), item.payload...),
-			})
-			lastTurnOrdinal = item.turnOrdinal
-			continue
-		}
-		projectedTurns[last].EndSeq = item.endSeq
-		projectedTurns[last].Events = append(projectedTurns[last].Events, item.payload...)
-	}
-	for index := range projectedTurns {
-		sort.SliceStable(projectedTurns[index].Events, func(left, right int) bool {
-			return projectedTurns[index].Events[left].Seq < projectedTurns[index].Events[right].Seq
-		})
-	}
-
-	var nextBefore int64
-	if hasMore && len(items) > 0 {
-		nextBefore = items[0].startSeq
-	}
-	return servicechat.TranscriptPage{
-		Turns:      projectedTurns,
-		NextBefore: nextBefore,
-		LastSeq:    state.lastSeq,
-		HasMore:    hasMore,
-	}, nil
-}
-
-func projectedTurnID(item projectedTranscriptItem) string {
-	if item.turnID != "" {
-		return item.turnID
-	}
-	return "legacy-" + strconv.FormatInt(item.turnStart, 10)
+	return pageBuffer.page(state.lastSeq), nil
 }

--- a/backend/internal/stores/filechat/transcript_projection_reader.go
+++ b/backend/internal/stores/filechat/transcript_projection_reader.go
@@ -1,0 +1,441 @@
+package filechat
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"unicode/utf8"
+
+	configconstants "github.com/futrx-com/remote.futrx.com/internal/config/constants"
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+)
+
+const (
+	defaultTranscriptContentPageBytes = 256 * 1024
+	maxTranscriptContentPageBytes     = 1024 * 1024
+)
+
+type projectedTranscriptItem struct {
+	turnOrdinal  int64
+	turnID       string
+	turnStart    int64
+	startSeq     int64
+	endSeq       int64
+	payload      []servicechat.Event
+	payloadBytes int
+}
+
+// ReadTranscriptPage serves only complete materialized snapshots. Missing or
+// stale legacy projections are rebuilt in the background and exposed as byte
+// progress, so opening a large chat never performs a gigabyte request scan.
+func (s *Store) ReadTranscriptPage(
+	ctx context.Context,
+	id servicechat.ID,
+	query servicechat.TranscriptPageQuery,
+) (servicechat.TranscriptPage, error) {
+	if !servicechat.ValidID(id) {
+		return servicechat.TranscriptPage{}, servicechat.ErrInvalidID
+	}
+	if err := s.index.availabilityError(); err != nil {
+		return servicechat.TranscriptPage{}, fmt.Errorf(
+			"%w: %v", servicechat.ErrTranscriptProjectionUnavailable, err,
+		)
+	}
+
+	info, err := os.Stat(s.eventsPath(id))
+	var totalBytes, mtimeNS int64
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return servicechat.TranscriptPage{}, err
+		}
+	} else {
+		totalBytes = info.Size()
+		mtimeNS = info.ModTime().UnixNano()
+	}
+	state, found, err := s.index.readState(ctx, id)
+	if err != nil {
+		return servicechat.TranscriptPage{}, err
+	}
+	ready := found && state.indexedBytes == totalBytes && state.fileMtimeNS == mtimeNS
+	if !ready {
+		s.startTranscriptIndex(id)
+		indexedBytes := state.indexedBytes
+		if indexedBytes < 0 || indexedBytes > totalBytes {
+			indexedBytes = 0
+		}
+		lastSeq := state.lastSeq
+		tailSeqKnown := totalBytes == 0
+		if tailSeq, tailErr := lastStoredEventSeq(s.eventsPath(id), totalBytes); tailErr == nil && tailSeq > 0 {
+			tailSeqKnown = true
+			if tailSeq > lastSeq {
+				lastSeq = tailSeq
+			}
+		}
+		return servicechat.TranscriptPage{
+			Turns:   []servicechat.TranscriptTurn{},
+			LastSeq: lastSeq,
+			Indexing: &servicechat.TranscriptIndexProgress{
+				IndexedBytes: indexedBytes,
+				TotalBytes:   totalBytes,
+				TailSeqKnown: tailSeqKnown,
+			},
+		}, nil
+	}
+	return s.index.readProjectedTranscriptPage(ctx, id, state, query)
+}
+
+func lastStoredEventSeq(eventsPath string, fileSize int64) (int64, error) {
+	if fileSize <= 0 {
+		return 0, nil
+	}
+	window := int64(maxEventRecordBytes + 2)
+	if window > fileSize {
+		window = fileSize
+	}
+	file, err := os.Open(eventsPath)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+	raw := make([]byte, int(window))
+	if _, err := file.ReadAt(raw, fileSize-window); err != nil && !errors.Is(err, io.EOF) {
+		return 0, err
+	}
+	lines := bytes.Split(raw, []byte{'\n'})
+	for index := len(lines) - 1; index >= 0; index-- {
+		line := bytes.TrimSuffix(lines[index], []byte{'\r'})
+		if len(line) == 0 {
+			continue
+		}
+		event, err := decodeStoredEvent(line, 0)
+		if err == nil && event.Seq > 0 {
+			return event.Seq, nil
+		}
+	}
+	return 0, errors.New("last stored event has no sequence")
+}
+
+func (s *Store) startTranscriptIndex(id servicechat.ID) {
+	s.indexingMu.Lock()
+	if _, exists := s.indexing[id]; exists {
+		s.indexingMu.Unlock()
+		return
+	}
+	s.indexing[id] = struct{}{}
+	s.indexWG.Add(1)
+	s.indexingMu.Unlock()
+
+	go func() {
+		defer s.indexWG.Done()
+		defer func() {
+			s.indexingMu.Lock()
+			delete(s.indexing, id)
+			s.indexingMu.Unlock()
+		}()
+		lock := s.lock(id)
+		lock.Lock()
+		defer lock.Unlock()
+		if _, err := os.Stat(s.chatDir(id)); err != nil {
+			return
+		}
+		if _, err := s.index.syncChat(s.indexContext, id, s.eventsPath(id)); err != nil &&
+			!errors.Is(err, context.Canceled) {
+			log.Printf("background transcript projection for chat %s failed: %v", id, err)
+		}
+	}()
+}
+
+func (index *chatEventIndex) readProjectedTranscriptPage(
+	ctx context.Context,
+	id servicechat.ID,
+	state chatIndexState,
+	query servicechat.TranscriptPageQuery,
+) (servicechat.TranscriptPage, error) {
+	turnLimit := query.Limit
+	if turnLimit <= 0 {
+		turnLimit = configconstants.DefaultChatTranscriptTurnLimit
+	}
+	if turnLimit > configconstants.MaxChatTranscriptTurnLimit {
+		turnLimit = configconstants.MaxChatTranscriptTurnLimit
+	}
+	byteLimit := query.ByteLimit
+	if byteLimit <= 0 {
+		byteLimit = configconstants.DefaultChatTranscriptByteLimit
+	}
+	if byteLimit > configconstants.MaxChatTranscriptByteLimit {
+		byteLimit = configconstants.MaxChatTranscriptByteLimit
+	}
+
+	rows, err := index.db.QueryContext(ctx, `
+		SELECT i.turn_ordinal, t.source_turn_id, t.start_seq,
+		       i.start_seq, i.end_seq, i.payload_json, i.payload_bytes
+		FROM chat_transcript_items AS i
+		JOIN chat_transcript_turns AS t
+		  ON t.chat_id = i.chat_id AND t.turn_ordinal = i.turn_ordinal
+		WHERE i.chat_id = ? AND (? <= 0 OR i.start_seq < ?)
+		ORDER BY i.start_seq DESC, i.item_key DESC`,
+		id, query.BeforeSeq, query.BeforeSeq,
+	)
+	if err != nil {
+		return servicechat.TranscriptPage{}, err
+	}
+	defer rows.Close()
+
+	items := make([]projectedTranscriptItem, 0, 64)
+	turns := make(map[int64]struct{}, turnLimit)
+	usedBytes := 0
+	hasMore := false
+	for rows.Next() {
+		var item projectedTranscriptItem
+		var payloadJSON []byte
+		if err := rows.Scan(
+			&item.turnOrdinal,
+			&item.turnID,
+			&item.turnStart,
+			&item.startSeq,
+			&item.endSeq,
+			&payloadJSON,
+			&item.payloadBytes,
+		); err != nil {
+			return servicechat.TranscriptPage{}, err
+		}
+		_, knownTurn := turns[item.turnOrdinal]
+		if (!knownTurn && len(turns) == turnLimit) ||
+			(len(items) > 0 && usedBytes+item.payloadBytes > byteLimit) {
+			hasMore = true
+			break
+		}
+		if err := json.Unmarshal(payloadJSON, &item.payload); err != nil {
+			return servicechat.TranscriptPage{}, fmt.Errorf(
+				"%w: decode projected item: %v", errInvalidChatEventIndex, err,
+			)
+		}
+		items = append(items, item)
+		turns[item.turnOrdinal] = struct{}{}
+		usedBytes += item.payloadBytes
+	}
+	if err := rows.Err(); err != nil {
+		return servicechat.TranscriptPage{}, err
+	}
+
+	for left, right := 0, len(items)-1; left < right; left, right = left+1, right-1 {
+		items[left], items[right] = items[right], items[left]
+	}
+	projectedTurns := make([]servicechat.TranscriptTurn, 0, len(turns))
+	var lastTurnOrdinal int64 = -1
+	for _, item := range items {
+		last := len(projectedTurns) - 1
+		if last < 0 || lastTurnOrdinal != item.turnOrdinal {
+			projectedTurns = append(projectedTurns, servicechat.TranscriptTurn{
+				ID:       projectedTurnID(item),
+				StartSeq: item.startSeq,
+				EndSeq:   item.endSeq,
+				Events:   append([]servicechat.Event(nil), item.payload...),
+			})
+			lastTurnOrdinal = item.turnOrdinal
+			continue
+		}
+		projectedTurns[last].EndSeq = item.endSeq
+		projectedTurns[last].Events = append(projectedTurns[last].Events, item.payload...)
+	}
+	for index := range projectedTurns {
+		sort.SliceStable(projectedTurns[index].Events, func(left, right int) bool {
+			return projectedTurns[index].Events[left].Seq < projectedTurns[index].Events[right].Seq
+		})
+	}
+
+	var nextBefore int64
+	if hasMore && len(items) > 0 {
+		nextBefore = items[0].startSeq
+	}
+	return servicechat.TranscriptPage{
+		Turns:      projectedTurns,
+		NextBefore: nextBefore,
+		LastSeq:    state.lastSeq,
+		HasMore:    hasMore,
+	}, nil
+}
+
+func projectedTurnID(item projectedTranscriptItem) string {
+	if item.turnID != "" {
+		return item.turnID
+	}
+	return "legacy-" + strconv.FormatInt(item.turnStart, 10)
+}
+
+func (s *Store) ReadTranscriptContent(
+	ctx context.Context,
+	id servicechat.ID,
+	contentID string,
+	afterBytes int64,
+	limitBytes int,
+) (servicechat.TranscriptContentPage, error) {
+	if !servicechat.ValidID(id) {
+		return servicechat.TranscriptContentPage{}, servicechat.ErrInvalidID
+	}
+	if contentID == "" || afterBytes < 0 {
+		return servicechat.TranscriptContentPage{}, servicechat.ErrTranscriptContentNotFound
+	}
+	if err := s.index.availabilityError(); err != nil {
+		return servicechat.TranscriptContentPage{}, fmt.Errorf(
+			"%w: %v", servicechat.ErrTranscriptProjectionUnavailable, err,
+		)
+	}
+	if limitBytes <= 0 {
+		limitBytes = defaultTranscriptContentPageBytes
+	}
+	if limitBytes < utf8.UTFMax {
+		limitBytes = utf8.UTFMax
+	}
+	if limitBytes > maxTranscriptContentPageBytes {
+		limitBytes = maxTranscriptContentPageBytes
+	}
+
+	var fieldKind, fieldKey string
+	var sourceOffset, sourceLength, recordedBytes int64
+	err := s.index.db.QueryRowContext(ctx, `
+		SELECT field_kind, field_key, source_offset, source_length, content_bytes
+		FROM chat_transcript_content_refs
+		WHERE chat_id = ? AND content_id = ?`, id, contentID,
+	).Scan(&fieldKind, &fieldKey, &sourceOffset, &sourceLength, &recordedBytes)
+	if errors.Is(err, sql.ErrNoRows) {
+		return servicechat.TranscriptContentPage{}, servicechat.ErrTranscriptContentNotFound
+	}
+	if err != nil {
+		return servicechat.TranscriptContentPage{}, err
+	}
+	event, err := readProjectedSourceEvent(ctx, s.eventsPath(id), sourceOffset, sourceLength)
+	if err != nil {
+		return servicechat.TranscriptContentPage{}, err
+	}
+	content, err := extractTranscriptContent(event, fieldKind, fieldKey)
+	if err != nil {
+		return servicechat.TranscriptContentPage{}, err
+	}
+	if int64(len(content)) != recordedBytes {
+		return servicechat.TranscriptContentPage{}, fmt.Errorf(
+			"%w: projected content changed", errInvalidChatEventIndex,
+		)
+	}
+	if afterBytes > int64(len(content)) {
+		return servicechat.TranscriptContentPage{}, servicechat.ErrTranscriptContentNotFound
+	}
+	start := int(afterBytes)
+	for start < len(content) && !utf8.RuneStart(content[start]) {
+		start++
+	}
+	end := start + limitBytes
+	if end > len(content) {
+		end = len(content)
+	}
+	for end > start && end < len(content) && !utf8.RuneStart(content[end]) {
+		end--
+	}
+	complete := end == len(content)
+	var nextAfter int64
+	if !complete {
+		nextAfter = int64(end)
+	}
+	return servicechat.TranscriptContentPage{
+		ContentID:  contentID,
+		Content:    content[start:end],
+		NextAfter:  nextAfter,
+		TotalBytes: int64(len(content)),
+		Complete:   complete,
+	}, nil
+}
+
+func readProjectedSourceEvent(
+	ctx context.Context,
+	eventsPath string,
+	offset int64,
+	length int64,
+) (servicechat.Event, error) {
+	if offset < 0 || length <= 0 || length > maxEventRecordBytes+2 {
+		return servicechat.Event{}, fmt.Errorf("%w: content source range", errInvalidChatEventIndex)
+	}
+	file, err := os.Open(eventsPath)
+	if err != nil {
+		return servicechat.Event{}, err
+	}
+	defer file.Close()
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		return servicechat.Event{}, err
+	}
+	raw := make([]byte, int(length))
+	if _, err := io.ReadFull(file, raw); err != nil {
+		return servicechat.Event{}, indexedReadError(err)
+	}
+	if err := ctx.Err(); err != nil {
+		return servicechat.Event{}, err
+	}
+	raw = bytes.TrimSuffix(raw, []byte{'\n'})
+	raw = bytes.TrimSuffix(raw, []byte{'\r'})
+	event, err := decodeStoredEvent(raw, 0)
+	if err != nil {
+		return servicechat.Event{}, fmt.Errorf("%w: decode content source: %v", errInvalidChatEventIndex, err)
+	}
+	return event, nil
+}
+
+func extractTranscriptContent(event servicechat.Event, fieldKind, fieldKey string) (string, error) {
+	switch fieldKind {
+	case "tool_output":
+		return event.Output, nil
+	case "tool_input":
+		return string(event.Input), nil
+	}
+	var data map[string]any
+	if json.Unmarshal(event.Data, &data) != nil {
+		return "", fmt.Errorf("%w: invalid collaboration data", errInvalidChatEventIndex)
+	}
+	switch fieldKind {
+	case "collaboration_tool_output", "collaboration_tool_input":
+		index, err := strconv.Atoi(fieldKey)
+		tools, ok := data["tools"].([]any)
+		if err != nil || !ok || index < 0 || index >= len(tools) {
+			return "", fmt.Errorf("%w: collaboration tool reference", errInvalidChatEventIndex)
+		}
+		tool, ok := tools[index].(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("%w: collaboration tool payload", errInvalidChatEventIndex)
+		}
+		if fieldKind == "collaboration_tool_output" {
+			output, ok := tool["output"].(string)
+			if !ok {
+				return "", fmt.Errorf("%w: collaboration tool output", errInvalidChatEventIndex)
+			}
+			return output, nil
+		}
+		input, ok := tool["input"]
+		if !ok {
+			return "", fmt.Errorf("%w: collaboration tool input", errInvalidChatEventIndex)
+		}
+		encoded, err := json.Marshal(input)
+		return string(encoded), err
+	case "collaboration_agent_message":
+		states, ok := data["agentsStates"].(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("%w: collaboration states", errInvalidChatEventIndex)
+		}
+		state, ok := states[fieldKey].(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("%w: collaboration state", errInvalidChatEventIndex)
+		}
+		message, ok := state["message"].(string)
+		if !ok {
+			return "", fmt.Errorf("%w: collaboration message", errInvalidChatEventIndex)
+		}
+		return message, nil
+	default:
+		return "", servicechat.ErrTranscriptContentNotFound
+	}
+}

--- a/backend/internal/stores/filechat/transcript_projection_reader_test.go
+++ b/backend/internal/stores/filechat/transcript_projection_reader_test.go
@@ -1,0 +1,90 @@
+package filechat
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+)
+
+func TestTranscriptContentPreservesByteOffsetBoundaries(t *testing.T) {
+	root := t.TempDir()
+	output := strings.Repeat("a🙂z", 6_000)
+	writeStoredChat(t, root, "abcd", []servicechat.Event{
+		{Seq: 1, Type: "tool_use_end", TurnID: "turn", ID: "tool", Output: output},
+	})
+	store := newIndexedTestStore(t, root)
+	if _, err := store.index.syncChat(context.Background(), "abcd", store.eventsPath("abcd")); err != nil {
+		t.Fatal(err)
+	}
+	page, err := store.ReadTranscriptPage(context.Background(), "abcd", servicechat.TranscriptPageQuery{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentID := page.Turns[0].Events[0].OutputRef
+	for _, test := range []struct {
+		name      string
+		after     int64
+		limit     int
+		content   string
+		next      int64
+		complete  bool
+		wantError error
+	}{
+		{name: "minimum limit ends before rune", limit: 1, content: "a", next: 1},
+		{name: "minimum limit fits rune", after: 1, limit: 1, content: "🙂", next: 5},
+		{name: "offset inside rune advances", after: 2, limit: 4, content: "za", next: 7},
+		{name: "default limit", content: output, complete: true},
+		{name: "end offset", after: int64(len(output)), limit: 4, complete: true},
+		{name: "past end", after: int64(len(output)) + 1, wantError: servicechat.ErrTranscriptContentNotFound},
+		{name: "negative offset", after: -1, wantError: servicechat.ErrTranscriptContentNotFound},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			chunk, err := store.ReadTranscriptContent(context.Background(), "abcd", contentID, test.after, test.limit)
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("content error = %v, want %v", err, test.wantError)
+			}
+			if test.wantError != nil {
+				return
+			}
+			if chunk.ContentID != contentID || chunk.Content != test.content || chunk.NextAfter != test.next ||
+				chunk.Complete != test.complete || chunk.TotalBytes != int64(len(output)) {
+				t.Fatalf("content chunk = %#v", chunk)
+			}
+		})
+	}
+}
+
+func TestTranscriptPageDecodesOnlyItemsInsideBudget(t *testing.T) {
+	root := t.TempDir()
+	writeStoredChat(t, root, "abcd", []servicechat.Event{
+		{Seq: 1, Type: "user", TurnID: "older", Text: "older prompt"},
+		{Seq: 2, Type: "user", TurnID: "newer", Text: "newer prompt"},
+	})
+	store := newIndexedTestStore(t, root)
+	if _, err := store.index.syncChat(context.Background(), "abcd", store.eventsPath("abcd")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.index.db.Exec(`UPDATE chat_transcript_items SET payload_json = ? WHERE chat_id = ? AND start_seq = ?`,
+		[]byte("invalid JSON"), "abcd", 1); err != nil {
+		t.Fatal(err)
+	}
+	for _, query := range []servicechat.TranscriptPageQuery{
+		{Limit: 1},
+		{Limit: 2, ByteLimit: 1},
+	} {
+		page, err := store.ReadTranscriptPage(context.Background(), "abcd", query)
+		if err != nil {
+			t.Fatalf("query %#v: %v", query, err)
+		}
+		if len(page.Turns) != 1 || page.Turns[0].ID != "newer" || len(page.Turns[0].Events) != 1 ||
+			page.Turns[0].Events[0].Text != "newer prompt" || !page.HasMore || page.NextBefore != 2 || page.LastSeq != 2 {
+			t.Fatalf("query %#v: page = %#v", query, page)
+		}
+	}
+	if _, err := store.ReadTranscriptPage(context.Background(), "abcd", servicechat.TranscriptPageQuery{Limit: 2}); !errors.Is(err, errInvalidChatEventIndex) {
+		t.Fatalf("included invalid payload error = %v", err)
+	}
+}

--- a/backend/internal/stores/filechat/transcript_projection_test.go
+++ b/backend/internal/stores/filechat/transcript_projection_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	configconstants "github.com/futrx-com/remote.futrx.com/internal/config/constants"
 	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
 )
 
@@ -208,11 +209,11 @@ func TestChatIndexCheckpointEndsOnARecordBoundary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	size := chatIndexCheckpointBytes + 20
+	size := configconstants.ChatIndexCheckpointBytes + 20
 	if err := file.Truncate(size); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := file.WriteAt([]byte("abc\ndef"), chatIndexCheckpointBytes); err != nil {
+	if _, err := file.WriteAt([]byte("abc\ndef"), configconstants.ChatIndexCheckpointBytes); err != nil {
 		t.Fatal(err)
 	}
 	if err := file.Close(); err != nil {
@@ -222,8 +223,8 @@ func TestChatIndexCheckpointEndsOnARecordBoundary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if checkpoint != chatIndexCheckpointBytes+4 {
-		t.Fatalf("checkpoint = %d, want %d", checkpoint, chatIndexCheckpointBytes+4)
+	if checkpoint != configconstants.ChatIndexCheckpointBytes+4 {
+		t.Fatalf("checkpoint = %d, want %d", checkpoint, configconstants.ChatIndexCheckpointBytes+4)
 	}
 }
 

--- a/backend/internal/stores/filechat/transcript_projection_test.go
+++ b/backend/internal/stores/filechat/transcript_projection_test.go
@@ -1,0 +1,256 @@
+package filechat
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+)
+
+func TestTranscriptProjectionCollapsesTelemetryAndLoadsFullResponses(t *testing.T) {
+	root := t.TempDir()
+	toolOutput := strings.Repeat("tool-result-🙂\n", 4_000)
+	subagentOutput := strings.Repeat("subagent-tool-output\n", 3_000)
+	subagentMessage := strings.Repeat("final subagent report\n", 3_000)
+	firstCollaboration := json.RawMessage(`{
+		"type":"subagentThread",
+		"tools":[{"id":"child-tool","name":"exec","output":"working"}],
+		"agentsStates":{"child":{"status":"inProgress"}}
+	}`)
+	finalCollaboration, err := json.Marshal(map[string]any{
+		"type": "subagentThread",
+		"tools": []any{map[string]any{
+			"id": "child-tool", "name": "exec", "status": "completed",
+			"output": subagentOutput,
+		}},
+		"agentsStates": map[string]any{
+			"child": map[string]any{"status": "completed", "message": subagentMessage},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := []servicechat.Event{
+		{Seq: 1, T: 1, Type: "user", TurnID: "turn-1", Text: "question"},
+		{Seq: 2, T: 2, Type: "provider_event", TurnID: "turn-1", Data: json.RawMessage(`{"raw":"telemetry"}`)},
+		{Seq: 3, T: 3, Type: "tool_use_start", TurnID: "turn-1", ID: "tool-1", Name: "Bash", Input: json.RawMessage(`{"command":"test"}`)},
+		{Seq: 4, T: 4, Type: "collaboration", TurnID: "turn-1", ID: "child", Name: "spawn", Status: "inProgress", Data: firstCollaboration},
+		{Seq: 5, T: 5, Type: "tool_use_end", TurnID: "turn-1", ID: "tool-1", Output: toolOutput},
+		{Seq: 6, T: 6, Type: "collaboration", TurnID: "turn-1", ID: "child", Name: "spawn", Status: "completed", Data: finalCollaboration},
+		{Seq: 7, T: 7, Type: "complete", TurnID: "turn-1"},
+		{Seq: 8, T: 8, Type: "user", TurnID: "turn-2", Text: "next question"},
+		{Seq: 9, T: 9, Type: "complete", TurnID: "turn-2"},
+	}
+	writeStoredChat(t, root, "abcd", events)
+	store := newIndexedTestStore(t, root)
+	if _, err := store.index.syncChat(context.Background(), "abcd", store.eventsPath("abcd")); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := store.ReadTranscriptPage(
+		context.Background(), "abcd", servicechat.TranscriptPageQuery{Limit: 10},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Indexing != nil || len(page.Turns) != 2 {
+		t.Fatalf("projected page = %#v", page)
+	}
+	var projected []servicechat.Event
+	for _, turn := range page.Turns {
+		projected = append(projected, turn.Events...)
+	}
+	var collaborations int
+	var toolRef, childToolRef, childMessageRef string
+	for _, event := range projected {
+		switch event.Type {
+		case "provider_event":
+			t.Fatal("provider telemetry leaked into transcript projection")
+		case "tool_use_end":
+			toolRef = event.OutputRef
+			if !event.OutputTruncated || event.OutputBytes != int64(len(toolOutput)) || len(event.Output) >= len(toolOutput) {
+				t.Fatalf("tool preview = %#v", event)
+			}
+		case "collaboration":
+			collaborations++
+			if event.Status != "completed" || event.Seq != 4 {
+				t.Fatalf("collaboration did not retain position and latest state: %#v", event)
+			}
+			var data map[string]any
+			if err := json.Unmarshal(event.Data, &data); err != nil {
+				t.Fatal(err)
+			}
+			tool := data["tools"].([]any)[0].(map[string]any)
+			childToolRef, _ = tool["outputRef"].(string)
+			state := data["agentsStates"].(map[string]any)["child"].(map[string]any)
+			childMessageRef, _ = state["messageRef"].(string)
+		}
+	}
+	var collaborationEndSeq, collaborationTurnOrdinal int64
+	if err := store.index.db.QueryRow(`
+		SELECT end_seq, turn_ordinal
+		FROM chat_transcript_items
+		WHERE chat_id = ? AND item_key = ?`, "abcd", "collaboration:child",
+	).Scan(&collaborationEndSeq, &collaborationTurnOrdinal); err != nil {
+		t.Fatal(err)
+	}
+	if collaborationEndSeq != 6 || collaborationTurnOrdinal != 1 {
+		t.Fatalf("collaboration index end=%d turn=%d", collaborationEndSeq, collaborationTurnOrdinal)
+	}
+	var contentTurnOrdinal int64
+	if err := store.index.db.QueryRow(`
+		SELECT turn_ordinal
+		FROM chat_transcript_content_refs
+		WHERE chat_id = ? AND content_id = ?`, "abcd", childToolRef,
+	).Scan(&contentTurnOrdinal); err != nil {
+		t.Fatal(err)
+	}
+	if contentTurnOrdinal != collaborationTurnOrdinal {
+		t.Fatalf("content reference turn=%d, want %d", contentTurnOrdinal, collaborationTurnOrdinal)
+	}
+	if collaborations != 1 || toolRef == "" || childToolRef == "" || childMessageRef == "" {
+		t.Fatalf("projection refs: collaborations=%d tool=%q childTool=%q childMessage=%q", collaborations, toolRef, childToolRef, childMessageRef)
+	}
+	for ref, want := range map[string]string{
+		toolRef:         toolOutput,
+		childToolRef:    subagentOutput,
+		childMessageRef: subagentMessage,
+	} {
+		if got := readAllTranscriptContent(t, store, "abcd", ref, 4_001); got != want {
+			t.Fatalf("full content %q has %d bytes, want %d", ref, len(got), len(want))
+		}
+	}
+}
+
+func TestTranscriptProjectionPagesInsideOneLargeTurnByBytes(t *testing.T) {
+	root := t.TempDir()
+	events := []servicechat.Event{{Seq: 1, T: 1, Type: "user", TurnID: "turn-1", Text: "question"}}
+	for seq := int64(2); seq <= 11; seq++ {
+		events = append(events, servicechat.Event{
+			Seq: seq, T: seq, Type: "assistant_text", TurnID: "turn-1",
+			MessageID: "message-" + string(rune('a'+seq)), Text: strings.Repeat("x", 900),
+		})
+	}
+	events = append(events, servicechat.Event{Seq: 12, T: 12, Type: "complete", TurnID: "turn-1"})
+	writeStoredChat(t, root, "abcd", events)
+	store := newIndexedTestStore(t, root)
+	if _, err := store.index.syncChat(context.Background(), "abcd", store.eventsPath("abcd")); err != nil {
+		t.Fatal(err)
+	}
+
+	before := int64(0)
+	seen := make(map[int64]struct{})
+	pages := 0
+	for {
+		page, err := store.ReadTranscriptPage(context.Background(), "abcd", servicechat.TranscriptPageQuery{
+			Limit: 10, BeforeSeq: before, ByteLimit: 1_500,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		pages++
+		for _, turn := range page.Turns {
+			for _, event := range turn.Events {
+				if _, duplicate := seen[event.Seq]; duplicate {
+					t.Fatalf("duplicate sequence %d", event.Seq)
+				}
+				seen[event.Seq] = struct{}{}
+			}
+		}
+		if !page.HasMore {
+			break
+		}
+		if page.NextBefore <= 0 || page.NextBefore >= before && before > 0 {
+			t.Fatalf("unsafe cursor: before=%d page=%#v", before, page)
+		}
+		before = page.NextBefore
+	}
+	if pages < 2 || len(seen) != len(events) {
+		t.Fatalf("pages=%d sequences=%d want=%d", pages, len(seen), len(events))
+	}
+}
+
+func TestTranscriptProjectionStartsBackgroundBackfillWithTailSequence(t *testing.T) {
+	root := t.TempDir()
+	writeStoredChat(t, root, "abcd", []servicechat.Event{
+		{Seq: 41, T: 1, Type: "user", TurnID: "turn", Text: "question"},
+		{Seq: 42, T: 2, Type: "complete", TurnID: "turn"},
+	})
+	store := newIndexedTestStore(t, root)
+	page, err := store.ReadTranscriptPage(context.Background(), "abcd", servicechat.TranscriptPageQuery{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Indexing == nil || !page.Indexing.TailSeqKnown || page.LastSeq != 42 {
+		t.Fatalf("initial background page = %#v", page)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for page.Indexing != nil && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+		page, err = store.ReadTranscriptPage(context.Background(), "abcd", servicechat.TranscriptPageQuery{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if page.Indexing != nil || len(page.Turns) != 1 {
+		t.Fatalf("completed background page = %#v", page)
+	}
+}
+
+func TestChatIndexCheckpointEndsOnARecordBoundary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	size := chatIndexCheckpointBytes + 20
+	if err := file.Truncate(size); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteAt([]byte("abc\ndef"), chatIndexCheckpointBytes); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	checkpoint, err := chatIndexCheckpoint(path, 0, size)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkpoint != chatIndexCheckpointBytes+4 {
+		t.Fatalf("checkpoint = %d, want %d", checkpoint, chatIndexCheckpointBytes+4)
+	}
+}
+
+func readAllTranscriptContent(
+	t *testing.T,
+	store *Store,
+	chatID servicechat.ID,
+	contentID string,
+	limit int,
+) string {
+	t.Helper()
+	var content strings.Builder
+	var after int64
+	for {
+		page, err := store.ReadTranscriptContent(
+			context.Background(), chatID, contentID, after, limit,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		content.WriteString(page.Content)
+		if page.Complete {
+			return content.String()
+		}
+		if page.NextAfter <= after {
+			t.Fatalf("content cursor did not advance: %#v", page)
+		}
+		after = page.NextAfter
+	}
+}

--- a/backend/internal/stores/filechat/transcript_projection_writer.go
+++ b/backend/internal/stores/filechat/transcript_projection_writer.go
@@ -2,29 +2,14 @@ package filechat
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"sort"
 	"strconv"
-	"strings"
-	"unicode/utf8"
 
 	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
 )
-
-const transcriptInlineFieldBytes = 32 * 1024
-
-type transcriptContentRef struct {
-	id           string
-	fieldKind    string
-	fieldKey     string
-	sourceOffset int64
-	sourceLength int64
-	contentBytes int64
-}
 
 type pendingTranscriptItem struct {
 	event       servicechat.Event
@@ -133,8 +118,8 @@ func (writer *transcriptProjectionWriter) persistTranscriptItem(
 		return err
 	}
 
-	projected, refs := writer.compactTranscriptEvent(
-		event, itemKey, startOffset, endOffset-startOffset, turnOrdinal,
+	projected, refs := compactTranscriptEvent(
+		writer.chatID, event, itemKey, startOffset, endOffset-startOffset, turnOrdinal,
 	)
 	projected.Seq = displaySeq
 	payload := []servicechat.Event{projected}
@@ -209,39 +194,6 @@ func (writer *transcriptProjectionWriter) persistTranscriptItem(
 	return nil
 }
 
-type transcriptItemMode uint8
-
-const (
-	transcriptItemSingle transcriptItemMode = iota
-	transcriptItemReplace
-	transcriptItemAppend
-)
-
-func transcriptItemIdentity(event servicechat.Event, ordinal int64) (string, transcriptItemMode, bool) {
-	switch event.Type {
-	case "provider_event", "usage_update", "session", "sync", "system", "permission_request":
-		return "", transcriptItemSingle, false
-	case "collaboration":
-		if event.Name == "wait" {
-			return "", transcriptItemSingle, false
-		}
-		if event.ID != "" {
-			return "collaboration:" + event.ID, transcriptItemReplace, true
-		}
-	case "turn_status":
-		return "turn-status", transcriptItemReplace, true
-	case "tool_use_start", "tool_use_end":
-		if event.ID != "" {
-			return "tool:" + event.ID, transcriptItemAppend, true
-		}
-	case "interaction_request", "interaction_resolved":
-		if event.ID != "" {
-			return "interaction:" + event.ID, transcriptItemAppend, true
-		}
-	}
-	return "event:" + strconv.FormatInt(ordinal, 10), transcriptItemSingle, true
-}
-
 func readTranscriptItem(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -289,131 +241,4 @@ func deleteTranscriptContentRefs(
 		chatID, turnOrdinal, itemKey,
 	)
 	return err
-}
-
-func (writer *transcriptProjectionWriter) compactTranscriptEvent(
-	event servicechat.Event,
-	itemKey string,
-	sourceOffset int64,
-	sourceLength int64,
-	turnOrdinal int64,
-) (servicechat.Event, []transcriptContentRef) {
-	event.Native = nil
-	makeRef := func(fieldKind, fieldKey string, contentBytes int) transcriptContentRef {
-		sum := sha256.Sum256([]byte(strings.Join([]string{
-			string(writer.chatID),
-			strconv.FormatInt(turnOrdinal, 10),
-			itemKey,
-			fieldKind,
-			fieldKey,
-		}, "\x00")))
-		return transcriptContentRef{
-			id:           hex.EncodeToString(sum[:16]),
-			fieldKind:    fieldKind,
-			fieldKey:     fieldKey,
-			sourceOffset: sourceOffset,
-			sourceLength: sourceLength,
-			contentBytes: int64(contentBytes),
-		}
-	}
-
-	var refs []transcriptContentRef
-	switch event.Type {
-	case "tool_use_start":
-		if len(event.Input) > transcriptInlineFieldBytes {
-			ref := makeRef("tool_input", "", len(event.Input))
-			refs = append(refs, ref)
-			preview, _ := json.Marshal(map[string]any{
-				"preview":    utf8Prefix(string(event.Input), transcriptInlineFieldBytes),
-				"truncated":  true,
-				"contentRef": ref.id,
-			})
-			event.Input = preview
-		}
-	case "tool_use_end":
-		if len(event.Output) > transcriptInlineFieldBytes {
-			fullBytes := len(event.Output)
-			ref := makeRef("tool_output", "", fullBytes)
-			refs = append(refs, ref)
-			event.Output = utf8Prefix(event.Output, transcriptInlineFieldBytes)
-			event.OutputRef = ref.id
-			event.OutputBytes = int64(fullBytes)
-			event.OutputTruncated = true
-		}
-	case "collaboration":
-		event.Data, refs = compactCollaborationData(event.Data, makeRef)
-	}
-	return event, refs
-}
-
-func compactCollaborationData(
-	raw json.RawMessage,
-	makeRef func(string, string, int) transcriptContentRef,
-) (json.RawMessage, []transcriptContentRef) {
-	var data map[string]any
-	if len(raw) == 0 || json.Unmarshal(raw, &data) != nil {
-		return raw, nil
-	}
-	var refs []transcriptContentRef
-	if tools, ok := data["tools"].([]any); ok {
-		for index, value := range tools {
-			tool, ok := value.(map[string]any)
-			if !ok {
-				continue
-			}
-			key := strconv.Itoa(index)
-			if output, ok := tool["output"].(string); ok && len(output) > transcriptInlineFieldBytes {
-				ref := makeRef("collaboration_tool_output", key, len(output))
-				refs = append(refs, ref)
-				tool["output"] = utf8Prefix(output, transcriptInlineFieldBytes)
-				tool["outputRef"] = ref.id
-				tool["outputBytes"] = len(output)
-				tool["outputTruncated"] = true
-			}
-			if input, exists := tool["input"]; exists {
-				encoded, err := json.Marshal(input)
-				if err == nil && len(encoded) > transcriptInlineFieldBytes {
-					ref := makeRef("collaboration_tool_input", key, len(encoded))
-					refs = append(refs, ref)
-					tool["input"] = map[string]any{
-						"preview":    utf8Prefix(string(encoded), transcriptInlineFieldBytes),
-						"truncated":  true,
-						"contentRef": ref.id,
-					}
-				}
-			}
-		}
-	}
-	if states, ok := data["agentsStates"].(map[string]any); ok {
-		for threadID, value := range states {
-			state, ok := value.(map[string]any)
-			if !ok {
-				continue
-			}
-			if message, ok := state["message"].(string); ok && len(message) > transcriptInlineFieldBytes {
-				ref := makeRef("collaboration_agent_message", threadID, len(message))
-				refs = append(refs, ref)
-				state["message"] = utf8Prefix(message, transcriptInlineFieldBytes)
-				state["messageRef"] = ref.id
-				state["messageBytes"] = len(message)
-				state["messageTruncated"] = true
-			}
-		}
-	}
-	encoded, err := json.Marshal(data)
-	if err != nil {
-		return raw, nil
-	}
-	return encoded, refs
-}
-
-func utf8Prefix(value string, limit int) string {
-	if limit <= 0 || len(value) <= limit {
-		return value
-	}
-	end := limit
-	for end > 0 && !utf8.RuneStart(value[end]) {
-		end--
-	}
-	return value[:end]
 }

--- a/backend/internal/stores/filechat/transcript_projection_writer.go
+++ b/backend/internal/stores/filechat/transcript_projection_writer.go
@@ -1,0 +1,396 @@
+package filechat
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+)
+
+const transcriptInlineFieldBytes = 32 * 1024
+
+type transcriptContentRef struct {
+	id           string
+	fieldKind    string
+	fieldKey     string
+	sourceOffset int64
+	sourceLength int64
+	contentBytes int64
+}
+
+type pendingTranscriptItem struct {
+	event       servicechat.Event
+	itemKey     string
+	startOffset int64
+	endOffset   int64
+	turnOrdinal int64
+	displaySeq  int64
+}
+
+func (writer *chatIndexWriter) indexTranscriptItem(
+	event servicechat.Event,
+	startOffset int64,
+	endOffset int64,
+) error {
+	itemKey, mode, visible := transcriptItemIdentity(event, writer.state.eventOrdinal)
+	if !visible {
+		return nil
+	}
+	if mode == transcriptItemReplace {
+		key := strconv.FormatInt(writer.turn.ordinal, 10) + "\x00" + itemKey
+		displaySeq := event.Seq
+		if pending, exists := writer.pendingTranscriptItems[key]; exists {
+			displaySeq = pending.displaySeq
+		}
+		writer.pendingTranscriptItems[key] = pendingTranscriptItem{
+			event:       event,
+			itemKey:     itemKey,
+			startOffset: startOffset,
+			endOffset:   endOffset,
+			turnOrdinal: writer.turn.ordinal,
+			displaySeq:  displaySeq,
+		}
+		return nil
+	}
+	return writer.persistTranscriptItem(
+		event, itemKey, mode, startOffset, endOffset, writer.turn.ordinal, event.Seq,
+	)
+}
+
+func (writer *chatIndexWriter) flushPendingTranscriptItems() error {
+	keys := make([]string, 0, len(writer.pendingTranscriptItems))
+	for key := range writer.pendingTranscriptItems {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		item := writer.pendingTranscriptItems[key]
+		if err := writer.persistTranscriptItem(
+			item.event,
+			item.itemKey,
+			transcriptItemReplace,
+			item.startOffset,
+			item.endOffset,
+			item.turnOrdinal,
+			item.displaySeq,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (writer *chatIndexWriter) persistTranscriptItem(
+	event servicechat.Event,
+	itemKey string,
+	mode transcriptItemMode,
+	startOffset int64,
+	endOffset int64,
+	turnOrdinal int64,
+	displaySeq int64,
+) error {
+
+	existingStart, existingPayload, found, err := readTranscriptItem(
+		writer.ctx,
+		writer.tx,
+		writer.chatID,
+		turnOrdinal,
+		itemKey,
+		mode == transcriptItemAppend,
+	)
+	if err != nil {
+		return err
+	}
+
+	projected, refs := writer.compactTranscriptEvent(
+		event, itemKey, startOffset, endOffset-startOffset, turnOrdinal,
+	)
+	projected.Seq = displaySeq
+	payload := []servicechat.Event{projected}
+	startSeq := projected.Seq
+	if found {
+		startSeq = existingStart
+		switch mode {
+		case transcriptItemReplace:
+			// Replacement items render at their first occurrence even though
+			// their payload is the latest state snapshot.
+			projected.Seq = existingStart
+			payload[0] = projected
+			if err := deleteTranscriptContentRefs(
+				writer.ctx, writer.tx, writer.chatID, turnOrdinal, itemKey,
+			); err != nil {
+				return err
+			}
+		case transcriptItemAppend:
+			if err := json.Unmarshal(existingPayload, &payload); err != nil {
+				return err
+			}
+			payload = append(payload, projected)
+		}
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := writer.tx.ExecContext(writer.ctx, `
+		INSERT INTO chat_transcript_items
+			(chat_id, turn_ordinal, item_key, start_seq, end_seq,
+			 payload_json, payload_bytes)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(chat_id, turn_ordinal, item_key) DO UPDATE SET
+			end_seq = excluded.end_seq,
+			payload_json = excluded.payload_json,
+			payload_bytes = excluded.payload_bytes`,
+		writer.chatID,
+		turnOrdinal,
+		itemKey,
+		startSeq,
+		event.Seq,
+		payloadJSON,
+		len(payloadJSON),
+	); err != nil {
+		return err
+	}
+	for _, ref := range refs {
+		if _, err := writer.tx.ExecContext(writer.ctx, `
+			INSERT INTO chat_transcript_content_refs
+				(chat_id, content_id, turn_ordinal, item_key, field_kind,
+				 field_key, source_offset, source_length, content_bytes)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(chat_id, content_id) DO UPDATE SET
+				source_offset = excluded.source_offset,
+				source_length = excluded.source_length,
+				content_bytes = excluded.content_bytes`,
+			writer.chatID,
+			ref.id,
+			turnOrdinal,
+			itemKey,
+			ref.fieldKind,
+			ref.fieldKey,
+			ref.sourceOffset,
+			ref.sourceLength,
+			ref.contentBytes,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type transcriptItemMode uint8
+
+const (
+	transcriptItemSingle transcriptItemMode = iota
+	transcriptItemReplace
+	transcriptItemAppend
+)
+
+func transcriptItemIdentity(event servicechat.Event, ordinal int64) (string, transcriptItemMode, bool) {
+	switch event.Type {
+	case "provider_event", "usage_update", "session", "sync", "system", "permission_request":
+		return "", transcriptItemSingle, false
+	case "collaboration":
+		if event.Name == "wait" {
+			return "", transcriptItemSingle, false
+		}
+		if event.ID != "" {
+			return "collaboration:" + event.ID, transcriptItemReplace, true
+		}
+	case "turn_status":
+		return "turn-status", transcriptItemReplace, true
+	case "tool_use_start", "tool_use_end":
+		if event.ID != "" {
+			return "tool:" + event.ID, transcriptItemAppend, true
+		}
+	case "interaction_request", "interaction_resolved":
+		if event.ID != "" {
+			return "interaction:" + event.ID, transcriptItemAppend, true
+		}
+	}
+	return "event:" + strconv.FormatInt(ordinal, 10), transcriptItemSingle, true
+}
+
+func readTranscriptItem(
+	ctx context.Context,
+	tx *sql.Tx,
+	chatID servicechat.ID,
+	turnOrdinal int64,
+	itemKey string,
+	includePayload bool,
+) (int64, []byte, bool, error) {
+	var startSeq int64
+	var payload []byte
+	if !includePayload {
+		err := tx.QueryRowContext(ctx, `
+			SELECT start_seq
+			FROM chat_transcript_items
+			WHERE chat_id = ? AND turn_ordinal = ? AND item_key = ?`,
+			chatID, turnOrdinal, itemKey,
+		).Scan(&startSeq)
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil, false, nil
+		}
+		return startSeq, nil, err == nil, err
+	}
+	err := tx.QueryRowContext(ctx, `
+		SELECT start_seq, payload_json
+		FROM chat_transcript_items
+		WHERE chat_id = ? AND turn_ordinal = ? AND item_key = ?`,
+		chatID, turnOrdinal, itemKey,
+	).Scan(&startSeq, &payload)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil, false, nil
+	}
+	return startSeq, payload, err == nil, err
+}
+
+func deleteTranscriptContentRefs(
+	ctx context.Context,
+	tx *sql.Tx,
+	chatID servicechat.ID,
+	turnOrdinal int64,
+	itemKey string,
+) error {
+	_, err := tx.ExecContext(ctx, `
+		DELETE FROM chat_transcript_content_refs
+		WHERE chat_id = ? AND turn_ordinal = ? AND item_key = ?`,
+		chatID, turnOrdinal, itemKey,
+	)
+	return err
+}
+
+func (writer *chatIndexWriter) compactTranscriptEvent(
+	event servicechat.Event,
+	itemKey string,
+	sourceOffset int64,
+	sourceLength int64,
+	turnOrdinal int64,
+) (servicechat.Event, []transcriptContentRef) {
+	event.Native = nil
+	makeRef := func(fieldKind, fieldKey string, contentBytes int) transcriptContentRef {
+		sum := sha256.Sum256([]byte(strings.Join([]string{
+			string(writer.chatID),
+			strconv.FormatInt(turnOrdinal, 10),
+			itemKey,
+			fieldKind,
+			fieldKey,
+		}, "\x00")))
+		return transcriptContentRef{
+			id:           hex.EncodeToString(sum[:16]),
+			fieldKind:    fieldKind,
+			fieldKey:     fieldKey,
+			sourceOffset: sourceOffset,
+			sourceLength: sourceLength,
+			contentBytes: int64(contentBytes),
+		}
+	}
+
+	var refs []transcriptContentRef
+	switch event.Type {
+	case "tool_use_start":
+		if len(event.Input) > transcriptInlineFieldBytes {
+			ref := makeRef("tool_input", "", len(event.Input))
+			refs = append(refs, ref)
+			preview, _ := json.Marshal(map[string]any{
+				"preview":    utf8Prefix(string(event.Input), transcriptInlineFieldBytes),
+				"truncated":  true,
+				"contentRef": ref.id,
+			})
+			event.Input = preview
+		}
+	case "tool_use_end":
+		if len(event.Output) > transcriptInlineFieldBytes {
+			fullBytes := len(event.Output)
+			ref := makeRef("tool_output", "", fullBytes)
+			refs = append(refs, ref)
+			event.Output = utf8Prefix(event.Output, transcriptInlineFieldBytes)
+			event.OutputRef = ref.id
+			event.OutputBytes = int64(fullBytes)
+			event.OutputTruncated = true
+		}
+	case "collaboration":
+		event.Data, refs = compactCollaborationData(event.Data, makeRef)
+	}
+	return event, refs
+}
+
+func compactCollaborationData(
+	raw json.RawMessage,
+	makeRef func(string, string, int) transcriptContentRef,
+) (json.RawMessage, []transcriptContentRef) {
+	var data map[string]any
+	if len(raw) == 0 || json.Unmarshal(raw, &data) != nil {
+		return raw, nil
+	}
+	var refs []transcriptContentRef
+	if tools, ok := data["tools"].([]any); ok {
+		for index, value := range tools {
+			tool, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			key := strconv.Itoa(index)
+			if output, ok := tool["output"].(string); ok && len(output) > transcriptInlineFieldBytes {
+				ref := makeRef("collaboration_tool_output", key, len(output))
+				refs = append(refs, ref)
+				tool["output"] = utf8Prefix(output, transcriptInlineFieldBytes)
+				tool["outputRef"] = ref.id
+				tool["outputBytes"] = len(output)
+				tool["outputTruncated"] = true
+			}
+			if input, exists := tool["input"]; exists {
+				encoded, err := json.Marshal(input)
+				if err == nil && len(encoded) > transcriptInlineFieldBytes {
+					ref := makeRef("collaboration_tool_input", key, len(encoded))
+					refs = append(refs, ref)
+					tool["input"] = map[string]any{
+						"preview":    utf8Prefix(string(encoded), transcriptInlineFieldBytes),
+						"truncated":  true,
+						"contentRef": ref.id,
+					}
+				}
+			}
+		}
+	}
+	if states, ok := data["agentsStates"].(map[string]any); ok {
+		for threadID, value := range states {
+			state, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			if message, ok := state["message"].(string); ok && len(message) > transcriptInlineFieldBytes {
+				ref := makeRef("collaboration_agent_message", threadID, len(message))
+				refs = append(refs, ref)
+				state["message"] = utf8Prefix(message, transcriptInlineFieldBytes)
+				state["messageRef"] = ref.id
+				state["messageBytes"] = len(message)
+				state["messageTruncated"] = true
+			}
+		}
+	}
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return raw, nil
+	}
+	return encoded, refs
+}
+
+func utf8Prefix(value string, limit int) string {
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	end := limit
+	for end > 0 && !utf8.RuneStart(value[end]) {
+		end--
+	}
+	return value[:end]
+}

--- a/backend/internal/stores/filechat/transcript_projection_writer.go
+++ b/backend/internal/stores/filechat/transcript_projection_writer.go
@@ -35,44 +35,68 @@ type pendingTranscriptItem struct {
 	displaySeq  int64
 }
 
-func (writer *chatIndexWriter) indexTranscriptItem(
+// transcriptProjectionWriter owns materialized items and replacement snapshots
+// within one index checkpoint. The event writer owns the surrounding transaction.
+type transcriptProjectionWriter struct {
+	ctx     context.Context
+	tx      *sql.Tx
+	chatID  servicechat.ID
+	pending map[string]pendingTranscriptItem
+}
+
+func newTranscriptProjectionWriter(
+	ctx context.Context,
+	tx *sql.Tx,
+	chatID servicechat.ID,
+) *transcriptProjectionWriter {
+	return &transcriptProjectionWriter{
+		ctx:     ctx,
+		tx:      tx,
+		chatID:  chatID,
+		pending: make(map[string]pendingTranscriptItem),
+	}
+}
+
+func (writer *transcriptProjectionWriter) indexItem(
 	event servicechat.Event,
+	eventOrdinal int64,
+	turnOrdinal int64,
 	startOffset int64,
 	endOffset int64,
 ) error {
-	itemKey, mode, visible := transcriptItemIdentity(event, writer.state.eventOrdinal)
+	itemKey, mode, visible := transcriptItemIdentity(event, eventOrdinal)
 	if !visible {
 		return nil
 	}
 	if mode == transcriptItemReplace {
-		key := strconv.FormatInt(writer.turn.ordinal, 10) + "\x00" + itemKey
+		key := strconv.FormatInt(turnOrdinal, 10) + "\x00" + itemKey
 		displaySeq := event.Seq
-		if pending, exists := writer.pendingTranscriptItems[key]; exists {
+		if pending, exists := writer.pending[key]; exists {
 			displaySeq = pending.displaySeq
 		}
-		writer.pendingTranscriptItems[key] = pendingTranscriptItem{
+		writer.pending[key] = pendingTranscriptItem{
 			event:       event,
 			itemKey:     itemKey,
 			startOffset: startOffset,
 			endOffset:   endOffset,
-			turnOrdinal: writer.turn.ordinal,
+			turnOrdinal: turnOrdinal,
 			displaySeq:  displaySeq,
 		}
 		return nil
 	}
 	return writer.persistTranscriptItem(
-		event, itemKey, mode, startOffset, endOffset, writer.turn.ordinal, event.Seq,
+		event, itemKey, mode, startOffset, endOffset, turnOrdinal, event.Seq,
 	)
 }
 
-func (writer *chatIndexWriter) flushPendingTranscriptItems() error {
-	keys := make([]string, 0, len(writer.pendingTranscriptItems))
-	for key := range writer.pendingTranscriptItems {
+func (writer *transcriptProjectionWriter) flush() error {
+	keys := make([]string, 0, len(writer.pending))
+	for key := range writer.pending {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		item := writer.pendingTranscriptItems[key]
+		item := writer.pending[key]
 		if err := writer.persistTranscriptItem(
 			item.event,
 			item.itemKey,
@@ -88,7 +112,7 @@ func (writer *chatIndexWriter) flushPendingTranscriptItems() error {
 	return nil
 }
 
-func (writer *chatIndexWriter) persistTranscriptItem(
+func (writer *transcriptProjectionWriter) persistTranscriptItem(
 	event servicechat.Event,
 	itemKey string,
 	mode transcriptItemMode,
@@ -97,7 +121,6 @@ func (writer *chatIndexWriter) persistTranscriptItem(
 	turnOrdinal int64,
 	displaySeq int64,
 ) error {
-
 	existingStart, existingPayload, found, err := readTranscriptItem(
 		writer.ctx,
 		writer.tx,
@@ -268,7 +291,7 @@ func deleteTranscriptContentRefs(
 	return err
 }
 
-func (writer *chatIndexWriter) compactTranscriptEvent(
+func (writer *transcriptProjectionWriter) compactTranscriptEvent(
 	event servicechat.Event,
 	itemKey string,
 	sourceOffset int64,

--- a/backend/internal/stores/stores.go
+++ b/backend/internal/stores/stores.go
@@ -39,6 +39,7 @@ type ChatStore interface {
 	servicechat.Repository
 	servicechat.TranscriptEventSource
 	servicechat.TranscriptEventWindowSource
+	servicechat.TranscriptProjectionSource
 }
 
 type recentChatIndexWarmer interface {

--- a/backend/internal/transport/http/handlers/chat_handler.go
+++ b/backend/internal/transport/http/handlers/chat_handler.go
@@ -114,6 +114,8 @@ func (h *ChatHandler) HandleResource(w http.ResponseWriter, r *http.Request) {
 			h.handleEvents(w, r, id)
 		case "transcript":
 			h.handleTranscript(w, r, id)
+		case "transcript/content":
+			h.handleTranscriptContent(w, r, id)
 		case "rewind":
 			h.handleRewind(w, r, id)
 		case "fork":
@@ -207,7 +209,27 @@ func (h *ChatHandler) handleTranscript(w http.ResponseWriter, r *http.Request, i
 	page, err := h.chats.TranscriptPage(r.Context(), id, servicechat.TranscriptPageQuery{
 		Limit:     intQuery(r, "limit", 0),
 		BeforeSeq: int64Query(r, "before", 0),
+		ByteLimit: intQuery(r, "bytes", 0),
 	})
+	if err != nil {
+		sendChatError(w, err)
+		return
+	}
+	httptransport.SendJSON(w, http.StatusOK, page)
+}
+
+func (h *ChatHandler) handleTranscriptContent(w http.ResponseWriter, r *http.Request, id servicechat.ID) {
+	if r.Method != http.MethodGet {
+		httptransport.SendErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	page, err := h.chats.TranscriptContent(
+		r.Context(),
+		id,
+		strings.TrimSpace(r.URL.Query().Get("id")),
+		int64Query(r, "after", 0),
+		intQuery(r, "bytes", 0),
+	)
 	if err != nil {
 		sendChatError(w, err)
 		return
@@ -372,6 +394,8 @@ func sendChatError(w http.ResponseWriter, err error) {
 		httptransport.SendErr(w, http.StatusBadRequest, err.Error())
 	case errors.Is(err, servicechat.ErrNotFound):
 		httptransport.SendErr(w, http.StatusNotFound, "chat not found")
+	case errors.Is(err, servicechat.ErrTranscriptContentNotFound):
+		httptransport.SendErr(w, http.StatusNotFound, "transcript content not found")
 	case errors.Is(err, servicechat.ErrChatRunning):
 		httptransport.SendErr(w, http.StatusConflict, err.Error())
 	case errors.Is(err, servicechat.ErrProjectMembershipRequired),

--- a/frontend/src/api/chat/chatTranscriptApi.test.ts
+++ b/frontend/src/api/chat/chatTranscriptApi.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { fetchTranscript } from "./chatTranscriptApi.ts";
+import { fetchFullTranscriptContent, fetchTranscript } from "./chatTranscriptApi.ts";
 
 test("fetches and flattens transcript turns without changing cursor metadata", async (t) => {
   const page = {
@@ -46,4 +46,36 @@ test("fetches and flattens transcript turns without changing cursor metadata", a
     lastSeq: 6,
     hasMore: true,
   });
+});
+
+test("loads oversized transcript content through complete cursor pages", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  const requests: string[] = [];
+  globalThis.fetch = async (input) => {
+    requests.push(String(input));
+    if (requests.length === 1) {
+      return Response.json({
+        contentId: "content-1",
+        content: "first ",
+        nextAfter: 6,
+        totalBytes: 12,
+        complete: false,
+      });
+    }
+    return Response.json({
+      contentId: "content-1",
+      content: "second",
+      totalBytes: 12,
+      complete: true,
+    });
+  };
+
+  assert.equal(await fetchFullTranscriptContent("chat/1", "content-1"), "first second");
+  assert.deepEqual(requests, [
+    "/api/chats/chat%2F1/transcript/content?id=content-1",
+    "/api/chats/chat%2F1/transcript/content?id=content-1&after=6",
+  ]);
 });

--- a/frontend/src/api/chat/chatTranscriptApi.ts
+++ b/frontend/src/api/chat/chatTranscriptApi.ts
@@ -1,5 +1,10 @@
 import { API_ROUTES } from "../../config/routes.ts";
-import type { ChatEvent, ChatEventPage } from "../../models/chat.ts";
+import type {
+  ChatEvent,
+  ChatEventPage,
+  TranscriptContentPage,
+  TranscriptIndexProgress,
+} from "../../models/chat.ts";
 import { requestJson } from "../apiRequest.ts";
 
 interface ChatTranscriptTurnPayload {
@@ -14,6 +19,7 @@ interface ChatTranscriptPagePayload {
   nextBefore?: number;
   lastSeq: number;
   hasMore: boolean;
+  indexing?: TranscriptIndexProgress;
 }
 
 export async function fetchTranscript(
@@ -37,5 +43,36 @@ function transcriptPageToEventPage(page: ChatTranscriptPagePayload): ChatEventPa
     nextBefore: page.nextBefore,
     lastSeq: page.lastSeq,
     hasMore: page.hasMore,
+    ...(page.indexing ? { indexing: page.indexing } : {}),
   };
+}
+
+export async function fetchTranscriptContent(
+  chatId: string,
+  contentId: string,
+  after = 0,
+): Promise<TranscriptContentPage> {
+  const search = new URLSearchParams({ id: contentId });
+  if (after > 0) search.set("after", String(after));
+  return requestJson<TranscriptContentPage>(
+    "GET",
+    API_ROUTES.chats.transcriptContent(chatId, search.toString()),
+  );
+}
+
+export async function fetchFullTranscriptContent(
+  chatId: string,
+  contentId: string,
+): Promise<string> {
+  let content = "";
+  let after = 0;
+  for (;;) {
+    const page = await fetchTranscriptContent(chatId, contentId, after);
+    content += page.content;
+    if (page.complete) return content;
+    if (!page.nextAfter || page.nextAfter <= after) {
+      throw new Error("invalid transcript content cursor");
+    }
+    after = page.nextAfter;
+  }
 }

--- a/frontend/src/api/chatApi.ts
+++ b/frontend/src/api/chatApi.ts
@@ -3,7 +3,11 @@ import { chatEventsApi } from "./chat/chatEventsApi";
 import { chatFilesApi } from "./chat/chatFilesApi";
 import { chatHistoryApi } from "./chat/chatHistoryApi";
 import { chatScheduleApi } from "./chat/chatScheduleApi";
-import { fetchTranscript } from "./chat/chatTranscriptApi";
+import {
+  fetchFullTranscriptContent,
+  fetchTranscript,
+  fetchTranscriptContent,
+} from "./chat/chatTranscriptApi";
 import type { ChatMeta, CreateChatInput, UpdateChatInput } from "../models/chat";
 import { API_ROUTES } from "../config/routes";
 
@@ -25,6 +29,8 @@ export const chatApi = {
     requestJson<ChatMeta>("POST", API_ROUTES.chats.fork(id), {}),
   ...chatFilesApi,
   fetchTranscript,
+  fetchTranscriptContent,
+  fetchFullTranscriptContent,
   rewind: chatEventsApi.rewind,
   ...chatHistoryApi,
   ...chatScheduleApi,

--- a/frontend/src/app/containers/ChatContainer.tsx
+++ b/frontend/src/app/containers/ChatContainer.tsx
@@ -36,6 +36,7 @@ export function ChatContainer({
     eventCount,
     hasOlder,
     loadingOlder,
+    indexingProgress,
     status,
     error,
     canSendPrompt,
@@ -202,6 +203,7 @@ export function ChatContainer({
             blocks={blocks}
             hasOlder={hasOlder}
             loadingOlder={loadingOlder}
+            indexingProgress={indexingProgress}
             status={status}
             error={error}
             composer={composerView}

--- a/frontend/src/config/chat.ts
+++ b/frontend/src/config/chat.ts
@@ -1,5 +1,8 @@
 import type { ApprovalPolicy, SandboxPolicy } from "../models/chat";
 
+export const DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS = 6000;
+export const READ_TOOL_OUTPUT_PREVIEW_CHARS = 8000;
+
 export const APPROVAL_POLICY_OPTIONS: readonly {
   value: ApprovalPolicy;
   label: string;

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -27,6 +27,8 @@ export const API_ROUTES = {
       `/api/chats/${encodeURIComponent(id)}/ide-open?path=${encodeURIComponent(path)}`,
     transcript: (id: string, query: string) =>
       `/api/chats/${encodeURIComponent(id)}/transcript${query ? `?${query}` : ""}`,
+    transcriptContent: (id: string, query: string) =>
+      `/api/chats/${encodeURIComponent(id)}/transcript/content?${query}`,
     rewind: (id: string) => `/api/chats/${encodeURIComponent(id)}/rewind`,
     historyRepos: (id: string) =>
       `/api/chats/${encodeURIComponent(id)}/history/repos`,

--- a/frontend/src/dev/preview.tsx
+++ b/frontend/src/dev/preview.tsx
@@ -148,7 +148,7 @@ function Preview() {
           </div>
           <div class="relative min-h-0 flex-1">
             <MessageList
-              status="streaming" blocks={blocks} hasOlder loadingOlder={false} error={null}
+              status="streaming" blocks={blocks} hasOlder loadingOlder={false} indexingProgress={null} error={null}
               chatId="c1" cwd="/opt/remote.futrx/gamerhead"
               scrollRef={scrollRef} contentRef={contentRef} bottomRef={bottomRef}
               onScroll={noop} onAnswerQuestion={noop} onLoadOlder={noopAsync} onRewind={noop}

--- a/frontend/src/models/chat.ts
+++ b/frontend/src/models/chat.ts
@@ -66,7 +66,15 @@ export type ChatEvent = ChatEventBase & (
   | { type: "assistant_text"; text: string; messageId?: string }
   | { type: "thinking"; text: string; messageId?: string }
   | { type: "tool_use_start"; id: string; name: string; input: Record<string, unknown> }
-  | { type: "tool_use_end"; id: string; output?: string; isError?: boolean }
+  | {
+      type: "tool_use_end";
+      id: string;
+      output?: string;
+      outputRef?: string;
+      outputBytes?: number;
+      outputTruncated?: boolean;
+      isError?: boolean;
+    }
   | { type: "permission_request"; id: string; toolName: string; input: Record<string, unknown> }
   | { type: "interaction_request"; id: string; interactionId?: string; name: string; input?: Record<string, unknown> }
   | { type: "interaction_resolved"; id: string; interactionId?: string; name?: string }
@@ -86,6 +94,21 @@ export interface ChatEventPage {
   nextBefore?: number;
   lastSeq: number;
   hasMore: boolean;
+  indexing?: TranscriptIndexProgress;
+}
+
+export interface TranscriptIndexProgress {
+  indexedBytes: number;
+  totalBytes: number;
+  tailSeqKnown: boolean;
+}
+
+export interface TranscriptContentPage {
+  contentId: string;
+  content: string;
+  nextAfter?: number;
+  totalBytes: number;
+  complete: boolean;
 }
 
 export type ClientToServer =

--- a/frontend/src/models/chatMessage.ts
+++ b/frontend/src/models/chatMessage.ts
@@ -8,6 +8,9 @@ export type AssistantMessagePart =
       name: string;
       input: Record<string, unknown>;
       output?: string;
+      outputRef?: string;
+      outputBytes?: number;
+      outputTruncated?: boolean;
       isError?: boolean;
       status: "running" | "done";
     }

--- a/frontend/src/state/hooks/chat/chatMessageBlockBuilder.ts
+++ b/frontend/src/state/hooks/chat/chatMessageBlockBuilder.ts
@@ -60,6 +60,9 @@ class ChatMessageBlockBuilder {
       case "tool_use_end":
         return this.updateTrailingTool(blocks, event.id, {
           output: event.output,
+          ...(event.outputRef ? { outputRef: event.outputRef } : {}),
+          ...(event.outputBytes ? { outputBytes: event.outputBytes } : {}),
+          ...(event.outputTruncated ? { outputTruncated: true } : {}),
           isError: event.isError,
           status: "done",
         });

--- a/frontend/src/state/hooks/chat/transcriptContentPresentation.test.ts
+++ b/frontend/src/state/hooks/chat/transcriptContentPresentation.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fullResponseErrorMessage, fullResponseLabel } from "./transcriptContentPresentation.ts";
+
+test("full response errors always produce a useful message", () => {
+  assert.equal(fullResponseErrorMessage(new Error("network failed")), "network failed");
+  assert.equal(fullResponseErrorMessage("request rejected"), "request rejected");
+  assert.equal(fullResponseErrorMessage({ status: 500 }), "Failed to load the full response.");
+  assert.equal(fullResponseErrorMessage(null), "Failed to load the full response.");
+});
+
+test("full response labels preserve optional sizes and their rounding", () => {
+  assert.equal(fullResponseLabel(false), "Load full response");
+  assert.equal(fullResponseLabel(false, 0), "Load full response");
+  assert.equal(fullResponseLabel(false, 1023), "Load full response (1023 B)");
+  assert.equal(fullResponseLabel(false, 1024), "Load full response (1 KB)");
+  assert.equal(fullResponseLabel(false, 1025), "Load full response (2 KB)");
+  assert.equal(fullResponseLabel(false, 1024 * 1024), "Load full response (1.0 MB)");
+  assert.equal(fullResponseLabel(true, 1024), "Loading full response…");
+});

--- a/frontend/src/state/hooks/chat/transcriptContentPresentation.ts
+++ b/frontend/src/state/hooks/chat/transcriptContentPresentation.ts
@@ -1,0 +1,16 @@
+export function fullResponseErrorMessage(cause: unknown): string {
+  if (cause instanceof Error && cause.message) return cause.message;
+  if (typeof cause === "string" && cause.trim()) return cause;
+  return "Failed to load the full response.";
+}
+
+export function fullResponseLabel(loading: boolean, bytes?: number): string {
+  if (loading) return "Loading full response…";
+  return `Load full response${bytes ? ` (${formatBytes(bytes)})` : ""}`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.ceil(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/frontend/src/state/hooks/chat/useChat.ts
+++ b/frontend/src/state/hooks/chat/useChat.ts
@@ -288,7 +288,9 @@ export function useChat(chatId: string): UseChatResult {
     indexingProgress,
     status,
     error,
-    canSendPrompt: !indexingProgress && wsReady && synced && status === "ready",
+    // A known canonical tail lets the socket synchronize safely even while
+    // older transcript items continue materializing in the background.
+    canSendPrompt: wsReady && synced && status === "ready",
     sendPrompt,
     promptOutcome,
     cancel,

--- a/frontend/src/state/hooks/chat/useChat.ts
+++ b/frontend/src/state/hooks/chat/useChat.ts
@@ -15,6 +15,7 @@ import type {
   ChatRenderState,
   ChatStatus,
   PromptOutcome,
+  TranscriptIndexProgress,
 } from "../../../models/chat";
 import { chatEventStateProjector } from "./chatEventStateProjector";
 import type { ChatMessageBlock } from "../../../models/chatMessage";
@@ -25,6 +26,7 @@ interface UseChatResult {
   eventCount: number;
   hasOlder: boolean;
   loadingOlder: boolean;
+  indexingProgress: TranscriptIndexProgress | null;
   status: ChatStatus;
   error: string | null;
   canSendPrompt: boolean;
@@ -55,6 +57,8 @@ export function useChat(chatId: string): UseChatResult {
   const [synced, setSynced] = useState(false);
   const [promptOutcome, setPromptOutcome] = useState<PromptOutcome | null>(null);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  const [indexingProgress, setIndexingProgress] = useState<TranscriptIndexProgress | null>(null);
+  const [historyReadyForStream, setHistoryReadyForStream] = useState(false);
   const streamRef = useRef<ChatStream | null>(null);
   const pendingEventsRef = useRef<ChatEvent[]>([]);
   const pendingFrameRef = useRef<number | null>(null);
@@ -106,27 +110,51 @@ export function useChat(chatId: string): UseChatResult {
     setSynced(false);
     setPromptOutcome(null);
     setLoadingOlder(false);
+    setIndexingProgress(null);
+    setHistoryReadyForStream(false);
     lastSeqRef.current = 0;
 
     (async () => {
       try {
-        const [m, page] = await Promise.all([
+        const [m, initialPage] = await Promise.all([
           chatApi.fetch(chatId),
           chatApi.fetchTranscript(chatId, {
             limit: CHAT_INITIAL_TRANSCRIPT_TURN_LIMIT,
           }),
         ]);
         if (cancelled) return;
+        let page = initialPage;
         lastSeqRef.current = Math.max(
           page.lastSeq,
           chatEventStateProjector.latestSequence(page.events)
         );
         setRenderState(chatEventStateProjector.fromEvents(page.events, page));
+        setIndexingProgress(page.indexing ?? null);
+        setHistoryReadyForStream(!page.indexing || page.indexing.tailSeqKnown);
         setMeta(m);
         // The server reports whether a run holds the lock right now. Seeding
         // from it keeps queued prompts from firing into a mid-run chat before
         // the socket's sync event corrects the status.
         setStatus(m.running ? "streaming" : "ready");
+
+        while (page.indexing) {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          if (cancelled) return;
+          page = await chatApi.fetchTranscript(chatId, {
+            limit: CHAT_INITIAL_TRANSCRIPT_TURN_LIMIT,
+          });
+          if (cancelled) return;
+          setIndexingProgress(page.indexing ?? null);
+          lastSeqRef.current = Math.max(
+            lastSeqRef.current,
+            page.lastSeq,
+            chatEventStateProjector.latestSequence(page.events),
+          );
+          if (!page.indexing) {
+            setRenderState((current) => chatEventStateProjector.prepend(current, page));
+            setHistoryReadyForStream(true);
+          }
+        }
       } catch (e) {
         if (!cancelled) {
           setError((e as Error).message);
@@ -138,10 +166,11 @@ export function useChat(chatId: string): UseChatResult {
     return () => { cancelled = true; };
   }, [chatId]);
 
-  // Open WS once the latest page is loaded. Reconnects request only events
-  // after the latest sequence this client has already applied.
+  // Open WS once the server knows the canonical tail sequence. Modern legacy
+  // logs can stream while their projection builds; unsequenced logs wait so a
+  // since=0 connection cannot replay the entire raw file.
   useEffect(() => {
-    if (!meta || meta.id !== chatId) return;
+    if (!meta || meta.id !== chatId || !historyReadyForStream) return;
     const streamChatId = meta.id;
     setWsReady(false);
 
@@ -194,7 +223,7 @@ export function useChat(chatId: string): UseChatResult {
       clearPendingEvents();
       stream.close();
     };
-  }, [meta?.id, chatId]);
+  }, [meta?.id, chatId, historyReadyForStream]);
 
   const sendPrompt = useCallback((text: string, clientId?: string) => {
     const stream = streamRef.current;
@@ -256,9 +285,10 @@ export function useChat(chatId: string): UseChatResult {
     eventCount: renderState.eventCount,
     hasOlder: renderState.hasOlder,
     loadingOlder,
+    indexingProgress,
     status,
     error,
-    canSendPrompt: wsReady && synced && status === "ready",
+    canSendPrompt: !indexingProgress && wsReady && synced && status === "ready",
     sendPrompt,
     promptOutcome,
     cancel,

--- a/frontend/src/state/hooks/chat/useTranscriptContent.ts
+++ b/frontend/src/state/hooks/chat/useTranscriptContent.ts
@@ -1,0 +1,54 @@
+import { useState } from "preact/hooks";
+import { fetchFullTranscriptContent } from "../../../api/chat/chatTranscriptApi";
+import { fullResponseErrorMessage, fullResponseLabel } from "./transcriptContentPresentation";
+
+/** Expansion belongs to the mounted detail view, including across prop updates. */
+export function useTranscriptContent({
+  chatId,
+  content,
+  contentRef,
+  contentBytes,
+  inlinePreviewLimit,
+}: {
+  chatId?: string;
+  content?: string;
+  contentRef?: string;
+  contentBytes?: number;
+  inlinePreviewLimit?: number | null;
+}) {
+  const [fullContent, setFullContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const canExpandInline = !contentRef
+    && !!content
+    && inlinePreviewLimit != null
+    && content.length > inlinePreviewLimit;
+
+  async function load() {
+    if (loading) return;
+    if (!contentRef) {
+      if (content) setFullContent(content);
+      return;
+    }
+    if (!chatId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setFullContent(await fetchFullTranscriptContent(chatId, contentRef));
+    } catch (cause) {
+      setError(fullResponseErrorMessage(cause));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return {
+    content: fullContent ?? content,
+    expanded: fullContent !== null,
+    canExpand: (!!contentRef || canExpandInline) && fullContent === null,
+    disabled: (!!contentRef && !chatId) || loading,
+    label: fullResponseLabel(loading, contentBytes),
+    error,
+    load,
+  };
+}

--- a/frontend/src/ui/chat/ChatThread.tsx
+++ b/frontend/src/ui/chat/ChatThread.tsx
@@ -1,5 +1,5 @@
 import type { ComponentChildren, RefObject } from "preact";
-import type { ChatMeta, ChatStatus } from "../../models/chat";
+import type { ChatMeta, ChatStatus, TranscriptIndexProgress } from "../../models/chat";
 import type { ChatMessageBlock } from "../../models/chatMessage";
 import { ChatComposer, type ChatComposerProps } from "./composer/ChatComposer";
 import { JumpToLatestButton } from "./messages/JumpToLatestButton";
@@ -12,6 +12,7 @@ export function ChatThread({
   blocks,
   hasOlder,
   loadingOlder,
+  indexingProgress,
   status,
   error,
   composer,
@@ -33,6 +34,7 @@ export function ChatThread({
   blocks: ChatMessageBlock[];
   hasOlder: boolean;
   loadingOlder: boolean;
+  indexingProgress: TranscriptIndexProgress | null;
   status: ChatStatus;
   error: string | null;
   composer: ChatComposerProps;
@@ -72,6 +74,7 @@ export function ChatThread({
             blocks={blocks}
             hasOlder={hasOlder}
             loadingOlder={loadingOlder}
+            indexingProgress={indexingProgress}
             error={error}
             chatId={chat.id}
             cwd={chat.cwd}

--- a/frontend/src/ui/chat/messages/AssistantPartList.tsx
+++ b/frontend/src/ui/chat/messages/AssistantPartList.tsx
@@ -124,6 +124,9 @@ function renderAssistantParts(
         name={part.name}
         input={part.input}
         output={part.output}
+        outputRef={part.outputRef}
+        outputBytes={part.outputBytes}
+        outputTruncated={part.outputTruncated}
         isError={part.isError}
         status={part.status}
         onAnswerQuestion={context.onAnswerQuestion}

--- a/frontend/src/ui/chat/messages/CollaborationCard.tsx
+++ b/frontend/src/ui/chat/messages/CollaborationCard.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronRight } from "../../primitives/icons";
 import { Markdown } from "../markdown/Markdown";
 import { CodeBlock } from "../tool-calls/CodeBlock";
 import { chatApi } from "../../../api/chatApi";
+import { fullResponseErrorMessage } from "../tool-calls/utils";
 
 type CollaborationPart = Extract<AssistantMessagePart, { kind: "collaboration" }>;
 type SubagentTool = {
@@ -241,7 +242,7 @@ function SubagentToolDetails({ tool, index, chatId }: { tool: SubagentTool; inde
     try {
       setFullOutput(await chatApi.fetchFullTranscriptContent(chatId, tool.outputRef));
     } catch (error) {
-      setOutputError((error as Error).message);
+      setOutputError(fullResponseErrorMessage(error));
     } finally {
       setLoadingOutput(false);
     }
@@ -271,7 +272,7 @@ function SubagentMessage({
     try {
       setFullMessage(await chatApi.fetchFullTranscriptContent(chatId, messageRef));
     } catch (loadError) {
-      setError((loadError as Error).message);
+      setError(fullResponseErrorMessage(loadError));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/ui/chat/messages/CollaborationCard.tsx
+++ b/frontend/src/ui/chat/messages/CollaborationCard.tsx
@@ -3,6 +3,7 @@ import { useState } from "preact/hooks";
 import { ChevronDown, ChevronRight } from "../../primitives/icons";
 import { Markdown } from "../markdown/Markdown";
 import { CodeBlock } from "../tool-calls/CodeBlock";
+import { chatApi } from "../../../api/chatApi";
 
 type CollaborationPart = Extract<AssistantMessagePart, { kind: "collaboration" }>;
 type SubagentTool = {
@@ -12,6 +13,8 @@ type SubagentTool = {
   isError: boolean;
   input?: unknown;
   output?: string;
+  outputRef?: string;
+  outputBytes?: number;
   startedAt?: number;
   completedAt?: number;
   durationMs?: number;
@@ -75,6 +78,7 @@ export function CollaborationCard({
             tools={tools}
             toolCount={toolCount}
             failedToolCount={failedToolCount}
+            chatId={chatId}
           />
         )}
         {Object.entries(states).length === 0 ? (
@@ -88,9 +92,13 @@ export function CollaborationCard({
                 <span class="text-[10px] text-ink-400">{typeof state.status === "string" ? state.status : "unknown"}</span>
               </div>
               {typeof state.message === "string" && state.message && (
-                <div class="codex-prose mt-2 text-[12px] leading-relaxed text-ink-200">
-                  <Markdown chatId={chatId} cwd={cwd}>{state.message}</Markdown>
-                </div>
+                <SubagentMessage
+                  message={state.message}
+                  messageRef={typeof state.messageRef === "string" ? state.messageRef : undefined}
+                  messageBytes={typeof state.messageBytes === "number" ? state.messageBytes : undefined}
+                  chatId={chatId}
+                  cwd={cwd}
+                />
               )}
               {isSubagentThread && !(typeof state.message === "string" && state.message) && (
                 <div class="mt-2 text-[11px] text-ink-400">
@@ -109,10 +117,12 @@ function SubagentTools({
   tools,
   toolCount,
   failedToolCount,
+  chatId,
 }: {
   tools: SubagentTool[];
   toolCount: number;
   failedToolCount: number;
+  chatId?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
   const toolNames = unique(tools.map((tool) => tool.name));
@@ -144,7 +154,7 @@ function SubagentTools({
       {expanded && (
         <ol class="divide-y divide-line border-t border-line bg-inset">
           {tools.map((tool, index) => (
-            <SubagentToolDetails key={tool.id || `${tool.name}-${index}`} tool={tool} index={index} />
+            <SubagentToolDetails key={tool.id || `${tool.name}-${index}`} tool={tool} index={index} chatId={chatId} />
           ))}
         </ol>
       )}
@@ -152,8 +162,11 @@ function SubagentTools({
   );
 }
 
-function SubagentToolDetails({ tool, index }: { tool: SubagentTool; index: number }) {
+function SubagentToolDetails({ tool, index, chatId }: { tool: SubagentTool; index: number; chatId?: string }) {
   const [expanded, setExpanded] = useState(false);
+  const [fullOutput, setFullOutput] = useState<string | null>(null);
+  const [loadingOutput, setLoadingOutput] = useState(false);
+  const [outputError, setOutputError] = useState<string | null>(null);
   const hasDetails = tool.input !== undefined || tool.output !== undefined;
   const timing = toolTiming(tool);
   return (
@@ -200,12 +213,86 @@ function SubagentToolDetails({ tool, index }: { tool: SubagentTool; index: numbe
           {tool.output !== undefined && (
             <div>
               <div class="bg-tint px-3 py-1 text-[10px] font-medium text-ink-400">Output</div>
-              <CodeBlock text={tool.output} />
+              <CodeBlock text={fullOutput ?? tool.output} />
+              {tool.outputRef && fullOutput === null && (
+                <div class="flex items-center gap-2 border-t border-line px-3 py-2 text-[10px]">
+                  <button
+                    type="button"
+                    disabled={!chatId || loadingOutput}
+                    onClick={() => void loadOutput()}
+                    class="text-accent-blue hover:underline disabled:opacity-50"
+                  >
+                    {loadingOutput ? "Loading full response…" : `Load full response${tool.outputBytes ? ` (${formatBytes(tool.outputBytes)})` : ""}`}
+                  </button>
+                  {outputError && <span class="text-accent-red">{outputError}</span>}
+                </div>
+              )}
             </div>
           )}
         </div>
       )}
     </li>
+  );
+
+  async function loadOutput() {
+    if (!chatId || !tool.outputRef || loadingOutput) return;
+    setLoadingOutput(true);
+    setOutputError(null);
+    try {
+      setFullOutput(await chatApi.fetchFullTranscriptContent(chatId, tool.outputRef));
+    } catch (error) {
+      setOutputError((error as Error).message);
+    } finally {
+      setLoadingOutput(false);
+    }
+  }
+}
+
+function SubagentMessage({
+  message,
+  messageRef,
+  messageBytes,
+  chatId,
+  cwd,
+}: {
+  message: string;
+  messageRef?: string;
+  messageBytes?: number;
+  chatId?: string;
+  cwd?: string;
+}) {
+  const [fullMessage, setFullMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  async function loadMessage() {
+    if (!chatId || !messageRef || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setFullMessage(await chatApi.fetchFullTranscriptContent(chatId, messageRef));
+    } catch (loadError) {
+      setError((loadError as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }
+  return (
+    <div class="codex-prose mt-2 text-[12px] leading-relaxed text-ink-200">
+      <Markdown chatId={chatId} cwd={cwd}>{fullMessage ?? message}</Markdown>
+      {messageRef && fullMessage === null && (
+        <div class="mt-2 flex items-center gap-2 text-[10px]">
+          <button
+            type="button"
+            disabled={!chatId || loading}
+            onClick={() => void loadMessage()}
+            class="text-accent-blue hover:underline disabled:opacity-50"
+          >
+            {loading ? "Loading full response…" : `Load full response${messageBytes ? ` (${formatBytes(messageBytes)})` : ""}`}
+          </button>
+          {error && <span class="text-accent-red">{error}</span>}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -244,11 +331,19 @@ function subagentTools(value: unknown): SubagentTool[] {
       isError: item.isError === true,
       input: item.input,
       output: typeof item.output === "string" ? item.output : undefined,
+      outputRef: typeof item.outputRef === "string" ? item.outputRef : undefined,
+      outputBytes: typeof item.outputBytes === "number" ? item.outputBytes : undefined,
       startedAt: typeof item.startedAt === "number" ? item.startedAt : undefined,
       completedAt: typeof item.completedAt === "number" ? item.completedAt : undefined,
       durationMs: typeof item.durationMs === "number" ? item.durationMs : undefined,
     }];
   });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.ceil(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function formatToolInput(input: unknown): string {

--- a/frontend/src/ui/chat/messages/CollaborationCard.tsx
+++ b/frontend/src/ui/chat/messages/CollaborationCard.tsx
@@ -3,8 +3,7 @@ import { useState } from "preact/hooks";
 import { ChevronDown, ChevronRight } from "../../primitives/icons";
 import { Markdown } from "../markdown/Markdown";
 import { CodeBlock } from "../tool-calls/CodeBlock";
-import { chatApi } from "../../../api/chatApi";
-import { fullResponseErrorMessage } from "../tool-calls/utils";
+import { useTranscriptContent } from "../../../state/hooks/chat/useTranscriptContent";
 
 type CollaborationPart = Extract<AssistantMessagePart, { kind: "collaboration" }>;
 type SubagentTool = {
@@ -165,9 +164,12 @@ function SubagentTools({
 
 function SubagentToolDetails({ tool, index, chatId }: { tool: SubagentTool; index: number; chatId?: string }) {
   const [expanded, setExpanded] = useState(false);
-  const [fullOutput, setFullOutput] = useState<string | null>(null);
-  const [loadingOutput, setLoadingOutput] = useState(false);
-  const [outputError, setOutputError] = useState<string | null>(null);
+  const response = useTranscriptContent({
+    chatId,
+    content: tool.output,
+    contentRef: tool.outputRef,
+    contentBytes: tool.outputBytes,
+  });
   const hasDetails = tool.input !== undefined || tool.output !== undefined;
   const timing = toolTiming(tool);
   return (
@@ -214,18 +216,18 @@ function SubagentToolDetails({ tool, index, chatId }: { tool: SubagentTool; inde
           {tool.output !== undefined && (
             <div>
               <div class="bg-tint px-3 py-1 text-[10px] font-medium text-ink-400">Output</div>
-              <CodeBlock text={fullOutput ?? tool.output} />
-              {tool.outputRef && fullOutput === null && (
+              <CodeBlock text={response.content ?? tool.output} />
+              {response.canExpand && (
                 <div class="flex items-center gap-2 border-t border-line px-3 py-2 text-[10px]">
                   <button
                     type="button"
-                    disabled={!chatId || loadingOutput}
-                    onClick={() => void loadOutput()}
+                    disabled={response.disabled}
+                    onClick={() => void response.load()}
                     class="text-accent-blue hover:underline disabled:opacity-50"
                   >
-                    {loadingOutput ? "Loading full response…" : `Load full response${tool.outputBytes ? ` (${formatBytes(tool.outputBytes)})` : ""}`}
+                    {response.label}
                   </button>
-                  {outputError && <span class="text-accent-red">{outputError}</span>}
+                  {response.error && <span class="text-accent-red">{response.error}</span>}
                 </div>
               )}
             </div>
@@ -234,19 +236,6 @@ function SubagentToolDetails({ tool, index, chatId }: { tool: SubagentTool; inde
       )}
     </li>
   );
-
-  async function loadOutput() {
-    if (!chatId || !tool.outputRef || loadingOutput) return;
-    setLoadingOutput(true);
-    setOutputError(null);
-    try {
-      setFullOutput(await chatApi.fetchFullTranscriptContent(chatId, tool.outputRef));
-    } catch (error) {
-      setOutputError(fullResponseErrorMessage(error));
-    } finally {
-      setLoadingOutput(false);
-    }
-  }
 }
 
 function SubagentMessage({
@@ -262,35 +251,26 @@ function SubagentMessage({
   chatId?: string;
   cwd?: string;
 }) {
-  const [fullMessage, setFullMessage] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  async function loadMessage() {
-    if (!chatId || !messageRef || loading) return;
-    setLoading(true);
-    setError(null);
-    try {
-      setFullMessage(await chatApi.fetchFullTranscriptContent(chatId, messageRef));
-    } catch (loadError) {
-      setError(fullResponseErrorMessage(loadError));
-    } finally {
-      setLoading(false);
-    }
-  }
+  const response = useTranscriptContent({
+    chatId,
+    content: message,
+    contentRef: messageRef,
+    contentBytes: messageBytes,
+  });
   return (
     <div class="codex-prose mt-2 text-[12px] leading-relaxed text-ink-200">
-      <Markdown chatId={chatId} cwd={cwd}>{fullMessage ?? message}</Markdown>
-      {messageRef && fullMessage === null && (
+      <Markdown chatId={chatId} cwd={cwd}>{response.content ?? message}</Markdown>
+      {response.canExpand && (
         <div class="mt-2 flex items-center gap-2 text-[10px]">
           <button
             type="button"
-            disabled={!chatId || loading}
-            onClick={() => void loadMessage()}
+            disabled={response.disabled}
+            onClick={() => void response.load()}
             class="text-accent-blue hover:underline disabled:opacity-50"
           >
-            {loading ? "Loading full response…" : `Load full response${messageBytes ? ` (${formatBytes(messageBytes)})` : ""}`}
+            {response.label}
           </button>
-          {error && <span class="text-accent-red">{error}</span>}
+          {response.error && <span class="text-accent-red">{response.error}</span>}
         </div>
       )}
     </div>
@@ -339,12 +319,6 @@ function subagentTools(value: unknown): SubagentTool[] {
       durationMs: typeof item.durationMs === "number" ? item.durationMs : undefined,
     }];
   });
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${Math.ceil(bytes / 1024)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function formatToolInput(input: unknown): string {

--- a/frontend/src/ui/chat/messages/MessageList.tsx
+++ b/frontend/src/ui/chat/messages/MessageList.tsx
@@ -1,6 +1,6 @@
 import type { RefObject } from "preact";
 import { useEffect, useMemo, useState } from "preact/hooks";
-import type { ChatStatus } from "../../../models/chat";
+import type { ChatStatus, TranscriptIndexProgress } from "../../../models/chat";
 import type { ChatMessageBlock } from "../../../models/chatMessage";
 import { MessageBlock } from "./MessageBlock";
 import { MessageSkeleton } from "./MessageSkeleton";
@@ -15,6 +15,7 @@ export function MessageList({
   blocks,
   hasOlder,
   loadingOlder,
+  indexingProgress,
   error,
   chatId,
   cwd,
@@ -31,6 +32,7 @@ export function MessageList({
   blocks: ChatMessageBlock[];
   hasOlder: boolean;
   loadingOlder: boolean;
+  indexingProgress: TranscriptIndexProgress | null;
   error: string | null;
   chatId: string;
   cwd?: string;
@@ -82,7 +84,13 @@ export function MessageList({
       <div ref={contentRef} class="mx-auto w-full min-w-0 max-w-[54rem] space-y-5 md:space-y-6">
         {status === "loading" && <MessageSkeleton />}
 
-        {status !== "loading" && blocks.length === 0 && <ThreadEmptyState cwd={cwd} />}
+        {indexingProgress && (
+          <div class="rounded-card border border-line bg-surface p-4 text-[13px] text-ink-300">
+            Preparing conversation… {indexPercent(indexingProgress)}%
+          </div>
+        )}
+
+        {status !== "loading" && blocks.length === 0 && !indexingProgress && <ThreadEmptyState cwd={cwd} />}
 
         {(hiddenCount > 0 || hasOlder) && (
           <div class="flex justify-center">
@@ -127,4 +135,9 @@ export function MessageList({
       </div>
     </div>
   );
+}
+
+function indexPercent(progress: TranscriptIndexProgress): number {
+  if (progress.totalBytes <= 0) return 0;
+  return Math.min(99, Math.floor((progress.indexedBytes / progress.totalBytes) * 100));
 }

--- a/frontend/src/ui/chat/messages/ToolGroup.tsx
+++ b/frontend/src/ui/chat/messages/ToolGroup.tsx
@@ -37,6 +37,9 @@ export function ToolGroup({
             name={part.name}
             input={part.input}
             output={part.output}
+            outputRef={part.outputRef}
+            outputBytes={part.outputBytes}
+            outputTruncated={part.outputTruncated}
             isError={part.isError}
             status={part.status}
             onAnswerQuestion={onAnswerQuestion}

--- a/frontend/src/ui/chat/tool-calls/ToolCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/ToolCall.tsx
@@ -8,6 +8,7 @@ import { GenericCall } from "./renderers/GenericCall";
 import { ReadCall } from "./renderers/ReadCall";
 import { SearchCall } from "./renderers/SearchCall";
 import { WriteCall } from "./renderers/WriteCall";
+import { fullResponseErrorMessage, toolOutputPreviewLimit } from "./utils";
 
 export function ToolCall(props: ToolCallProps) {
   const {
@@ -23,7 +24,11 @@ export function ToolCall(props: ToolCallProps) {
   const [fullOutput, setFullOutput] = useState<string | null>(null);
   const [loadingOutput, setLoadingOutput] = useState(false);
   const [outputError, setOutputError] = useState<string | null>(null);
-  const canExpandInline = !outputRef && !!output && output.length > 6000;
+  const previewLimit = toolOutputPreviewLimit(name);
+  const canExpandInline = !outputRef
+    && !!output
+    && previewLimit !== null
+    && output.length > previewLimit;
 
   if (name === "AskUserQuestion" && toolUseId && chatId && onAnswerQuestion) {
     return (
@@ -76,7 +81,7 @@ export function ToolCall(props: ToolCallProps) {
     try {
       setFullOutput(await chatApi.fetchFullTranscriptContent(chatId, outputRef));
     } catch (error) {
-      setOutputError((error as Error).message);
+      setOutputError(fullResponseErrorMessage(error));
     } finally {
       setLoadingOutput(false);
     }

--- a/frontend/src/ui/chat/tool-calls/ToolCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/ToolCall.tsx
@@ -1,5 +1,7 @@
 import { AskUserQuestion } from "./ask-user-question/AskUserQuestion";
 import type { AskInput, ToolCallProps } from "./ToolCallTypes";
+import { useState } from "preact/hooks";
+import { chatApi } from "../../../api/chatApi";
 import { BashCall } from "./renderers/BashCall";
 import { EditCall } from "./renderers/EditCall";
 import { GenericCall } from "./renderers/GenericCall";
@@ -7,7 +9,22 @@ import { ReadCall } from "./renderers/ReadCall";
 import { SearchCall } from "./renderers/SearchCall";
 import { WriteCall } from "./renderers/WriteCall";
 
-export function ToolCall({ toolUseId, chatId, name, input, output, isError, status, onAnswerQuestion }: ToolCallProps) {
+export function ToolCall(props: ToolCallProps) {
+  const {
+    toolUseId,
+    chatId,
+    name,
+    input,
+    output,
+    outputRef,
+    outputBytes,
+    onAnswerQuestion,
+  } = props;
+  const [fullOutput, setFullOutput] = useState<string | null>(null);
+  const [loadingOutput, setLoadingOutput] = useState(false);
+  const [outputError, setOutputError] = useState<string | null>(null);
+  const canExpandInline = !outputRef && !!output && output.length > 6000;
+
   if (name === "AskUserQuestion" && toolUseId && chatId && onAnswerQuestion) {
     return (
       <AskUserQuestion
@@ -19,20 +36,74 @@ export function ToolCall({ toolUseId, chatId, name, input, output, isError, stat
     );
   }
 
+  const rendererProps = {
+    ...props,
+    output: fullOutput ?? output,
+    outputExpanded: fullOutput !== null,
+  };
+  let rendered;
   switch (name) {
     case "Read":
-      return <ReadCall input={input} output={output} status={status} isError={isError} />;
+      rendered = <ReadCall {...rendererProps} />;
+      break;
     case "Edit":
     case "MultiEdit":
-      return <EditCall input={input} output={output} status={status} isError={isError} />;
+      rendered = <EditCall {...rendererProps} />;
+      break;
     case "Write":
-      return <WriteCall input={input} output={output} status={status} isError={isError} />;
+      rendered = <WriteCall {...rendererProps} />;
+      break;
     case "Bash":
-      return <BashCall input={input} output={output} status={status} isError={isError} />;
+      rendered = <BashCall {...rendererProps} />;
+      break;
     case "Glob":
     case "Grep":
-      return <SearchCall name={name} input={input} output={output} status={status} isError={isError} />;
+      rendered = <SearchCall {...rendererProps} />;
+      break;
     default:
-      return <GenericCall name={name} input={input} output={output} status={status} isError={isError} />;
+      rendered = <GenericCall {...rendererProps} />;
   }
+
+  async function loadFullOutput() {
+    if (loadingOutput) return;
+    if (!outputRef) {
+      if (output) setFullOutput(output);
+      return;
+    }
+    if (!chatId) return;
+    setLoadingOutput(true);
+    setOutputError(null);
+    try {
+      setFullOutput(await chatApi.fetchFullTranscriptContent(chatId, outputRef));
+    } catch (error) {
+      setOutputError((error as Error).message);
+    } finally {
+      setLoadingOutput(false);
+    }
+  }
+
+  return (
+    <>
+      {rendered}
+      {(outputRef || canExpandInline) && fullOutput === null && (
+        <div class="-mt-1 mb-2 flex items-center gap-2 px-2 text-[11px]">
+          <button
+            type="button"
+            disabled={(!!outputRef && !chatId) || loadingOutput}
+            onClick={() => void loadFullOutput()}
+            class="text-accent-blue hover:underline disabled:opacity-50"
+          >
+            {loadingOutput ? "Loading full response…" : `Load full response${outputBytes ? ` (${formatBytes(outputBytes)})` : ""}`}
+          </button>
+          {outputError && <span class="text-accent-red">{outputError}</span>}
+        </div>
+      )}
+    </>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.ceil(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/frontend/src/ui/chat/tool-calls/ToolCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/ToolCall.tsx
@@ -1,14 +1,13 @@
 import { AskUserQuestion } from "./ask-user-question/AskUserQuestion";
 import type { AskInput, ToolCallProps } from "./ToolCallTypes";
-import { useState } from "preact/hooks";
-import { chatApi } from "../../../api/chatApi";
+import { useTranscriptContent } from "../../../state/hooks/chat/useTranscriptContent";
 import { BashCall } from "./renderers/BashCall";
 import { EditCall } from "./renderers/EditCall";
 import { GenericCall } from "./renderers/GenericCall";
 import { ReadCall } from "./renderers/ReadCall";
 import { SearchCall } from "./renderers/SearchCall";
 import { WriteCall } from "./renderers/WriteCall";
-import { fullResponseErrorMessage, toolOutputPreviewLimit } from "./utils";
+import { toolOutputPreviewLimit } from "./utils";
 
 export function ToolCall(props: ToolCallProps) {
   const {
@@ -21,14 +20,13 @@ export function ToolCall(props: ToolCallProps) {
     outputBytes,
     onAnswerQuestion,
   } = props;
-  const [fullOutput, setFullOutput] = useState<string | null>(null);
-  const [loadingOutput, setLoadingOutput] = useState(false);
-  const [outputError, setOutputError] = useState<string | null>(null);
-  const previewLimit = toolOutputPreviewLimit(name);
-  const canExpandInline = !outputRef
-    && !!output
-    && previewLimit !== null
-    && output.length > previewLimit;
+  const response = useTranscriptContent({
+    chatId,
+    content: output,
+    contentRef: outputRef,
+    contentBytes: outputBytes,
+    inlinePreviewLimit: toolOutputPreviewLimit(name),
+  });
 
   if (name === "AskUserQuestion" && toolUseId && chatId && onAnswerQuestion) {
     return (
@@ -43,8 +41,8 @@ export function ToolCall(props: ToolCallProps) {
 
   const rendererProps = {
     ...props,
-    output: fullOutput ?? output,
-    outputExpanded: fullOutput !== null,
+    output: response.content,
+    outputExpanded: response.expanded,
   };
   let rendered;
   switch (name) {
@@ -69,46 +67,22 @@ export function ToolCall(props: ToolCallProps) {
       rendered = <GenericCall {...rendererProps} />;
   }
 
-  async function loadFullOutput() {
-    if (loadingOutput) return;
-    if (!outputRef) {
-      if (output) setFullOutput(output);
-      return;
-    }
-    if (!chatId) return;
-    setLoadingOutput(true);
-    setOutputError(null);
-    try {
-      setFullOutput(await chatApi.fetchFullTranscriptContent(chatId, outputRef));
-    } catch (error) {
-      setOutputError(fullResponseErrorMessage(error));
-    } finally {
-      setLoadingOutput(false);
-    }
-  }
-
   return (
     <>
       {rendered}
-      {(outputRef || canExpandInline) && fullOutput === null && (
+      {response.canExpand && (
         <div class="-mt-1 mb-2 flex items-center gap-2 px-2 text-[11px]">
           <button
             type="button"
-            disabled={(!!outputRef && !chatId) || loadingOutput}
-            onClick={() => void loadFullOutput()}
+            disabled={response.disabled}
+            onClick={() => void response.load()}
             class="text-accent-blue hover:underline disabled:opacity-50"
           >
-            {loadingOutput ? "Loading full response…" : `Load full response${outputBytes ? ` (${formatBytes(outputBytes)})` : ""}`}
+            {response.label}
           </button>
-          {outputError && <span class="text-accent-red">{outputError}</span>}
+          {response.error && <span class="text-accent-red">{response.error}</span>}
         </div>
       )}
     </>
   );
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${Math.ceil(bytes / 1024)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/frontend/src/ui/chat/tool-calls/ToolCallTypes.ts
+++ b/frontend/src/ui/chat/tool-calls/ToolCallTypes.ts
@@ -13,6 +13,10 @@ export interface ToolCallProps {
   name: string;
   input: Record<string, unknown> | undefined;
   output?: string;
+  outputRef?: string;
+  outputBytes?: number;
+  outputTruncated?: boolean;
+  outputExpanded?: boolean;
   isError?: boolean;
   status: "running" | "done";
   onAnswerQuestion?: (text: string) => void;

--- a/frontend/src/ui/chat/tool-calls/renderers/BashCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/BashCall.tsx
@@ -2,7 +2,8 @@ import { TerminalIcon } from "../../../primitives/icons";
 import type { ToolCallProps } from "../ToolCallTypes";
 import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
-import { DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS, truncate } from "../utils";
+import { DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS } from "../../../../config/chat";
+import { truncate } from "../utils";
 
 export function BashCall({ input, output, outputExpanded, status, isError }: Omit<ToolCallProps, "name">) {
   const command = (input?.command as string) ?? "";

--- a/frontend/src/ui/chat/tool-calls/renderers/BashCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/BashCall.tsx
@@ -4,7 +4,7 @@ import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
 import { truncate } from "../utils";
 
-export function BashCall({ input, output, status, isError }: Omit<ToolCallProps, "name">) {
+export function BashCall({ input, output, outputExpanded, status, isError }: Omit<ToolCallProps, "name">) {
   const command = (input?.command as string) ?? "";
   const description = (input?.description as string) ?? "";
   return (
@@ -15,7 +15,7 @@ export function BashCall({ input, output, status, isError }: Omit<ToolCallProps,
       status={status}
       isError={isError}
     >
-      {output ? <CodeBlock text={truncate(output, 6000)} /> : null}
+      {output ? <CodeBlock text={outputExpanded ? output : truncate(output, 6000)} /> : null}
     </ToolShell>
   );
 }

--- a/frontend/src/ui/chat/tool-calls/renderers/BashCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/BashCall.tsx
@@ -2,7 +2,7 @@ import { TerminalIcon } from "../../../primitives/icons";
 import type { ToolCallProps } from "../ToolCallTypes";
 import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
-import { truncate } from "../utils";
+import { DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS, truncate } from "../utils";
 
 export function BashCall({ input, output, outputExpanded, status, isError }: Omit<ToolCallProps, "name">) {
   const command = (input?.command as string) ?? "";
@@ -15,7 +15,7 @@ export function BashCall({ input, output, outputExpanded, status, isError }: Omi
       status={status}
       isError={isError}
     >
-      {output ? <CodeBlock text={outputExpanded ? output : truncate(output, 6000)} /> : null}
+      {output ? <CodeBlock text={outputExpanded ? output : truncate(output, DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS)} /> : null}
     </ToolShell>
   );
 }

--- a/frontend/src/ui/chat/tool-calls/renderers/EditCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/EditCall.tsx
@@ -5,7 +5,7 @@ import type { ToolCallProps } from "../ToolCallTypes";
 import { ToolShell } from "../ToolShell";
 import { shortPath } from "../utils";
 
-export function EditCall({ input, output, status, isError }: Omit<ToolCallProps, "name">) {
+export function EditCall({ input, output, outputExpanded, status, isError }: Omit<ToolCallProps, "name">) {
   const path = (input?.file_path as string) ?? "";
   const oldStr = (input?.old_string as string) ?? "";
   const newStr = (input?.new_string as string) ?? "";
@@ -45,7 +45,9 @@ export function EditCall({ input, output, status, isError }: Omit<ToolCallProps,
           </pre>
         ))}
       </div>
-      {output && isError ? <div class="p-3 text-accent-red font-mono text-xs">{output}</div> : null}
+      {output && (isError || outputExpanded) ? (
+        <div class={`p-3 font-mono text-xs ${isError ? "text-accent-red" : "text-ink-300"}`}>{output}</div>
+      ) : null}
     </ToolShell>
   );
 }

--- a/frontend/src/ui/chat/tool-calls/renderers/GenericCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/GenericCall.tsx
@@ -2,7 +2,7 @@ import { TerminalIcon } from "../../../primitives/icons";
 import type { ToolCallProps } from "../ToolCallTypes";
 import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
-import { truncate } from "../utils";
+import { DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS, truncate } from "../utils";
 
 export function GenericCall({ name, input, output, outputExpanded, status, isError }: ToolCallProps) {
   return (
@@ -22,7 +22,7 @@ export function GenericCall({ name, input, output, outputExpanded, status, isErr
         {output && (
           <div>
             <div class="px-3 py-1 text-[11px] text-ink-300 bg-tint">Output</div>
-            <CodeBlock text={outputExpanded ? output : truncate(output, 6000)} />
+            <CodeBlock text={outputExpanded ? output : truncate(output, DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS)} />
           </div>
         )}
       </div>

--- a/frontend/src/ui/chat/tool-calls/renderers/GenericCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/GenericCall.tsx
@@ -2,7 +2,8 @@ import { TerminalIcon } from "../../../primitives/icons";
 import type { ToolCallProps } from "../ToolCallTypes";
 import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
-import { DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS, truncate } from "../utils";
+import { DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS } from "../../../../config/chat";
+import { truncate } from "../utils";
 
 export function GenericCall({ name, input, output, outputExpanded, status, isError }: ToolCallProps) {
   return (

--- a/frontend/src/ui/chat/tool-calls/renderers/GenericCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/GenericCall.tsx
@@ -4,7 +4,7 @@ import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
 import { truncate } from "../utils";
 
-export function GenericCall({ name, input, output, status, isError }: ToolCallProps) {
+export function GenericCall({ name, input, output, outputExpanded, status, isError }: ToolCallProps) {
   return (
     <ToolShell
       icon={<TerminalIcon class="w-4 h-4" />}
@@ -22,7 +22,7 @@ export function GenericCall({ name, input, output, status, isError }: ToolCallPr
         {output && (
           <div>
             <div class="px-3 py-1 text-[11px] text-ink-300 bg-tint">Output</div>
-            <CodeBlock text={truncate(output, 6000)} />
+            <CodeBlock text={outputExpanded ? output : truncate(output, 6000)} />
           </div>
         )}
       </div>

--- a/frontend/src/ui/chat/tool-calls/renderers/ReadCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/ReadCall.tsx
@@ -2,7 +2,7 @@ import { File } from "../../../primitives/icons";
 import type { ToolCallProps } from "../ToolCallTypes";
 import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
-import { shortPath, truncate } from "../utils";
+import { READ_TOOL_OUTPUT_PREVIEW_CHARS, shortPath, truncate } from "../utils";
 
 export function ReadCall({ input, output, outputExpanded, status, isError }: Omit<ToolCallProps, "name">) {
   const path = (input?.file_path as string) ?? "";
@@ -13,7 +13,7 @@ export function ReadCall({ input, output, outputExpanded, status, isError }: Omi
       status={status}
       isError={isError}
     >
-      {output ? <CodeBlock text={outputExpanded ? output : truncate(output, 8000)} /> : null}
+      {output ? <CodeBlock text={outputExpanded ? output : truncate(output, READ_TOOL_OUTPUT_PREVIEW_CHARS)} /> : null}
     </ToolShell>
   );
 }

--- a/frontend/src/ui/chat/tool-calls/renderers/ReadCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/ReadCall.tsx
@@ -2,7 +2,8 @@ import { File } from "../../../primitives/icons";
 import type { ToolCallProps } from "../ToolCallTypes";
 import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
-import { READ_TOOL_OUTPUT_PREVIEW_CHARS, shortPath, truncate } from "../utils";
+import { READ_TOOL_OUTPUT_PREVIEW_CHARS } from "../../../../config/chat";
+import { shortPath, truncate } from "../utils";
 
 export function ReadCall({ input, output, outputExpanded, status, isError }: Omit<ToolCallProps, "name">) {
   const path = (input?.file_path as string) ?? "";

--- a/frontend/src/ui/chat/tool-calls/renderers/ReadCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/ReadCall.tsx
@@ -4,7 +4,7 @@ import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
 import { shortPath, truncate } from "../utils";
 
-export function ReadCall({ input, output, status, isError }: Omit<ToolCallProps, "name">) {
+export function ReadCall({ input, output, outputExpanded, status, isError }: Omit<ToolCallProps, "name">) {
   const path = (input?.file_path as string) ?? "";
   return (
     <ToolShell
@@ -13,7 +13,7 @@ export function ReadCall({ input, output, status, isError }: Omit<ToolCallProps,
       status={status}
       isError={isError}
     >
-      {output ? <CodeBlock text={truncate(output, 8000)} /> : null}
+      {output ? <CodeBlock text={outputExpanded ? output : truncate(output, 8000)} /> : null}
     </ToolShell>
   );
 }

--- a/frontend/src/ui/chat/tool-calls/renderers/SearchCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/SearchCall.tsx
@@ -2,7 +2,8 @@ import { TerminalIcon } from "../../../primitives/icons";
 import type { ToolCallProps } from "../ToolCallTypes";
 import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
-import { DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS, shortPath, truncate } from "../utils";
+import { DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS } from "../../../../config/chat";
+import { shortPath, truncate } from "../utils";
 
 export function SearchCall({ name, input, output, outputExpanded, status, isError }: ToolCallProps) {
   const pattern = (input?.pattern as string) ?? (input?.query as string) ?? "";

--- a/frontend/src/ui/chat/tool-calls/renderers/SearchCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/SearchCall.tsx
@@ -2,7 +2,7 @@ import { TerminalIcon } from "../../../primitives/icons";
 import type { ToolCallProps } from "../ToolCallTypes";
 import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
-import { shortPath, truncate } from "../utils";
+import { DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS, shortPath, truncate } from "../utils";
 
 export function SearchCall({ name, input, output, outputExpanded, status, isError }: ToolCallProps) {
   const pattern = (input?.pattern as string) ?? (input?.query as string) ?? "";
@@ -20,7 +20,7 @@ export function SearchCall({ name, input, output, outputExpanded, status, isErro
       status={status}
       isError={isError}
     >
-      {output ? <CodeBlock text={outputExpanded ? output : truncate(output, 6000)} /> : null}
+      {output ? <CodeBlock text={outputExpanded ? output : truncate(output, DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS)} /> : null}
     </ToolShell>
   );
 }

--- a/frontend/src/ui/chat/tool-calls/renderers/SearchCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/SearchCall.tsx
@@ -4,7 +4,7 @@ import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
 import { shortPath, truncate } from "../utils";
 
-export function SearchCall({ name, input, output, status, isError }: ToolCallProps) {
+export function SearchCall({ name, input, output, outputExpanded, status, isError }: ToolCallProps) {
   const pattern = (input?.pattern as string) ?? (input?.query as string) ?? "";
   const path = (input?.path as string) ?? "";
   return (
@@ -20,7 +20,7 @@ export function SearchCall({ name, input, output, status, isError }: ToolCallPro
       status={status}
       isError={isError}
     >
-      {output ? <CodeBlock text={truncate(output, 6000)} /> : null}
+      {output ? <CodeBlock text={outputExpanded ? output : truncate(output, 6000)} /> : null}
     </ToolShell>
   );
 }

--- a/frontend/src/ui/chat/tool-calls/renderers/WriteCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/WriteCall.tsx
@@ -4,7 +4,7 @@ import { CodeBlock } from "../CodeBlock";
 import { ToolShell } from "../ToolShell";
 import { shortPath, truncate } from "../utils";
 
-export function WriteCall({ input, output, status, isError }: Omit<ToolCallProps, "name">) {
+export function WriteCall({ input, output, outputExpanded, status, isError }: Omit<ToolCallProps, "name">) {
   const path = (input?.file_path as string) ?? "";
   const content = (input?.content as string) ?? "";
   return (
@@ -16,7 +16,9 @@ export function WriteCall({ input, output, status, isError }: Omit<ToolCallProps
       isError={isError}
     >
       <CodeBlock text={truncate(content, 8000)} />
-      {output && isError ? <div class="border-t border-ink-500 p-3 text-accent-red font-mono text-xs">{output}</div> : null}
+      {output && (isError || outputExpanded) ? (
+        <div class={`border-t border-ink-500 p-3 font-mono text-xs ${isError ? "text-accent-red" : "text-ink-300"}`}>{output}</div>
+      ) : null}
     </ToolShell>
   );
 }

--- a/frontend/src/ui/chat/tool-calls/utils.test.ts
+++ b/frontend/src/ui/chat/tool-calls/utils.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS,
-  fullResponseErrorMessage,
   READ_TOOL_OUTPUT_PREVIEW_CHARS,
   toolOutputPreviewLimit,
 } from "./utils.ts";
@@ -15,11 +14,4 @@ test("tool output expansion follows each renderer preview limit", () => {
   assert.equal(toolOutputPreviewLimit("Edit"), null);
   assert.equal(toolOutputPreviewLimit("MultiEdit"), null);
   assert.equal(toolOutputPreviewLimit("Write"), null);
-});
-
-test("full response errors always produce a useful message", () => {
-  assert.equal(fullResponseErrorMessage(new Error("network failed")), "network failed");
-  assert.equal(fullResponseErrorMessage("request rejected"), "request rejected");
-  assert.equal(fullResponseErrorMessage({ status: 500 }), "Failed to load the full response.");
-  assert.equal(fullResponseErrorMessage(null), "Failed to load the full response.");
 });

--- a/frontend/src/ui/chat/tool-calls/utils.test.ts
+++ b/frontend/src/ui/chat/tool-calls/utils.test.ts
@@ -3,8 +3,8 @@ import test from "node:test";
 import {
   DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS,
   READ_TOOL_OUTPUT_PREVIEW_CHARS,
-  toolOutputPreviewLimit,
-} from "./utils.ts";
+} from "../../../config/chat.ts";
+import { toolOutputPreviewLimit } from "./utils.ts";
 
 test("tool output expansion follows each renderer preview limit", () => {
   assert.equal(toolOutputPreviewLimit("Read"), READ_TOOL_OUTPUT_PREVIEW_CHARS);

--- a/frontend/src/ui/chat/tool-calls/utils.test.ts
+++ b/frontend/src/ui/chat/tool-calls/utils.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS,
+  fullResponseErrorMessage,
+  READ_TOOL_OUTPUT_PREVIEW_CHARS,
+  toolOutputPreviewLimit,
+} from "./utils.ts";
+
+test("tool output expansion follows each renderer preview limit", () => {
+  assert.equal(toolOutputPreviewLimit("Read"), READ_TOOL_OUTPUT_PREVIEW_CHARS);
+  assert.equal(toolOutputPreviewLimit("Bash"), DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS);
+  assert.equal(toolOutputPreviewLimit("Grep"), DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS);
+  assert.equal(toolOutputPreviewLimit("future-tool"), DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS);
+  assert.equal(toolOutputPreviewLimit("Edit"), null);
+  assert.equal(toolOutputPreviewLimit("MultiEdit"), null);
+  assert.equal(toolOutputPreviewLimit("Write"), null);
+});
+
+test("full response errors always produce a useful message", () => {
+  assert.equal(fullResponseErrorMessage(new Error("network failed")), "network failed");
+  assert.equal(fullResponseErrorMessage("request rejected"), "request rejected");
+  assert.equal(fullResponseErrorMessage({ status: 500 }), "Failed to load the full response.");
+  assert.equal(fullResponseErrorMessage(null), "Failed to load the full response.");
+});

--- a/frontend/src/ui/chat/tool-calls/utils.ts
+++ b/frontend/src/ui/chat/tool-calls/utils.ts
@@ -17,9 +17,3 @@ export function toolOutputPreviewLimit(name: string): number | null {
   if (name === "Edit" || name === "MultiEdit" || name === "Write") return null;
   return DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS;
 }
-
-export function fullResponseErrorMessage(cause: unknown): string {
-  if (cause instanceof Error && cause.message) return cause.message;
-  if (typeof cause === "string" && cause.trim()) return cause;
-  return "Failed to load the full response.";
-}

--- a/frontend/src/ui/chat/tool-calls/utils.ts
+++ b/frontend/src/ui/chat/tool-calls/utils.ts
@@ -8,3 +8,18 @@ export function truncate(value: string, max: number): string {
   if (value.length <= max) return value;
   return value.slice(0, max) + `\n\n... (${value.length - max} more characters truncated)`;
 }
+
+export const DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS = 6000;
+export const READ_TOOL_OUTPUT_PREVIEW_CHARS = 8000;
+
+export function toolOutputPreviewLimit(name: string): number | null {
+  if (name === "Read") return READ_TOOL_OUTPUT_PREVIEW_CHARS;
+  if (name === "Edit" || name === "MultiEdit" || name === "Write") return null;
+  return DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS;
+}
+
+export function fullResponseErrorMessage(cause: unknown): string {
+  if (cause instanceof Error && cause.message) return cause.message;
+  if (typeof cause === "string" && cause.trim()) return cause;
+  return "Failed to load the full response.";
+}

--- a/frontend/src/ui/chat/tool-calls/utils.ts
+++ b/frontend/src/ui/chat/tool-calls/utils.ts
@@ -9,11 +9,12 @@ export function truncate(value: string, max: number): string {
   return value.slice(0, max) + `\n\n... (${value.length - max} more characters truncated)`;
 }
 
-export const DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS = 6000;
-export const READ_TOOL_OUTPUT_PREVIEW_CHARS = 8000;
-
 export function toolOutputPreviewLimit(name: string): number | null {
   if (name === "Read") return READ_TOOL_OUTPUT_PREVIEW_CHARS;
   if (name === "Edit" || name === "MultiEdit" || name === "Write") return null;
   return DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS;
 }
+import {
+  DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS,
+  READ_TOOL_OUTPUT_PREVIEW_CHARS,
+} from "../../../config/chat.ts";

--- a/frontend/src/ui/chat/tool-calls/utils.ts
+++ b/frontend/src/ui/chat/tool-calls/utils.ts
@@ -1,3 +1,8 @@
+import {
+  DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS,
+  READ_TOOL_OUTPUT_PREVIEW_CHARS,
+} from "../../../config/chat.ts";
+
 export function shortPath(path: string | undefined): string {
   if (!path) return "";
   if (path.startsWith("/root/")) return "~" + path.slice(5);
@@ -14,7 +19,3 @@ export function toolOutputPreviewLimit(name: string): number | null {
   if (name === "Edit" || name === "MultiEdit" || name === "Write") return null;
   return DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS;
 }
-import {
-  DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS,
-  READ_TOOL_OUTPUT_PREVIEW_CHARS,
-} from "../../../config/chat.ts";


### PR DESCRIPTION
Instead of reading and returning an entire events.jsonl file or an enormous final turn the server builds a compact SQLite read model:
- events.jsonl remains the authoritative source and is never rewritten.
- Provider telemetry and repeated collaboration snapshots are excluded/collapsed from the UI projection.
- Transcript API responses are limited to roughly 4 MiB and can paginate inside a single large turn.
- Existing transcripts are indexed automatically in resumable 32 MiB background checkpoints.
- The UI displays indexing progress and can continue sending messages once the WebSocket safely knows the transcript’s tail sequence.
- Tool outputs and subagent responses larger than 32 KiB are represented by previews.
- “Load full response” retrieves the original content from disk through authenticated, UTF-8-safe 256 KiB REST pages.

*Edge case that was the inspiration behind this PR:*
For a 1 GB+ conversation, the browser will therefore receive a small visible transcript rather than downloading hundreds of repeated subagent snapshots. Nothing important is deleted: full tool and subagent responses remain on disk and can be loaded on demand.