### PR TITLE
fix(ci): build frontend before backend vet/test/build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,19 @@ jobs:
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Build frontend bundle for go:embed
+        # backend/static.go embeds backend/public, which only exists after the
+        # Vite build. Without it go vet/test/build fail with
+        # "pattern public: no matching files found".
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
       - name: Check gofmt
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What

Fixes the red `backend (go vet/test/build)` job (`static.go:8:12: pattern public: no matching
files found`).

## Root cause

`backend/static.go` does `//go:embed public`, but `backend/public/` only exists after the Vite
build (`frontend/vite.config.ts` writes there). The backend CI job ran `go vet ./...` on a fresh
checkout with no bundle present, so vet (and test/build) failed on every commit.

## Changes

- `.github/workflows/ci.yml`: the backend job now sets up Node 22 and runs `npm ci` +
  `npm run build` in `frontend/` before `gofmt`/`vet`/`test`/`build`, mirroring the frontend
  job's Node setup.

## Testing

- Verified locally that `npm run build` succeeds and emits the bundle into `backend/public/`
  (the exact steps added to CI). No Go toolchain on this host, so `go vet` itself will be
  confirmed green by CI.
