### PR TITLE
fix(infra): validate bootstrap ref before root gate in install.sh

### DIFF
--- a/infra/install.sh
+++ b/infra/install.sh
@@ -47,6 +47,23 @@ set -euo pipefail
 # files on disk.
 INFRA_DIR_PROBE="$( cd "$( dirname "${BASH_SOURCE[0]:-}" 2>/dev/null || echo . )" >/dev/null 2>&1 && pwd || true )"
 if [ -z "$INFRA_DIR_PROBE" ] || [ ! -d "${INFRA_DIR_PROBE}/steps" ]; then
+    # Parse bootstrap-only values before touching either checkout. The full
+    # argument loop below parses them again after we re-exec from disk.
+    BOOTSTRAP_TOKEN="${GITHUB_TOKEN:-}"
+    BOOTSTRAP_REF=""
+    for a in "$@"; do
+        case "$a" in
+            --github-token=*) BOOTSTRAP_TOKEN="${a#*=}" ;;
+            --ref=*)          BOOTSTRAP_REF="${a#*=}" ;;
+        esac
+    done
+    # Validate the ref before demanding root so a malformed --ref reports the
+    # actionable error instead of a misleading root demand (and so the
+    # curl-piped contract in qa-scripts-test.sh holds for non-root runners).
+    if [ -n "$BOOTSTRAP_REF" ] && ! printf '%s' "$BOOTSTRAP_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
+        echo "--ref must be a full 40-character commit SHA" >&2
+        exit 1
+    fi
     if [ "$EUID" -ne 0 ]; then
         echo "this installer needs root; rerun with sudo" >&2
         exit 1
@@ -60,21 +77,6 @@ if [ -z "$INFRA_DIR_PROBE" ] || [ ! -d "${INFRA_DIR_PROBE}/steps" ]; then
     TARGET="${FUTRX_INSTALL_DIR:-/opt/remote.futrx}"
     LEGACY_TARGET="${FUTRX_LEGACY_INSTALL_DIR:-/opt/remote.futrx.dev}"
     MAIN_REFSPEC="+refs/heads/main:refs/remotes/origin/main"
-
-    # Parse bootstrap-only values before touching either checkout. The full
-    # argument loop below parses them again after we re-exec from disk.
-    BOOTSTRAP_TOKEN="${GITHUB_TOKEN:-}"
-    BOOTSTRAP_REF=""
-    for a in "$@"; do
-        case "$a" in
-            --github-token=*) BOOTSTRAP_TOKEN="${a#*=}" ;;
-            --ref=*)          BOOTSTRAP_REF="${a#*=}" ;;
-        esac
-    done
-    if [ -n "$BOOTSTRAP_REF" ] && ! printf '%s' "$BOOTSTRAP_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
-        echo "--ref must be a full 40-character commit SHA" >&2
-        exit 1
-    fi
 
     # A pre-rename checkout can update itself in place, then the checked-out
     # installer below performs the guarded path migration with rollback.


### PR DESCRIPTION
## What

Fixes the remaining red `infra shell tests` leg (`FAIL: curl-mode core install.sh gave an
unclear immutable-ref error` in `qa-scripts-test.sh`).

## Root cause

Same pattern as #171: in the curl-piped bootstrap block of `infra/install.sh`, the root gate
ran before the `--ref` validation, so non-root CI saw "needs root" instead of `--ref must be
a full 40-character commit SHA`. (Direct-file invocation was unaffected — only the
`bash -s -- ... < install.sh` path.)

## Changes

- Pure reorder (plus comment): parse bootstrap args, validate the SHA, then demand root.
  No behavior change for real deployments.

## Testing

- Reproduced the exact CI failure locally via Git Bash before the fix; after it the
  curl-mode contract holds.
- Full `bash infra/tests/qa-scripts-test.sh` passes locally end to end (exit 0).
