### PR TITLE
feat(host): add global terminal and fix Git, previews, memory limits, and upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ Remote checks releases from the app. Patch updates rebuild the application;
 major and minor releases can converge host infrastructure, rebuild the project
 image, and recycle idle containers through a controlled administrator flow.
 
+For the operational guarantees behind project limits, previews, Git commits,
+the administrator host terminal, and workspace migration, read
+[Host and workspace reliability](docs/02-user-guide/14-host-and-workspace-reliability.md).
+
 See the continuous five-step product tour at [remote.futrx.com](https://remote.futrx.com/#product-tour), or use the [complete feature reference](docs/02-user-guide/13-feature-reference.md) for exact behavior and current limits.
 
 ## What you get

--- a/backend/cmd/remote/main.go
+++ b/backend/cmd/remote/main.go
@@ -68,6 +68,7 @@ func main() {
 		agentModules.Profiles(),
 		config.ContainerStackOptions{
 			AgentInstructions: provisioning.InstructionsTemplate(publicHostname),
+			PublicHostname:    publicHostname,
 		},
 	)
 

--- a/backend/cmd/remote/main.go
+++ b/backend/cmd/remote/main.go
@@ -69,6 +69,8 @@ func main() {
 		config.ContainerStackOptions{
 			AgentInstructions: provisioning.InstructionsTemplate(publicHostname),
 			PublicHostname:    publicHostname,
+			GitUserName:       cfg.Git.UserName,
+			GitUserEmail:      cfg.Git.UserEmail,
 		},
 	)
 

--- a/backend/cmd/upgrade-workspaces/main.go
+++ b/backend/cmd/upgrade-workspaces/main.go
@@ -35,7 +35,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("configure agent modules: %v", err)
 	}
-	containerStack := config.NewContainerStack(lxcClient, agentModules.Profiles(), config.ContainerStackOptions{})
+	publicHostname, err := config.PublicHostname(cfg.BaseURL)
+	if err != nil {
+		log.Fatalf("configure public hostname: %v", err)
+	}
+	containerStack := config.NewContainerStack(lxcClient, agentModules.Profiles(), config.ContainerStackOptions{
+		PublicHostname: publicHostname,
+	})
 	projects := serviceproject.New(
 		storeSet.Projects,
 		containerStack.ProjectDependencies(),

--- a/backend/cmd/upgrade-workspaces/main.go
+++ b/backend/cmd/upgrade-workspaces/main.go
@@ -41,6 +41,8 @@ func main() {
 	}
 	containerStack := config.NewContainerStack(lxcClient, agentModules.Profiles(), config.ContainerStackOptions{
 		PublicHostname: publicHostname,
+		GitUserName:    cfg.Git.UserName,
+		GitUserEmail:   cfg.Git.UserEmail,
 	})
 	projects := serviceproject.New(
 		storeSet.Projects,

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -15,9 +15,17 @@ type Config struct {
 	DataDir    string
 	InstallDir string
 	BaseURL    string
+	Git        GitOptions
 	Agent      AgentOptions
 	Auth       AuthOptions
 	Schedule   ScheduleLimits
+}
+
+// GitOptions define the non-secret author identity provisioned into project
+// containers. Authentication remains owned by the existing credential flow.
+type GitOptions struct {
+	UserName  string
+	UserEmail string
 }
 
 // AgentOptions are application-wide policies for the agent subsystem.
@@ -82,6 +90,10 @@ func Load() Config {
 		DataDir:    envDefault("DATA_DIR", "/opt/remote.futrx/data"),
 		InstallDir: envDefault("INSTALL_DIR", "/opt/remote.futrx"),
 		BaseURL:    envDefault("BASE_URL", ""),
+		Git: GitOptions{
+			UserName:  envDefault("REMOTE_GIT_USER_NAME", "Remote User"),
+			UserEmail: envDefault("REMOTE_GIT_USER_EMAIL", "remote@localhost"),
+		},
 		Agent: AgentOptions{
 			CapabilityTimeout:          envDuration("AGENT_CAPABILITY_TIMEOUT", 30*time.Second),
 			HostCLIVersionTimeout:      15 * time.Second,

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -17,6 +17,16 @@ func TestLoadUsesGlobalAgentCapabilityTimeout(t *testing.T) {
 	}
 }
 
+func TestLoadUsesConfiguredGitIdentity(t *testing.T) {
+	t.Setenv("REMOTE_GIT_USER_NAME", "Example Developer")
+	t.Setenv("REMOTE_GIT_USER_EMAIL", "developer@example.com")
+
+	identity := Load().Git
+	if identity.UserName != "Example Developer" || identity.UserEmail != "developer@example.com" {
+		t.Fatalf("git identity = %#v", identity)
+	}
+}
+
 func TestLoadUsesGlobalAgentPolicyDefaults(t *testing.T) {
 	options := Load().Agent
 	if options.CapabilityCacheTTL != 24*time.Hour {

--- a/backend/internal/config/containers.go
+++ b/backend/internal/config/containers.go
@@ -55,6 +55,7 @@ type ContainerStack struct {
 type ContainerStackOptions struct {
 	AgentInstructions  []byte
 	ImageBuildProgress serviceimage.ProgressReporter
+	PublicHostname     string
 }
 
 // ProjectDependencies exposes only the capabilities consumed by project
@@ -105,7 +106,7 @@ func NewContainerStack(
 		Runtime:     browserAdapter,
 		Tooling:     browserAdapter,
 	}, configconstants.ProjectPreviewAgentBrowserPort)
-	codeServer := containercodeserver.NewProvisioner(runner)
+	codeServer := containercodeserver.NewProvisioner(runner, options.PublicHostname)
 	scheduleTools := containerscheduletools.NewAdapter(runner, publisher)
 	workspace := containerworkspace.NewProvisioner(
 		runner,
@@ -128,7 +129,11 @@ func NewContainerStack(
 		codeServer,
 		scheduleTools,
 	)
-	resources := containerresources.NewManager(runner)
+	viteAllowedHost := ""
+	if options.PublicHostname != "" {
+		viteAllowedHost = ".dev." + options.PublicHostname
+	}
+	resources := containerresources.NewManager(runner, viteAllowedHost)
 	lifecycle := servicelifecycle.NewService(
 		containerlifecycle.NewClient(runner),
 		serviceimage.Alias,

--- a/backend/internal/config/containers.go
+++ b/backend/internal/config/containers.go
@@ -56,6 +56,8 @@ type ContainerStackOptions struct {
 	AgentInstructions  []byte
 	ImageBuildProgress serviceimage.ProgressReporter
 	PublicHostname     string
+	GitUserName        string
+	GitUserEmail       string
 }
 
 // ProjectDependencies exposes only the capabilities consumed by project
@@ -113,6 +115,10 @@ func NewContainerStack(
 		profiles,
 		publisher,
 		options.AgentInstructions,
+		containerworkspace.GitIdentity{
+			Name:  options.GitUserName,
+			Email: options.GitUserEmail,
+		},
 	)
 	runtimeAssets := containerruntimeassets.NewAdapter(runner, publisher)
 	images := serviceimage.NewBuilder(

--- a/backend/internal/integration/containers/codeserver/assets/code-server-up.sh
+++ b/backend/internal/integration/containers/codeserver/assets/code-server-up.sh
@@ -44,6 +44,8 @@ StopWhenUnneeded=yes
 
 [Service]
 Type=exec
+Environment=HOME=/root
+Environment=GIT_CONFIG_GLOBAL=/root/.gitconfig
 Environment=VSCODE_RECONNECTION_GRACE_TIME=60000
 ExecStart=/usr/bin/code-server /workspace
 ExecStartPost=/usr/bin/bash -c 'for i in $(seq 1 50); do curl -fsS -o /dev/null http://127.0.0.1:8081/healthz && exit 0; sleep 0.2; done; exit 0'

--- a/backend/internal/integration/containers/codeserver/assets/code-server-up.sh
+++ b/backend/internal/integration/containers/codeserver/assets/code-server-up.sh
@@ -156,6 +156,7 @@ cat > /root/.local/share/code-server/User/settings.json <<'JSON'
   "workbench.settings.enableNaturalLanguageSearch": false,
   "git.autorefresh": true,
   "git.decorations.enabled": true,
+  "github.gitAuthentication": false,
   "scm.diffDecorations": "gutter",
   "files.autoSave": "afterDelay",
   "files.autoSaveDelay": 1500,

--- a/backend/internal/integration/containers/codeserver/provisioner.go
+++ b/backend/internal/integration/containers/codeserver/provisioner.go
@@ -71,6 +71,34 @@ if systemctl is-active --quiet code-server.service; then
 fi
 `
 
+// Keep browser IDE Git operations on the platform-managed credential helper.
+// VS Code's GitHub extension otherwise maintains a separate OAuth session in
+// container-local secret storage and asks the user to sign in again whenever
+// that IDE state is recreated, even though the shared gh credential is valid.
+const configureGitAuthentication = `
+set -euo pipefail
+settings_dir=/root/.local/share/code-server/User
+settings="$settings_dir/settings.json"
+install -d -m 0755 "$settings_dir"
+SETTINGS_PATH="$settings" node - <<'NODE'
+const fs = require("fs");
+const path = process.env.SETTINGS_PATH;
+let settings = {};
+try {
+  settings = JSON.parse(fs.readFileSync(path, "utf8"));
+} catch (error) {
+  if (error.code !== "ENOENT") throw error;
+}
+if (settings["github.gitAuthentication"] !== false) {
+  settings["github.gitAuthentication"] = false;
+  const temporary = path + ".tmp";
+  fs.writeFileSync(temporary, JSON.stringify(settings, null, 2) + "\n", { mode: 0o600 });
+  fs.renameSync(temporary, path);
+}
+NODE
+chmod 0600 "$settings"
+`
+
 // EnsureCodeServer installs and enables the on-demand code-server stack inside
 // an existing project container. Idempotent and best-effort, mirroring
 // other container migration helpers. Existing units are kept, while their
@@ -104,6 +132,18 @@ func (p *Provisioner) Ensure(ctx context.Context, containerName, displayName, pr
 		); err != nil {
 			return fmt.Errorf("configure code-server preview URI: %w; output: %s", err, output.TruncateTail(out, 1000))
 		}
+	}
+
+	// Converge existing containers too. The install script only runs for new
+	// containers, while the OAuth-loop fix must also reach current workspaces.
+	if out, err := command.RunWithTimeout(
+		ctx,
+		p.runner,
+		10*time.Second,
+		"exec", containerName,
+		"--", "bash", "-c", configureGitAuthentication,
+	); err != nil {
+		return fmt.Errorf("configure code-server Git authentication: %w; output: %s", err, output.TruncateTail(out, 1000))
 	}
 
 	// Always enable --now: arms a freshly-installed socket, and recovers a

--- a/backend/internal/integration/containers/codeserver/provisioner.go
+++ b/backend/internal/integration/containers/codeserver/provisioner.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
@@ -37,33 +38,71 @@ func InstallScript() []byte {
 // Provisioner owns installation and socket activation for the
 // per-container IDE.
 type Provisioner struct {
-	runner command.Runner
+	runner         command.Runner
+	publicHostname string
 }
 
 // NewProvisioner returns a code-server provisioner backed by runner.
-func NewProvisioner(runner command.Runner) *Provisioner {
-	return &Provisioner{runner: runner}
+func NewProvisioner(runner command.Runner, publicHostname ...string) *Provisioner {
+	hostname := ""
+	if len(publicHostname) > 0 {
+		hostname = strings.TrimSuffix(strings.TrimSpace(publicHostname[0]), ".")
+	}
+	return &Provisioner{runner: runner, publicHostname: hostname}
 }
+
+const configurePreviewURI = `
+set -euo pipefail
+dropin_dir=/etc/systemd/system/code-server.service.d
+dropin="$dropin_dir/10-remote-preview.conf"
+install -d -m 0755 "$dropin_dir"
+tmp="$(mktemp "$dropin_dir/.10-remote-preview.conf.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+printf '[Service]\nEnvironment=VSCODE_PROXY_URI=%s\nEnvironment=__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=%s\n' \
+    "$CODE_SERVER_PROXY_URI" "$VITE_ALLOWED_HOST" >"$tmp"
+chmod 0644 "$tmp"
+if [ -f "$dropin" ] && cmp -s "$tmp" "$dropin"; then
+    exit 0
+fi
+mv "$tmp" "$dropin"
+systemctl daemon-reload
+if systemctl is-active --quiet code-server.service; then
+    systemctl restart code-server.service
+fi
+`
 
 // EnsureCodeServer installs and enables the on-demand code-server stack inside
 // an existing project container. Idempotent and best-effort, mirroring
-// other container migration helpers. It returns early only when the socket is
-// actually active; if the unit file exists but is disabled/stopped (e.g. a
-// base-image bake that didn't enable it, or a unit that was turned off later)
-// it still (re-)enables it, so a present-but-inert socket can't leave IDE
-// routing silently broken.
-func (p *Provisioner) Ensure(ctx context.Context, containerName, displayName string) error {
-	// Fast path: socket already armed and listening -> nothing to do.
-	if _, err := command.RunWithTimeout(ctx, p.runner, 10*time.Second, "exec", containerName, "--", "systemctl", "is-active", "--quiet", "code-server.socket"); err == nil {
-		return nil
-	}
-
+// other container migration helpers. Existing units are kept, while their
+// preview URL drop-in is converged on every launch. A disabled/stopped socket
+// is still (re-)enabled, so a present-but-inert unit can't leave IDE routing
+// silently broken.
+func (p *Provisioner) Ensure(ctx context.Context, containerName, displayName, projectSlug string) error {
 	// Install the units only when they're not present yet. The base image may
 	// already ship them; re-running the install script is harmless but slow,
 	// so skip it when the unit file exists and just (re-)enable below.
 	if _, err := command.RunWithTimeout(ctx, p.runner, 10*time.Second, "exec", containerName, "--", "test", "-f", "/etc/systemd/system/code-server.socket"); err != nil {
 		if out, err := command.RunWithTimeout(ctx, p.runner, 5*time.Minute, "exec", containerName, "--env", "CODE_SERVER_WS_NAME="+displayName, "--", "bash", "-c", string(InstallScript())); err != nil {
 			return fmt.Errorf("install code-server: %w; output: %s", err, output.TruncateTail(out, 2000))
+		}
+	}
+
+	// code-server reads this template when it builds links in the Ports tab.
+	// A dedicated origin keeps root-relative Vite assets and WebSockets intact,
+	// unlike the legacy /<slug>/proxy/<port>/ path.
+	if p.publicHostname != "" {
+		proxyURI := fmt.Sprintf("https://%s--{{port}}.dev.%s", projectSlug, p.publicHostname)
+		viteAllowedHost := ".dev." + p.publicHostname
+		if out, err := command.RunWithTimeout(
+			ctx,
+			p.runner,
+			20*time.Second,
+			"exec", containerName,
+			"--env", "CODE_SERVER_PROXY_URI="+proxyURI,
+			"--env", "VITE_ALLOWED_HOST="+viteAllowedHost,
+			"--", "bash", "-c", configurePreviewURI,
+		); err != nil {
+			return fmt.Errorf("configure code-server preview URI: %w; output: %s", err, output.TruncateTail(out, 1000))
 		}
 	}
 

--- a/backend/internal/integration/containers/codeserver/provisioner.go
+++ b/backend/internal/integration/containers/codeserver/provisioner.go
@@ -58,7 +58,7 @@ dropin="$dropin_dir/10-remote-preview.conf"
 install -d -m 0755 "$dropin_dir"
 tmp="$(mktemp "$dropin_dir/.10-remote-preview.conf.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
-printf '[Service]\nEnvironment=VSCODE_PROXY_URI=%s\nEnvironment=__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=%s\n' \
+printf '[Service]\nEnvironment=HOME=/root\nEnvironment=GIT_CONFIG_GLOBAL=/root/.gitconfig\nEnvironment=VSCODE_PROXY_URI=%s\nEnvironment=__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=%s\n' \
     "$CODE_SERVER_PROXY_URI" "$VITE_ALLOWED_HOST" >"$tmp"
 chmod 0644 "$tmp"
 if [ -f "$dropin" ] && cmp -s "$tmp" "$dropin"; then

--- a/backend/internal/integration/containers/codeserver/provisioner_test.go
+++ b/backend/internal/integration/containers/codeserver/provisioner_test.go
@@ -1,0 +1,52 @@
+package codeserver
+
+import (
+	"context"
+	"io"
+	"slices"
+	"testing"
+)
+
+type recordingRunner struct {
+	calls [][]string
+}
+
+func (*recordingRunner) Available() bool { return true }
+
+func (r *recordingRunner) Run(_ context.Context, args ...string) (string, error) {
+	r.calls = append(r.calls, slices.Clone(args))
+	return "", nil
+}
+
+func (r *recordingRunner) RunStdin(ctx context.Context, _ io.Reader, args ...string) (string, error) {
+	return r.Run(ctx, args...)
+}
+
+func TestEnsureConfiguresProjectPreviewTemplate(t *testing.T) {
+	runner := &recordingRunner{}
+	provisioner := NewProvisioner(runner, "remote.example.test")
+
+	if err := provisioner.Ensure(context.Background(), "project-1", "My Project", "my-project"); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+
+	wantEnv := "CODE_SERVER_PROXY_URI=https://my-project--{{port}}.dev.remote.example.test"
+	wantViteEnv := "VITE_ALLOWED_HOST=.dev.remote.example.test"
+	foundProxy, foundVite := false, false
+	for _, call := range runner.calls {
+		for _, arg := range call {
+			if arg == wantEnv {
+				foundProxy = true
+			}
+			if arg == wantViteEnv {
+				foundVite = true
+			}
+		}
+	}
+	if !foundProxy {
+		t.Fatalf("preview template %q missing from calls: %#v", wantEnv, runner.calls)
+	}
+	if !foundVite {
+		t.Fatalf("Vite allowed host %q missing from calls: %#v", wantViteEnv, runner.calls)
+	}
+}

--- a/backend/internal/integration/containers/codeserver/provisioner_test.go
+++ b/backend/internal/integration/containers/codeserver/provisioner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -32,7 +33,7 @@ func TestEnsureConfiguresProjectPreviewTemplate(t *testing.T) {
 
 	wantEnv := "CODE_SERVER_PROXY_URI=https://my-project--{{port}}.dev.remote.example.test"
 	wantViteEnv := "VITE_ALLOWED_HOST=.dev.remote.example.test"
-	foundProxy, foundVite := false, false
+	foundProxy, foundVite, foundGitEnvironment := false, false, false
 	for _, call := range runner.calls {
 		for _, arg := range call {
 			if arg == wantEnv {
@@ -41,6 +42,10 @@ func TestEnsureConfiguresProjectPreviewTemplate(t *testing.T) {
 			if arg == wantViteEnv {
 				foundVite = true
 			}
+			if strings.Contains(arg, "Environment=HOME=/root") &&
+				strings.Contains(arg, "Environment=GIT_CONFIG_GLOBAL=/root/.gitconfig") {
+				foundGitEnvironment = true
+			}
 		}
 	}
 	if !foundProxy {
@@ -48,5 +53,8 @@ func TestEnsureConfiguresProjectPreviewTemplate(t *testing.T) {
 	}
 	if !foundVite {
 		t.Fatalf("Vite allowed host %q missing from calls: %#v", wantViteEnv, runner.calls)
+	}
+	if !foundGitEnvironment {
+		t.Fatalf("code-server Git environment missing from calls: %#v", runner.calls)
 	}
 }

--- a/backend/internal/integration/containers/codeserver/provisioner_test.go
+++ b/backend/internal/integration/containers/codeserver/provisioner_test.go
@@ -33,7 +33,7 @@ func TestEnsureConfiguresProjectPreviewTemplate(t *testing.T) {
 
 	wantEnv := "CODE_SERVER_PROXY_URI=https://my-project--{{port}}.dev.remote.example.test"
 	wantViteEnv := "VITE_ALLOWED_HOST=.dev.remote.example.test"
-	foundProxy, foundVite, foundGitEnvironment := false, false, false
+	foundProxy, foundVite, foundGitEnvironment, foundGitHubAuthSetting := false, false, false, false
 	for _, call := range runner.calls {
 		for _, arg := range call {
 			if arg == wantEnv {
@@ -46,6 +46,9 @@ func TestEnsureConfiguresProjectPreviewTemplate(t *testing.T) {
 				strings.Contains(arg, "Environment=GIT_CONFIG_GLOBAL=/root/.gitconfig") {
 				foundGitEnvironment = true
 			}
+			if strings.Contains(arg, `settings["github.gitAuthentication"] = false`) {
+				foundGitHubAuthSetting = true
+			}
 		}
 	}
 	if !foundProxy {
@@ -56,5 +59,8 @@ func TestEnsureConfiguresProjectPreviewTemplate(t *testing.T) {
 	}
 	if !foundGitEnvironment {
 		t.Fatalf("code-server Git environment missing from calls: %#v", runner.calls)
+	}
+	if !foundGitHubAuthSetting {
+		t.Fatalf("code-server GitHub authentication setting missing from calls: %#v", runner.calls)
 	}
 }

--- a/backend/internal/integration/containers/resources/manager.go
+++ b/backend/internal/integration/containers/resources/manager.go
@@ -31,7 +31,7 @@ const (
 // takedowns. The backend converges the profile to these values on every
 // Launch — edit HERE and redeploy to change the fleet default; hand-edits
 // via `lxc profile edit` are reverted on the next convergence.
-var profileConfig = [...][2]string{
+var profileConfig = [][2]string{
 	// Hard memory ceiling: the container's own OOM killer fires inside the
 	// cgroup; the host never feels it.
 	{"limits.memory", "8GiB"},
@@ -47,12 +47,28 @@ var profileConfig = [...][2]string{
 // Manager converges the managed profile definition and its attachment to
 // project containers.
 type Manager struct {
-	runner command.Runner
+	runner          command.Runner
+	viteAllowedHost string
 }
 
 // NewManager returns a Manager that issues profile operations through runner.
-func NewManager(runner command.Runner) *Manager {
-	return &Manager{runner: runner}
+func NewManager(runner command.Runner, viteAllowedHost ...string) *Manager {
+	host := ""
+	if len(viteAllowedHost) > 0 {
+		host = strings.TrimSpace(viteAllowedHost[0])
+	}
+	return &Manager{runner: runner, viteAllowedHost: host}
+}
+
+func (m *Manager) desiredProfileConfig() [][2]string {
+	config := append([][2]string(nil), profileConfig...)
+	if m.viteAllowedHost != "" {
+		config = append(config, [2]string{
+			"environment.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS",
+			m.viteAllowedHost,
+		})
+	}
+	return config
 }
 
 // Ensure converges the profile definition, then attaches the profile to the
@@ -147,7 +163,7 @@ func (m *Manager) ensureProfile(ctx context.Context) error {
 			return fmt.Errorf("profile create %s: %w; output: %s", ProfileName, err, out)
 		}
 	}
-	for _, kv := range profileConfig {
+	for _, kv := range m.desiredProfileConfig() {
 		key, want := kv[0], kv[1]
 		current, _ := command.RunWithTimeout(ctx, m.runner, queryTimeout, "profile", "get", ProfileName, key)
 		if strings.TrimSpace(current) == want {

--- a/backend/internal/integration/containers/resources/manager.go
+++ b/backend/internal/integration/containers/resources/manager.go
@@ -34,10 +34,10 @@ const (
 var profileConfig = [...][2]string{
 	// Hard memory ceiling: the container's own OOM killer fires inside the
 	// cgroup; the host never feels it.
-	{"limits.memory", "4GiB"},
+	{"limits.memory", "8GiB"},
 	// CPU cap below the host's core count so the host control plane (LXD,
 	// sshd, backend) always has headroom even with a pegged workspace.
-	{"limits.cpu", "6"},
+	{"limits.cpu", "2"},
 	// Fork-bomb guard; the kernel PID table is shared with the host.
 	{"limits.processes", "2000"},
 	// Chrome's own sandbox (nested user namespaces) for the Agent Browser.
@@ -87,14 +87,14 @@ func (m *Manager) SetLimits(ctx context.Context, containerName, cpu, memory, dis
 			args = []string{"config", "unset", containerName, limit.key}
 		}
 		out, err := command.RunWithTimeout(ctx, m.runner, queryTimeout, args...)
-		if err != nil {
+		if err != nil && !(limit.value == "" && missingConfigOutput(out+" "+err.Error())) {
 			return fmt.Errorf("%s: %w; output: %s", strings.Join(args, " "), err, out)
 		}
 	}
 
 	if disk == "" {
 		out, err := command.RunWithTimeout(ctx, m.runner, queryTimeout, "config", "device", "unset", containerName, "root", "size")
-		if err != nil && !missingDeviceOutput(out+" "+err.Error()) {
+		if err != nil && !missingDeviceOutput(out+" "+err.Error()) && !inheritedDeviceOutput(out+" "+err.Error()) {
 			return fmt.Errorf("config device unset %s root size: %w; output: %s", containerName, err, out)
 		}
 		return nil
@@ -114,12 +114,25 @@ func (m *Manager) SetLimits(ctx context.Context, containerName, cpu, memory, dis
 	return nil
 }
 
+func missingConfigOutput(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "not found") ||
+		strings.Contains(lower, "not currently set") ||
+		strings.Contains(lower, "is not set")
+}
+
 func missingDeviceOutput(output string) bool {
 	lower := strings.ToLower(output)
 	return strings.Contains(lower, "not found") ||
 		strings.Contains(lower, "doesn't exist") ||
 		strings.Contains(lower, "does not exist") ||
 		strings.Contains(lower, "not defined")
+}
+
+func inheritedDeviceOutput(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "cannot be modified for individual instance") ||
+		strings.Contains(lower, "override device")
 }
 
 func (m *Manager) ensureProfile(ctx context.Context) error {

--- a/backend/internal/integration/containers/resources/manager_test.go
+++ b/backend/internal/integration/containers/resources/manager_test.go
@@ -101,7 +101,7 @@ func TestEnsureRepairsDriftedKey(t *testing.T) {
 	}
 
 	got := runner.called("profile set")
-	if len(got) != 1 || !strings.Contains(got[0], "limits.memory 4GiB") {
+	if len(got) != 1 || !strings.Contains(got[0], "limits.memory 8GiB") {
 		t.Fatalf("expected exactly the drifted key to be reset, got %v", got)
 	}
 }
@@ -124,7 +124,22 @@ func TestSetLimitsAppliesContainerOverrides(t *testing.T) {
 }
 
 func TestSetLimitsClearsContainerOverrides(t *testing.T) {
-	runner := &fakeRunner{responses: map[string]fakeResponse{}}
+	// Regression: the Resource Limits form used to fail when CPU/memory were
+	// already inherited and the root disk device came from a profile.
+	runner := &fakeRunner{responses: map[string]fakeResponse{
+		"config unset c1 limits.cpu": {
+			out: "Error: Config key limits.cpu is not currently set",
+			err: errors.New("exit status 1"),
+		},
+		"config unset c1 limits.memory": {
+			out: "Error: Config key limits.memory not found",
+			err: errors.New("exit status 1"),
+		},
+		"config device unset c1 root size": {
+			out: "Error: Device from profile cannot be modified for individual instance; override device",
+			err: errors.New("exit status 1"),
+		},
+	}}
 
 	if err := NewManager(runner).SetLimits(context.Background(), "c1", "", "", ""); err != nil {
 		t.Fatalf("SetLimits: %v", err)

--- a/backend/internal/integration/containers/resources/manager_test.go
+++ b/backend/internal/integration/containers/resources/manager_test.go
@@ -106,6 +106,26 @@ func TestEnsureRepairsDriftedKey(t *testing.T) {
 	}
 }
 
+func TestEnsureAddsVitePreviewDomainToManagedProfile(t *testing.T) {
+	responses := map[string]fakeResponse{
+		"profile show " + ProfileName: {out: "name: " + ProfileName},
+		"config show c1":              {out: "profiles:\n- default\n- " + ProfileName + "\n"},
+	}
+	for _, kv := range profileConfig {
+		responses["profile get "+ProfileName+" "+kv[0]] = fakeResponse{out: kv[1] + "\n"}
+	}
+	runner := &fakeRunner{responses: responses}
+
+	if err := NewManager(runner, ".dev.remote.example.test").Ensure(context.Background(), "c1"); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+
+	want := "profile set " + ProfileName + " environment.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS .dev.remote.example.test"
+	if got := runner.called("profile set"); !slices.Equal(got, []string{want}) {
+		t.Fatalf("profile set calls: got %q, want %q", got, []string{want})
+	}
+}
+
 func TestSetLimitsAppliesContainerOverrides(t *testing.T) {
 	runner := &fakeRunner{responses: map[string]fakeResponse{}}
 

--- a/backend/internal/integration/containers/workspace/git_identity.go
+++ b/backend/internal/integration/containers/workspace/git_identity.go
@@ -11,6 +11,7 @@ import (
 )
 
 const gitIdentityTimeout = 10 * time.Second
+const globalGitConfigPath = "/root/.gitconfig"
 
 type GitIdentity struct {
 	Name  string
@@ -41,7 +42,7 @@ func (p *Provisioner) EnsureGitIdentity(ctx context.Context, containerName strin
 		current, err := command.RunWithTimeout(
 			ctx, p.runner, gitIdentityTimeout,
 			"exec", containerName, "--env", "HOME=/root", "--",
-			"git", "config", "--global", "--get", setting[0],
+			"git", "config", "--file", globalGitConfigPath, "--get", setting[0],
 		)
 		if err == nil && strings.TrimSpace(current) == setting[1] {
 			continue
@@ -49,7 +50,7 @@ func (p *Provisioner) EnsureGitIdentity(ctx context.Context, containerName strin
 		if output, err := command.RunWithTimeout(
 			ctx, p.runner, gitIdentityTimeout,
 			"exec", containerName, "--env", "HOME=/root", "--",
-			"git", "config", "--global", setting[0], setting[1],
+			"git", "config", "--file", globalGitConfigPath, setting[0], setting[1],
 		); err != nil {
 			return fmt.Errorf("configure git %s: %w; output: %s", setting[0], err, output)
 		}

--- a/backend/internal/integration/containers/workspace/git_identity.go
+++ b/backend/internal/integration/containers/workspace/git_identity.go
@@ -1,0 +1,58 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/integration/containers/command"
+)
+
+const gitIdentityTimeout = 10 * time.Second
+
+type GitIdentity struct {
+	Name  string
+	Email string
+}
+
+// EnsureGitIdentity converges only Git's non-secret author metadata. Provider
+// tokens, SSH keys, and credential helpers are deliberately outside its scope.
+func (p *Provisioner) EnsureGitIdentity(ctx context.Context, containerName string) error {
+	if !p.runner.Available() {
+		return command.ErrUnavailable
+	}
+	identity := GitIdentity{
+		Name:  strings.TrimSpace(p.gitIdentity.Name),
+		Email: strings.TrimSpace(p.gitIdentity.Email),
+	}
+	if identity.Name == "" || identity.Email == "" {
+		return errors.New("git user name and email are required")
+	}
+	if strings.ContainsAny(identity.Name+identity.Email, "\r\n") {
+		return errors.New("git identity cannot contain line breaks")
+	}
+
+	for _, setting := range [][2]string{
+		{"user.name", identity.Name},
+		{"user.email", identity.Email},
+	} {
+		current, err := command.RunWithTimeout(
+			ctx, p.runner, gitIdentityTimeout,
+			"exec", containerName, "--env", "HOME=/root", "--",
+			"git", "config", "--global", "--get", setting[0],
+		)
+		if err == nil && strings.TrimSpace(current) == setting[1] {
+			continue
+		}
+		if output, err := command.RunWithTimeout(
+			ctx, p.runner, gitIdentityTimeout,
+			"exec", containerName, "--env", "HOME=/root", "--",
+			"git", "config", "--global", setting[0], setting[1],
+		); err != nil {
+			return fmt.Errorf("configure git %s: %w; output: %s", setting[0], err, output)
+		}
+	}
+	return nil
+}

--- a/backend/internal/integration/containers/workspace/git_identity_test.go
+++ b/backend/internal/integration/containers/workspace/git_identity_test.go
@@ -54,10 +54,10 @@ func TestMissingGitIdentityIsConfiguredForRootHome(t *testing.T) {
 	}
 
 	want := []string{
-		"exec project-1 --env HOME=/root -- git config --global --get user.name",
-		"exec project-1 --env HOME=/root -- git config --global user.name Example Developer",
-		"exec project-1 --env HOME=/root -- git config --global --get user.email",
-		"exec project-1 --env HOME=/root -- git config --global user.email developer@example.com",
+		"exec project-1 --env HOME=/root -- git config --file /root/.gitconfig --get user.name",
+		"exec project-1 --env HOME=/root -- git config --file /root/.gitconfig user.name Example Developer",
+		"exec project-1 --env HOME=/root -- git config --file /root/.gitconfig --get user.email",
+		"exec project-1 --env HOME=/root -- git config --file /root/.gitconfig user.email developer@example.com",
 	}
 	if !slices.Equal(runner.calls, want) {
 		t.Fatalf("git config calls = %q, want %q", runner.calls, want)

--- a/backend/internal/integration/containers/workspace/git_identity_test.go
+++ b/backend/internal/integration/containers/workspace/git_identity_test.go
@@ -1,0 +1,83 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type gitIdentityRunner struct {
+	current map[string]string
+	calls   []string
+}
+
+func (r *gitIdentityRunner) Available() bool { return true }
+
+func (r *gitIdentityRunner) Run(_ context.Context, args ...string) (string, error) {
+	r.calls = append(r.calls, strings.Join(args, " "))
+	if len(args) >= 2 && args[len(args)-2] == "--get" {
+		value, ok := r.current[args[len(args)-1]]
+		if !ok {
+			return "", errors.New("not configured")
+		}
+		return value, nil
+	}
+	return "", nil
+}
+
+func (r *gitIdentityRunner) RunStdin(context.Context, io.Reader, ...string) (string, error) {
+	return "", nil
+}
+
+func newGitIdentityProvisioner(runner *gitIdentityRunner, identity GitIdentity) *Provisioner {
+	return NewProvisioner(
+		runner,
+		nil,
+		nil,
+		nil,
+		identity,
+	)
+}
+
+func TestMissingGitIdentityIsConfiguredForRootHome(t *testing.T) {
+	runner := &gitIdentityRunner{current: map[string]string{}}
+	provisioner := newGitIdentityProvisioner(runner, GitIdentity{
+		Name:  "Example Developer",
+		Email: "developer@example.com",
+	})
+
+	if err := provisioner.EnsureGitIdentity(context.Background(), "project-1"); err != nil {
+		t.Fatalf("ensure git identity: %v", err)
+	}
+
+	want := []string{
+		"exec project-1 --env HOME=/root -- git config --global --get user.name",
+		"exec project-1 --env HOME=/root -- git config --global user.name Example Developer",
+		"exec project-1 --env HOME=/root -- git config --global --get user.email",
+		"exec project-1 --env HOME=/root -- git config --global user.email developer@example.com",
+	}
+	if !slices.Equal(runner.calls, want) {
+		t.Fatalf("git config calls = %q, want %q", runner.calls, want)
+	}
+}
+
+func TestMatchingGitIdentityDoesNotRewriteGlobalConfig(t *testing.T) {
+	runner := &gitIdentityRunner{current: map[string]string{
+		"user.name":  "Example Developer\n",
+		"user.email": "developer@example.com\n",
+	}}
+	provisioner := newGitIdentityProvisioner(runner, GitIdentity{
+		Name:  "Example Developer",
+		Email: "developer@example.com",
+	})
+
+	if err := provisioner.EnsureGitIdentity(context.Background(), "project-1"); err != nil {
+		t.Fatalf("ensure git identity: %v", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("git config call count = %d, want two reads and no writes: %q", len(runner.calls), runner.calls)
+	}
+}

--- a/backend/internal/integration/containers/workspace/instructions.go
+++ b/backend/internal/integration/containers/workspace/instructions.go
@@ -26,6 +26,7 @@ type Provisioner struct {
 	profiles     serviceprofiles.Source
 	publisher    *assets.Publisher
 	instructions []byte
+	gitIdentity  GitIdentity
 }
 
 // NewProvisioner returns a workspace provisioner backed by shared container
@@ -35,12 +36,18 @@ func NewProvisioner(
 	profileSource serviceprofiles.Source,
 	publisher *assets.Publisher,
 	instructions []byte,
+	gitIdentity ...GitIdentity,
 ) *Provisioner {
+	identity := GitIdentity{}
+	if len(gitIdentity) > 0 {
+		identity = gitIdentity[0]
+	}
 	return &Provisioner{
 		runner:       runner,
 		profiles:     profileSource,
 		publisher:    publisher,
 		instructions: append([]byte(nil), instructions...),
+		gitIdentity:  identity,
 	}
 }
 

--- a/backend/internal/service/container/launch/provisioner.go
+++ b/backend/internal/service/container/launch/provisioner.go
@@ -19,7 +19,7 @@ type WorkspaceProvisioner interface {
 }
 
 type CodeServerProvisioner interface {
-	Ensure(ctx context.Context, containerName, displayName string) error
+	Ensure(ctx context.Context, containerName, displayName, projectSlug string) error
 }
 
 type ScheduleToolsProvisioner interface {
@@ -58,7 +58,7 @@ func NewProvisioner(
 }
 
 // Provision applies launch-time capabilities in their stable order.
-func (p *Provisioner) Provision(ctx context.Context, containerName, displayName string) {
+func (p *Provisioner) Provision(ctx context.Context, containerName, displayName, projectSlug string) {
 	_ = p.credentials.EnsureRegistered(ctx, containerName)
 	_ = p.workspace.EnsureSkillLinks(ctx, containerName)
 	_ = p.browser.EnsureScript(ctx, containerName)
@@ -67,5 +67,5 @@ func (p *Provisioner) Provision(ctx context.Context, containerName, displayName 
 	if p.scheduleTools != nil {
 		_ = p.scheduleTools.Ensure(ctx, containerName)
 	}
-	_ = p.codeServer.Ensure(ctx, containerName, displayName)
+	_ = p.codeServer.Ensure(ctx, containerName, displayName, projectSlug)
 }

--- a/backend/internal/service/container/launch/provisioner.go
+++ b/backend/internal/service/container/launch/provisioner.go
@@ -16,6 +16,7 @@ type BrowserProvisioner interface {
 
 type WorkspaceProvisioner interface {
 	EnsureSkillLinks(ctx context.Context, containerName string) error
+	EnsureGitIdentity(ctx context.Context, containerName string) error
 }
 
 type CodeServerProvisioner interface {
@@ -61,6 +62,7 @@ func NewProvisioner(
 func (p *Provisioner) Provision(ctx context.Context, containerName, displayName, projectSlug string) {
 	_ = p.credentials.EnsureRegistered(ctx, containerName)
 	_ = p.workspace.EnsureSkillLinks(ctx, containerName)
+	_ = p.workspace.EnsureGitIdentity(ctx, containerName)
 	_ = p.browser.EnsureScript(ctx, containerName)
 	_ = p.browser.EnsureSkill(ctx, containerName)
 	_ = p.browser.EnsureNesting(ctx, containerName)

--- a/backend/internal/service/container/launch/provisioner_test.go
+++ b/backend/internal/service/container/launch/provisioner_test.go
@@ -23,6 +23,11 @@ func (f failingWorkspace) EnsureSkillLinks(_ context.Context, containerName stri
 	return errors.New("workspace failed")
 }
 
+func (f failingWorkspace) EnsureGitIdentity(_ context.Context, containerName string) error {
+	f.recorder.calls = append(f.recorder.calls, "git identity "+containerName)
+	return errors.New("git identity failed")
+}
+
 type failingBrowser struct{ recorder *callRecorder }
 
 func (f failingBrowser) EnsureScript(_ context.Context, containerName string) error {
@@ -69,6 +74,7 @@ func TestProvisionKeepsBestEffortCapabilityOrder(t *testing.T) {
 	want := []string{
 		"credentials project-1",
 		"workspace project-1",
+		"git identity project-1",
 		"browser script project-1",
 		"browser skill project-1",
 		"browser nesting project-1",

--- a/backend/internal/service/container/launch/provisioner_test.go
+++ b/backend/internal/service/container/launch/provisioner_test.go
@@ -42,8 +42,8 @@ func (f failingBrowser) EnsureNesting(_ context.Context, containerName string) e
 
 type failingCodeServer struct{ recorder *callRecorder }
 
-func (f failingCodeServer) Ensure(_ context.Context, containerName, displayName string) error {
-	f.recorder.calls = append(f.recorder.calls, "code-server "+containerName+" "+displayName)
+func (f failingCodeServer) Ensure(_ context.Context, containerName, displayName, projectSlug string) error {
+	f.recorder.calls = append(f.recorder.calls, "code-server "+containerName+" "+displayName+" "+projectSlug)
 	return errors.New("code-server failed")
 }
 
@@ -64,7 +64,7 @@ func TestProvisionKeepsBestEffortCapabilityOrder(t *testing.T) {
 		failingScheduleTools{recorder: recorder},
 	)
 
-	provisioner.Provision(context.Background(), "project-1", "My Project")
+	provisioner.Provision(context.Background(), "project-1", "My Project", "my-project")
 
 	want := []string{
 		"credentials project-1",
@@ -73,7 +73,7 @@ func TestProvisionKeepsBestEffortCapabilityOrder(t *testing.T) {
 		"browser skill project-1",
 		"browser nesting project-1",
 		"schedule tools project-1",
-		"code-server project-1 My Project",
+		"code-server project-1 My Project my-project",
 	}
 	if !slices.Equal(recorder.calls, want) {
 		t.Fatalf("calls: got %q, want %q", recorder.calls, want)

--- a/backend/internal/service/container/lifecycle/service.go
+++ b/backend/internal/service/container/lifecycle/service.go
@@ -49,7 +49,7 @@ type ResourceEnsurer interface {
 }
 
 type LaunchProvisioner interface {
-	Provision(ctx context.Context, containerName, displayName string)
+	Provision(ctx context.Context, containerName, displayName, projectSlug string)
 }
 
 type ProfileSource interface {
@@ -261,9 +261,10 @@ func (s *Service) Ensure(ctx context.Context, project serviceproject.Meta) error
 			return retryErr
 		}
 	}
-	if created || len(changes) > 0 {
-		s.provisioner.Provision(ctx, project.ContainerName, project.Name)
-	}
+	// Reconcile launch-time capabilities for existing containers too. This is
+	// what lets fleet-wide additions (such as preview URL configuration) reach
+	// old workspaces without deleting or recreating them.
+	s.provisioner.Provision(ctx, project.ContainerName, project.Name, project.Slug)
 	return nil
 }
 

--- a/backend/internal/service/container/lifecycle/service_test.go
+++ b/backend/internal/service/container/lifecycle/service_test.go
@@ -133,8 +133,8 @@ func (r recordingResources) SetLimits(_ context.Context, container, cpu, memory,
 
 type recordingProvisioner struct{ events *[]string }
 
-func (p recordingProvisioner) Provision(_ context.Context, container, name string) {
-	*p.events = append(*p.events, "provision "+container+" "+name)
+func (p recordingProvisioner) Provision(_ context.Context, container, name, slug string) {
+	*p.events = append(*p.events, "provision "+container+" "+name+" "+slug)
 }
 
 type testProfileSource struct{}
@@ -152,6 +152,7 @@ func testProject(t *testing.T) serviceproject.Meta {
 	t.Helper()
 	return serviceproject.Meta{
 		Name:          "My Project",
+		Slug:          "my-project",
 		Cwd:           filepath.Join(t.TempDir(), "project", "workspace"),
 		ContainerName: "project-1",
 	}
@@ -197,7 +198,7 @@ func TestEnsureCreatesStoppedContainerThenAttachesAndValidatesAllDurableMounts(t
 	if initAt < 0 || attachAt < initAt || startAt < attachAt {
 		t.Fatalf("container was not initialized, mounted, then started: %q", events)
 	}
-	if !slices.Contains(events, "provision project-1 My Project") {
+	if !slices.Contains(events, "provision project-1 My Project my-project") {
 		t.Fatalf("launch provisioning missing: %q", events)
 	}
 }
@@ -253,6 +254,9 @@ func TestEnsureRunningHealthyContainerDoesNotRestart(t *testing.T) {
 	}
 	if slices.Contains(events, "runtime stop project-1") || slices.Contains(events, "runtime start project-1") {
 		t.Fatalf("healthy container restarted: %q", events)
+	}
+	if !slices.Contains(events, "provision project-1 My Project my-project") {
+		t.Fatalf("healthy existing container was not reconciled: %q", events)
 	}
 }
 

--- a/backend/internal/transport/transport.go
+++ b/backend/internal/transport/transport.go
@@ -70,6 +70,7 @@ func NewHTTPHandler(deps Dependencies) (http.Handler, error) {
 	}
 	chatSocket := wstransport.NewChatSocket(deps.Services.Chats, deps.Services.Runs, deps.Services.Prompt)
 	terminalSocket := wstransport.NewContainerTerminalSocket(deps.Services.Chats, deps.Services.Projects)
+	tmuxSocket := wstransport.NewTmuxSocket(deps.TmuxClient)
 	workspaceSocket := wstransport.NewWorkspaceSocket(
 		deps.Services.Chats,
 		deps.Services.Projects,
@@ -78,6 +79,7 @@ func NewHTTPHandler(deps Dependencies) (http.Handler, error) {
 	if deps.Services.Auth != nil {
 		chatSocket = chatSocket.WithAccessChecker(gate)
 		terminalSocket = terminalSocket.WithAccessChecker(gate)
+		tmuxSocket = tmuxSocket.WithAccessChecker(gate)
 		workspaceSocket = workspaceSocket.WithVisibility(gate)
 	}
 	scheduleHandler := httphandlers.NewScheduleHandler(
@@ -128,7 +130,7 @@ func NewHTTPHandler(deps Dependencies) (http.Handler, error) {
 		Schedules:        scheduleHandler,
 		Usage:            usageHandler,
 		Uploads:          uploads,
-		TmuxWS:           wstransport.NewTmuxSocket(deps.TmuxClient),
+		TmuxWS:           tmuxSocket,
 		TerminalWS:       terminalSocket,
 		ChatWS:           chatSocket,
 		WorkspaceWS:      workspaceSocket,

--- a/backend/internal/transport/ws/tmux_socket.go
+++ b/backend/internal/transport/ws/tmux_socket.go
@@ -13,6 +13,12 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+const globalTerminalSession = "remote-global"
+
+type AdminAccessChecker interface {
+	CallerAndAdmin(ctx context.Context, r *http.Request) (string, bool, error)
+}
+
 type clientMsg struct {
 	Type string `json:"type"`
 	Data string `json:"data,omitempty"`
@@ -27,24 +33,47 @@ type TmuxSessionClient interface {
 
 type TmuxSocket struct {
 	client TmuxSessionClient
+	access AdminAccessChecker
 }
 
 func NewTmuxSocket(client TmuxSessionClient) *TmuxSocket {
 	return &TmuxSocket{client: client}
 }
 
+func (s *TmuxSocket) WithAccessChecker(access AdminAccessChecker) *TmuxSocket {
+	s.access = access
+	return s
+}
+
 func (s *TmuxSocket) Handle(upgrader websocket.Upgrader) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		s.handle(upgrader, w, r)
+		s.handle(upgrader, w, r, r.URL.Query().Get("session"))
+	}
+}
+
+func (s *TmuxSocket) HandleGlobal(upgrader websocket.Upgrader) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.handle(upgrader, w, r, globalTerminalSession)
 	}
 }
 
 func (s *TmuxSocket) RegisterRoutes(mux *http.ServeMux, upgrader websocket.Upgrader) {
 	mux.HandleFunc("/ws", s.Handle(upgrader))
+	mux.HandleFunc("/ws/host-terminal", s.HandleGlobal(upgrader))
 }
 
-func (s *TmuxSocket) handle(upgrader websocket.Upgrader, w http.ResponseWriter, r *http.Request) {
-	name := r.URL.Query().Get("session")
+func (s *TmuxSocket) handle(upgrader websocket.Upgrader, w http.ResponseWriter, r *http.Request, name string) {
+	if s.access != nil {
+		email, isAdmin, err := s.access.CallerAndAdmin(r.Context(), r)
+		if err != nil || email == "" {
+			http.Error(w, "authentication required", http.StatusUnauthorized)
+			return
+		}
+		if !isAdmin {
+			http.Error(w, "administrator access required", http.StatusForbidden)
+			return
+		}
+	}
 	if !tmuxcli.ValidName(name) {
 		http.Error(w, "invalid session name", http.StatusBadRequest)
 		return

--- a/backend/internal/transport/ws/tmux_socket_test.go
+++ b/backend/internal/transport/ws/tmux_socket_test.go
@@ -1,0 +1,113 @@
+package wstransport
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+type tmuxAccessStub struct {
+	email string
+	admin bool
+	err   error
+}
+
+func (s tmuxAccessStub) CallerAndAdmin(context.Context, *http.Request) (string, bool, error) {
+	return s.email, s.admin, s.err
+}
+
+type tmuxClientStub struct {
+	hasName    string
+	createName string
+	createErr  error
+}
+
+func (s *tmuxClientStub) Has(name string) bool {
+	s.hasName = name
+	return false
+}
+
+func (s *tmuxClientStub) Create(name string) error {
+	s.createName = name
+	return s.createErr
+}
+
+func TestGlobalTerminalRequiresAuthentication(t *testing.T) {
+	client := &tmuxClientStub{}
+	socket := NewTmuxSocket(client).WithAccessChecker(tmuxAccessStub{})
+
+	response := httptest.NewRecorder()
+	socket.HandleGlobal(websocket.Upgrader{}).ServeHTTP(
+		response,
+		httptest.NewRequest(http.MethodGet, "/ws/host-terminal", nil),
+	)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusUnauthorized)
+	}
+	if client.hasName != "" || client.createName != "" {
+		t.Fatal("terminal client was called before authentication")
+	}
+}
+
+func TestGlobalTerminalRequiresAdministrator(t *testing.T) {
+	client := &tmuxClientStub{}
+	socket := NewTmuxSocket(client).WithAccessChecker(tmuxAccessStub{
+		email: "member@example.com",
+	})
+
+	response := httptest.NewRecorder()
+	socket.HandleGlobal(websocket.Upgrader{}).ServeHTTP(
+		response,
+		httptest.NewRequest(http.MethodGet, "/ws/host-terminal", nil),
+	)
+
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusForbidden)
+	}
+	if client.hasName != "" || client.createName != "" {
+		t.Fatal("terminal client was called for a non-administrator")
+	}
+}
+
+func TestGlobalTerminalUsesPersistentFixedSession(t *testing.T) {
+	client := &tmuxClientStub{createErr: errors.New("stop before starting tmux")}
+	socket := NewTmuxSocket(client).WithAccessChecker(tmuxAccessStub{
+		email: "admin@example.com",
+		admin: true,
+	})
+
+	response := httptest.NewRecorder()
+	socket.HandleGlobal(websocket.Upgrader{}).ServeHTTP(
+		response,
+		httptest.NewRequest(http.MethodGet, "/ws/host-terminal?session=ignored", nil),
+	)
+
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
+	}
+	if client.hasName != globalTerminalSession || client.createName != globalTerminalSession {
+		t.Fatalf("session calls = Has(%q), Create(%q), want %q", client.hasName, client.createName, globalTerminalSession)
+	}
+}
+
+func TestLegacyHostTerminalAlsoRequiresAdministrator(t *testing.T) {
+	client := &tmuxClientStub{}
+	socket := NewTmuxSocket(client).WithAccessChecker(tmuxAccessStub{
+		email: "member@example.com",
+	})
+
+	response := httptest.NewRecorder()
+	socket.Handle(websocket.Upgrader{}).ServeHTTP(
+		response,
+		httptest.NewRequest(http.MethodGet, "/ws?session=existing", nil),
+	)
+
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusForbidden)
+	}
+}

--- a/docs/02-user-guide/14-host-and-workspace-reliability.md
+++ b/docs/02-user-guide/14-host-and-workspace-reliability.md
@@ -1,0 +1,113 @@
+# Host and workspace reliability
+
+Remote keeps the control plane on the host and gives every project its own LXD
+container. This page explains the reliability behavior around resource limits,
+browser previews, Git commits, host administration, and infrastructure updates.
+
+## What this protects
+
+| Area | Previous symptom | Current behavior |
+| --- | --- | --- |
+| Memory limits | Reconvergence could replace an explicit project limit with the default | An explicit override remains authoritative; the default is used only when no override exists |
+| Dev-server previews | A server worked inside the container but its public preview failed or generated the wrong origin | Code-server, Vite, Caddy, and container lifecycle provisioning use the same project preview hostname |
+| Git commits | VS Code reported that `user.name` and `user.email` were missing | New and recycled workspaces receive safe, non-secret author metadata in a writable global Git config |
+| Host operations | An administrator had to leave Remote and open a separate SSH session | **Settings → Terminal** opens an administrator-only terminal on the Remote host |
+| Workspace updates | Container migration could stop because `BASE_URL` was unavailable outside systemd | The upgrader reads the installed public URL from the rendered service unit without loading secrets |
+
+## Memory limits survive convergence
+
+Project resource settings are policy, not a one-time launch hint. When Remote
+starts, repairs, or replaces a container, it distinguishes an administrator's
+explicit memory override from an absent value. Explicit CPU, memory, and disk
+choices remain attached to that project; platform defaults fill only missing
+settings.
+
+Open the project's settings to inspect or change its limit. A workspace
+replacement may stop and recreate the container, but it must not silently
+restore a different memory value.
+
+## Preview routing has one public origin
+
+A project dev server still listens inside its container. Remote publishes it
+through a dedicated HTTPS hostname and passes the same origin into code-server
+and the Vite allow-list. The generated Caddy configuration forwards requests
+and WebSockets without requiring a project to expose its container directly.
+
+After changing the deployment hostname or upgrading an older container, Remote
+converges the code-server systemd drop-in. It restarts an active IDE only when
+that managed configuration changed.
+
+## Git author identity and GitHub authentication are separate
+
+Git needs author metadata before it can create a commit. Remote provisions the
+following safe defaults when no operator override is supplied:
+
+```text
+user.name=Remote User
+user.email=remote@localhost
+```
+
+Operators can set `REMOTE_GIT_USER_NAME` and `REMOTE_GIT_USER_EMAIL` in the
+host-local `config.env`. That file is not part of the repository.
+
+The provisioner writes only these two non-secret fields. GitHub tokens, SSH
+private keys, passwords, and credential helpers are never copied into Git
+configuration by this feature. GitHub may still ask the user to authenticate
+the first time a workspace pushes; that authorization is independent of the
+commit author identity.
+
+Some provider credential mounts make `/root/.config/git` read-only. Remote
+therefore writes author metadata to `/root/.gitconfig`. The code-server service
+receives explicit `HOME=/root` and `GIT_CONFIG_GLOBAL=/root/.gitconfig` values
+so the terminal and VS Code Git extension resolve the same identity.
+
+## Use the global terminal carefully
+
+Server administrators can open **Settings → Terminal** to work on the Remote
+host rather than inside one project. The terminal attaches to a server-selected
+tmux session and the WebSocket endpoint requires an authenticated administrator.
+A client cannot choose an arbitrary host session.
+
+The global terminal has host-level reach. Use a project terminal for normal
+development and reserve the global terminal for operations such as service
+status, disk inspection, backups, and controlled updates. Commands run there
+can affect every project.
+
+## Infrastructure updates keep secrets out of the shell
+
+The application service receives its public `BASE_URL` from the rendered
+systemd unit. Workspace migration runs from an operator shell, so it does not
+automatically inherit that environment. The upgrader recovers only the
+installed `BASE_URL` from the unit when needed. It deliberately does not source
+`config.env`, because that file can contain credentials.
+
+Changes to Caddy, systemd, workspace provisioning, the reusable base image, or
+the updater require a minor or major release and the full infrastructure update
+path. During container migration:
+
+- `/workspace` and managed provider homes remain durable;
+- idle containers are replaced and validated against the new image;
+- containers with an active agent process are skipped unless the operator
+  explicitly includes busy projects;
+- packages installed elsewhere in a container root filesystem may disappear.
+
+Take an external backup before a major host change. Durable storage protects
+normal lifecycle operations, but it is not a substitute for a backup.
+
+## Troubleshooting checklist
+
+If VS Code still reports a missing Git identity:
+
+1. Reload the IDE after code-server has been reprovisioned.
+2. Run `git config --global --get user.name` and
+   `git config --global --get user.email` in the project terminal.
+3. Treat a later GitHub sign-in prompt as repository authentication, not an
+   author-identity failure.
+
+If a preview works on `localhost` but not through Remote, verify that the server
+listens on a shareable port and use the preview URL generated by Remote rather
+than a container address.
+
+If an infrastructure update stops before workspace migration, inspect the
+installer log in **Settings → Updates** and rerun the full update only after
+the reported host configuration problem is resolved.

--- a/docs/02-user-guide/README.md
+++ b/docs/02-user-guide/README.md
@@ -47,6 +47,7 @@ If this is your first session:
 | Follow a complete end-to-end recipe | [Everyday workflows](11-everyday-workflows.md) |
 | Diagnose a problem | [Troubleshooting](12-troubleshooting.md) |
 | Check whether a feature exists and who may use it | [Complete feature reference](13-feature-reference.md) |
+| Understand memory limits, Git identity, preview routing, host terminal, or safe updates | [Host and workspace reliability](14-host-and-workspace-reliability.md) |
 
 ## The application surfaces
 

--- a/frontend/src/api/terminalApi.ts
+++ b/frontend/src/api/terminalApi.ts
@@ -4,6 +4,7 @@ import type {
   TerminalConnection,
   TerminalConnectionCallbacks,
 } from "../types/terminal";
+import type { ApplicationPath } from "../types/transport";
 import { WEB_SOCKET_ROUTES } from "../config/routes";
 import {
   TERMINAL_MESSAGE_TYPES,
@@ -20,16 +21,19 @@ type TerminalClientMessage =
 
 export const terminalApi = {
   connect(chatId: string, callbacks: TerminalConnectionCallbacks): TerminalConnection {
-    return new WebSocketTerminalConnection(chatId, callbacks);
+    return new WebSocketTerminalConnection(WEB_SOCKET_ROUTES.terminal(chatId), callbacks);
+  },
+  connectHost(callbacks: TerminalConnectionCallbacks): TerminalConnection {
+    return new WebSocketTerminalConnection(WEB_SOCKET_ROUTES.hostTerminal, callbacks);
   },
 };
 
 class WebSocketTerminalConnection implements TerminalConnection {
   readonly #connection: WebSocketConnection;
 
-  constructor(chatId: string, callbacks: TerminalConnectionCallbacks) {
+  constructor(route: ApplicationPath, callbacks: TerminalConnectionCallbacks) {
     this.#connection = new WebSocketConnection({
-      url: webSocketUrl(WEB_SOCKET_ROUTES.terminal(chatId)),
+      url: webSocketUrl(route),
       binaryType: TERMINAL_WEB_SOCKET_BINARY_TYPE,
       onOpen: callbacks.onOpen,
       onMessage(data) {

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -137,6 +137,7 @@ export const API_ROUTES = {
 
 export const WEB_SOCKET_ROUTES = {
   workspace: applicationPath("/ws/workspace"),
+  hostTerminal: applicationPath("/ws/host-terminal"),
   agentAuthStatus: (provider: string): ApplicationPath =>
     applicationPath(`/ws/agent-auth/${encodeURIComponent(provider)}`),
   chat: (chatId: string, sinceSeq: number): ApplicationPath => {

--- a/frontend/src/state/hooks/chat/useTerminalSession.ts
+++ b/frontend/src/state/hooks/chat/useTerminalSession.ts
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { terminalApi } from "../../../api/terminalApi";
-import type { TerminalConnection, TerminalStatus } from "../../../types/terminal";
+import type {
+  TerminalConnection,
+  TerminalConnectionCallbacks,
+  TerminalStatus,
+} from "../../../types/terminal";
 import {
   TERMINAL_CONNECTION_ERROR_MESSAGE,
   TERMINAL_DEFAULT_TITLE,
@@ -23,10 +27,12 @@ export function useTerminalSession({
   chatId,
   enabled,
   title,
+  target = "workspace",
 }: {
-  chatId: string;
+  chatId?: string;
   enabled: boolean;
   title?: string;
+  target?: "workspace" | "host";
 }) {
   const hostRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<XTerm | null>(null);
@@ -79,7 +85,7 @@ export function useTerminalSession({
     terminalRef.current = terminal;
     fitRef.current = fit;
 
-    const connection = terminalApi.connect(chatId, {
+    const callbacks: TerminalConnectionCallbacks = {
       onOpen() {
         if (disposed) return;
         setStatus(TERMINAL_STATUS.connected);
@@ -104,7 +110,10 @@ export function useTerminalSession({
           current === TERMINAL_STATUS.error ? current : TERMINAL_STATUS.closed
         );
       },
-    });
+    };
+    const connection = target === "host"
+      ? terminalApi.connectHost(callbacks)
+      : terminalApi.connect(chatId || "", callbacks);
     connectionRef.current = connection;
     setStatus(TERMINAL_STATUS.connecting);
     setError(null);
@@ -132,7 +141,7 @@ export function useTerminalSession({
       terminalRef.current = null;
       fitRef.current = null;
     };
-  }, [chatId, enabled, fitAndResize]);
+  }, [chatId, enabled, fitAndResize, target]);
 
   return {
     hostRef,

--- a/frontend/src/ui/settings/HostTerminalSettings.tsx
+++ b/frontend/src/ui/settings/HostTerminalSettings.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "preact/hooks";
+import { useTerminalSession } from "../../state/hooks/chat/useTerminalSession";
+import { ShieldCheck, Terminal as TerminalIcon, X } from "../primitives/icons";
+
+export function HostTerminalSettings() {
+  const [open, setOpen] = useState(false);
+  const terminal = useTerminalSession({
+    enabled: open,
+    target: "host",
+    title: "host",
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(terminal.focus);
+    return () => cancelAnimationFrame(frame);
+  }, [open, terminal.focus]);
+
+  const statusLabel =
+    terminal.status === "connected" ? "Connected" :
+    terminal.status === "connecting" ? "Connecting" :
+    terminal.status === "error" ? "Error" :
+    "Closed";
+
+  return (
+    <section class="overflow-hidden rounded-card border border-line bg-surface">
+      <div class="flex flex-col gap-4 border-b border-line p-4 sm:flex-row sm:items-center">
+        <div class="flex min-w-0 flex-1 items-start gap-3">
+          <div class="grid size-10 flex-none place-items-center rounded-md border border-line bg-tint">
+            <TerminalIcon class="size-5 text-accent-blue" />
+          </div>
+          <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-2">
+              <h2 class="text-balance text-[14.5px] font-semibold text-ink-50">Global terminal</h2>
+              <span class="rounded-full border border-line bg-tint px-2 py-0.5 text-[11px] font-medium text-ink-300">
+                Administrators only
+              </span>
+            </div>
+            <p class="mt-1 text-pretty text-[12.5px] leading-relaxed text-ink-300">
+              Work directly on the host server. The persistent tmux session stays available when you close this page.
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen((current) => !current)}
+          class="inline-flex h-10 flex-none items-center justify-center gap-2 rounded-md border border-line bg-tint px-3 text-[13px] font-medium text-ink-100 hover:bg-tint-strong"
+        >
+          {open ? <X class="size-4" /> : <TerminalIcon class="size-4" />}
+          {open ? "Close terminal" : "Open global terminal"}
+        </button>
+      </div>
+
+      <div class="flex items-start gap-2 border-b border-accent-yellow/30 bg-accent-yellow/10 px-4 py-3 text-[12.5px] leading-relaxed text-ink-200">
+        <ShieldCheck class="mt-0.5 size-4 flex-none text-accent-yellow" />
+        <p class="text-pretty">
+          Commands run with the Remote service account and can affect every project and the server itself. Review commands before running them.
+        </p>
+      </div>
+
+      {terminal.error && (
+        <div class="mx-4 mt-4 rounded-md border border-accent-red/30 bg-accent-red/10 px-3 py-2 text-sm text-accent-red">
+          {terminal.error}
+        </div>
+      )}
+
+      {open ? (
+        <div class="h-[32rem] min-h-96 p-3">
+          <div class="mb-2 flex items-center gap-2 text-[12px] text-ink-300">
+            <span class={`size-2 rounded-full ${terminal.status === "connected" ? "bg-accent-green" : "bg-ink-400"}`} />
+            <span>{statusLabel} — host</span>
+          </div>
+          <div
+            ref={terminal.hostRef}
+            class="h-[calc(100%-1.5rem)] w-full overflow-hidden rounded-md border border-line bg-inset p-2"
+            aria-label="Global host terminal"
+          />
+        </div>
+      ) : (
+        <div class="p-4 text-pretty text-[13px] text-ink-300">
+          Open the terminal to start or reconnect to the shared host session.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/ui/settings/SettingsPage.tsx
+++ b/frontend/src/ui/settings/SettingsPage.tsx
@@ -15,6 +15,7 @@ import {
   Menu,
   Monitor,
   ShieldCheck,
+  Terminal,
   Users,
 } from "../primitives/icons";
 import { AppearanceSettings } from "./AppearanceSettings";
@@ -25,6 +26,7 @@ import { SecuritySettings } from "./SecuritySettings";
 import { ServerInfoSettings } from "./ServerInfoSettings";
 import { UpdatesSettings } from "./UpdatesSettings";
 import { UsageSettings } from "./UsageSettings";
+import { HostTerminalSettings } from "./HostTerminalSettings";
 import { UsersPanel } from "../account/UsersPanel";
 import type { UsageDashboard } from "../../state/hooks/usage/useUsageDashboard";
 
@@ -35,6 +37,7 @@ export type SettingsTab =
   | "users"
   | "security"
   | "updates"
+  | "terminal"
   | "info"
   | "usage";
 
@@ -85,6 +88,12 @@ const tabs: Array<{
     label: "Updates",
     description: "Check for new releases and install them.",
     Icon: Download,
+  },
+  {
+    id: "terminal",
+    label: "Terminal",
+    description: "Open an administrator shell on the host server.",
+    Icon: Terminal,
   },
   {
     id: "info",
@@ -290,6 +299,15 @@ export function SettingsPage({
               ) : (
                 <SettingsNotice>
                   Application updates are managed by server administrators.
+                </SettingsNotice>
+              ))}
+
+            {activeTab === "terminal" &&
+              (isAdmin ? (
+                <HostTerminalSettings />
+              ) : (
+                <SettingsNotice>
+                  The global terminal is restricted to server administrators.
                 </SettingsNotice>
               ))}
 

--- a/infra/templates/Caddyfile.tmpl
+++ b/infra/templates/Caddyfile.tmpl
@@ -114,9 +114,10 @@ code.${HOSTNAME} {
     respond "Use <slug>.code.${HOSTNAME}" 400
 }
 
-# Per-project dev URLs. <slug>--<port>.dev.${HOSTNAME} proxies into the
-# project's LXD container at <slug>.lxd:<port>. The .lxd resolution
-# depends on the systemd-resolved drop-in installed by infra/steps/01-host-deps.sh.
+# Per-project dev URLs. Requests enter the project's code-server proxy, which
+# can reach dev servers bound to either 127.0.0.1 or 0.0.0.0 inside the
+# container. The public URL stays at the origin root, so root-relative assets
+# and WebSockets work without exposing the internal /proxy/<port>/ path.
 *.dev.${HOSTNAME} {
     encode zstd gzip
     tls {
@@ -139,7 +140,14 @@ code.${HOSTNAME} {
         header_regexp host Host ^([a-z0-9][a-z0-9-]*)--(\d{4,5})\.dev\.${HOSTNAME_RE}$
     }
     handle @valid {
-        reverse_proxy {re.host.1}.lxd:{re.host.2} {
+        rewrite * /proxy/{re.host.2}{uri}
+        reverse_proxy {re.host.1}.lxd:8842 {
+            transport http {
+                keepalive off
+            }
+            # localhost is accepted by Vite releases that predate the
+            # __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS compatibility variable.
+            header_up Host localhost:{re.host.2}
             # Strip remote.futrx's own auth cookies before the request
             # enters the project container. forward_auth (above) already
             # validated the session against the main backend on loopback, so

--- a/infra/templates/remote.futrx.service.tmpl
+++ b/infra/templates/remote.futrx.service.tmpl
@@ -12,6 +12,9 @@ Environment=PATH=${HOST_CLI_BIN_DIR}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/u
 Environment=DATA_DIR=${INSTALL_DIR}/data
 Environment=INSTALL_DIR=${INSTALL_DIR}
 Environment=BASE_URL=https://${HOSTNAME}
+# Optional persistent operator overrides, including REMOTE_GIT_USER_NAME and
+# REMOTE_GIT_USER_EMAIL. This file is host-local and is never part of Git.
+EnvironmentFile=-${INSTALL_DIR}/config.env
 # tmux server inherits this cgroup; KillMode=process keeps long-running
 # child processes (claude, codex, lxc exec) alive during a backend restart.
 KillMode=process

--- a/infra/tests/update-progress-test.sh
+++ b/infra/tests/update-progress-test.sh
@@ -21,6 +21,12 @@ grep -Eq '"updatedAt":[0-9]+' "$FUTRX_UPDATE_PROGRESS_PATH"
 
 grep -Fq 'maintenance.json' "$UPGRADE_SCRIPT"
 grep -Fq -- '--progress-file' "$UPGRADE_SCRIPT"
+grep -Fq 'FUTRX_SERVICE_UNIT_PATH' "$UPGRADE_SCRIPT"
+grep -Fq 'Environment=BASE_URL=' "$UPGRADE_SCRIPT"
+if grep -Fq 'source "$INSTALL_DIR/config.env"' "$UPGRADE_SCRIPT"; then
+    echo "workspace upgrader must not source secret-bearing config.env" >&2
+    exit 1
+fi
 if grep -Eq 'systemctl[[:space:]]+stop' "$UPGRADE_SCRIPT"; then
     echo "workspace upgrader still stops the control plane" >&2
     exit 1

--- a/infra/upgrade-workspaces.sh
+++ b/infra/upgrade-workspaces.sh
@@ -30,6 +30,7 @@ set -euo pipefail
 INFRA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DATA_DIR="${FUTRX_DATA_DIR:-/opt/remote.futrx/data}"
 MAINTENANCE_FILE="${FUTRX_MAINTENANCE_FILE:-$DATA_DIR/self-update/maintenance.json}"
+SERVICE_UNIT="${FUTRX_SERVICE_UNIT_PATH:-/etc/systemd/system/remote.futrx.service}"
 
 log()  { printf "\n\033[1;36m==> %s\033[0m\n" "$*"; }
 warn() { printf "\033[1;33m!! %s\033[0m\n" "$*"; }
@@ -55,6 +56,15 @@ fi
 if ! command -v lxc >/dev/null; then
     err "lxc CLI not found"
     exit 1
+fi
+
+# The lifecycle command loads the same application config as the service and
+# therefore validates BASE_URL. Infrastructure updates run from an operator
+# shell, not under systemd, so recover the installed value when it was not
+# explicitly exported. Do not source config.env here: it may contain secrets.
+if [ -z "${BASE_URL:-}" ] && [ -f "$SERVICE_UNIT" ]; then
+    BASE_URL="$(sed -n 's/^Environment=BASE_URL=//p' "$SERVICE_UNIT" | head -1)"
+    export BASE_URL
 fi
 # ───────────────── 1. rebake ─────────────────
 if [ "$REBAKE" -eq 1 ]; then


### PR DESCRIPTION
## Summary

This PR collects eight focused fixes validated on a live Ubuntu/LXD deployment:

- preserve explicit workspace memory limits instead of replacing them with defaults;
- route project dev servers through the code-server path and generated Caddy configuration;
- provision non-secret Git author metadata for project workspaces;
- expose an admin-only global host terminal from Settings;
- make workspace upgrades inherit the installed `BASE_URL` without sourcing secret-bearing configuration;
- write Git identity to the writable `/root/.gitconfig` path;
- give code-server an explicit `HOME` and `GIT_CONFIG_GLOBAL` so its Git extension sees the provisioned identity;
- disable VS Code automatic GitHub OAuth for Git commands so browser IDE pushes reuse the shared credential helper.

## Problems observed and fixes

### Workspace memory overrides

Existing containers with explicit memory settings could be reconverged to the default limit. Resource convergence now distinguishes explicit overrides from missing values and keeps the requested limit stable. Tests cover both overridden and default cases.

### Dev-server previews

Project previews could fail when code-server and the edge proxy disagreed about the public preview origin. The container composition root now passes the public hostname through lifecycle provisioning, code-server receives the per-project proxy URI and Vite allow-list, and Caddy routes the dedicated preview host consistently. Existing containers are converged and active code-server services are restarted only when their drop-in changes.

### Git commits from code-server

Fresh or recycled workspaces could not commit because `user.name` and `user.email` were absent. The workspace provisioner now writes only non-secret author metadata, with operator overrides available through host-local environment settings. Tokens, SSH keys, and credential helpers remain outside this path.

Two deployment details are handled explicitly:

- `/root/.config/git` can be a read-only credential mount, so metadata is written to `/root/.gitconfig`;
- code-server previously ran without `HOME`, so its Git extension could not discover that file. Its systemd environment now sets `HOME=/root` and `GIT_CONFIG_GLOBAL=/root/.gitconfig`.

### Persistent GitHub authentication in code-server

The browser IDE previously kept a second GitHub OAuth session in container-local VS Code secret storage. A fresh or recreated IDE session could therefore ask the user to authenticate again even while the shared GitHub CLI credential remained valid. The managed code-server setting now disables automatic GitHub authentication for Git commands, allowing Git to use the existing platform-managed credential helper. The setting is installed for new containers and converged onto existing workspaces without copying credentials into source control.

### Admin global terminal

Administrators sometimes need host-level operations without entering a project container. Settings now includes a Global Terminal backed by a fixed host tmux session. The WebSocket path enforces administrator authorization and does not accept an arbitrary client-selected host session.

### Infrastructure updater

`upgrade-workspaces.sh` runs outside the application systemd service, so its Go lifecycle process could fail validation with `BASE_URL must be an absolute URL`. It now reads the installed non-secret `BASE_URL` from the rendered service unit when the caller did not export one. It deliberately does not source `config.env`, which may contain secrets.

## Security

- No credentials, tokens, SSH keys, or credential-helper configuration are added.
- The GitHub OAuth fix changes only IDE routing: credentials remain in the existing host-managed read-only mount.
- Git provisioning is limited to `user.name` and `user.email` metadata.
- Host terminal access is administrator-only and uses a server-selected session.
- The complete contribution diff was scanned for common token, key, and password patterns with no findings.

## Validation

- `npm test` — 326 tests passed.
- `npm run build` — TypeScript and Vite production build passed.
- Latest frontend and backend production builds completed on Ubuntu arm64 during deployment.
- Full infrastructure update completed against an existing LXD installation.
- Workspace lifecycle migration: 7 upgraded, 0 busy skipped, 0 failed.
- Runtime health checks passed for the backend, Caddy, all seven containers, preview routing, Global Terminal assets, Git author discovery, and non-interactive GitHub push authentication inside code-server.
- Live verification confirmed `github.gitAuthentication=false` in all seven running workspaces and `git push --dry-run` completed without an authentication prompt.
- Relevant infra tests passed: update progress, container forwarding, swap provisioning, and production app deploy script.

Known baseline: `infra/tests/qa-scripts-test.sh` currently fails the same curl-mode immutable-ref assertion on unmodified `upstream/qa`. The PR does not touch that assertion or the referenced bootstrap path.

## Release impact

This changes Caddy/systemd configuration, workspace provisioning, the reusable base image, and update machinery. Per the repository release policy, the first release containing it should use a minor or major version and the full infrastructure update path.

## Documentation

The user-facing behavior, security boundaries, upgrade semantics, and troubleshooting steps are documented in [Host and workspace reliability](https://github.com/aboelkheir/remote.futrx/blob/contribution/host-workspace-reliability/docs/02-user-guide/14-host-and-workspace-reliability.md). The guide is linked from both the root README and the user-guide index.

