### PR TITLE
refactor(infra): consolidate shared shell helpers into lib/common.sh

### DIFF
--- a/infra/deploy-app.sh
+++ b/infra/deploy-app.sh
@@ -26,6 +26,10 @@
 # Test-only overrides: FUTRX_INSTALL_DIR, FUTRX_SERVICE_NAME, FUTRX_SERVICE_PORT.
 set -euo pipefail
 
+SCRIPT_INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=lib/common.sh
+. "$SCRIPT_INFRA_DIR/lib/common.sh"
+
 usage() {
     sed -n '2,/^set -euo pipefail$/ { /^set -euo pipefail$/d; s/^# \{0,1\}//p; }' "$0"
 }
@@ -61,9 +65,8 @@ fi
 # demanding root there would make the script untestable in CI. The
 # missing-installation check above intentionally runs first so a bad path
 # reports the actionable error instead of a misleading root demand.
-if [ -z "${FUTRX_INSTALL_DIR:-}" ] && [ "$EUID" -ne 0 ]; then
-    echo "this application deployer needs root; rerun with sudo" >&2
-    exit 1
+if [ -z "${FUTRX_INSTALL_DIR:-}" ]; then
+    require_root "this application deployer"
 fi
 if ! systemctl cat "$SERVICE_NAME" >/dev/null 2>&1; then
     echo "$SERVICE_NAME is not installed; run infra/install.sh first" >&2
@@ -81,7 +84,6 @@ for command_name in git npm go systemctl; do
     }
 done
 
-SCRIPT_INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=lib/release-version.sh
 . "$SCRIPT_INFRA_DIR/lib/release-version.sh"
 # shellcheck source=lib/update-progress.sh

--- a/infra/install.sh
+++ b/infra/install.sh
@@ -60,6 +60,7 @@ if [ -z "$INFRA_DIR_PROBE" ] || [ ! -d "${INFRA_DIR_PROBE}/steps" ]; then
     # Validate the ref before demanding root so a malformed --ref reports the
     # actionable error instead of a misleading root demand (and so the
     # curl-piped contract in qa-scripts-test.sh holds for non-root runners).
+    # Inline (not via lib/common.sh): no checkout exists on disk yet here.
     if [ -n "$BOOTSTRAP_REF" ] && ! printf '%s' "$BOOTSTRAP_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
         echo "--ref must be a full 40-character commit SHA" >&2
         exit 1
@@ -151,6 +152,12 @@ if [ -z "$INFRA_DIR_PROBE" ] || [ ! -d "${INFRA_DIR_PROBE}/steps" ]; then
 fi
 
 # ───────────────── args ─────────────────
+# INFRA_DIR resolves before argument parsing so the shared helpers below
+# (and every validation gate) come from lib/common.sh. The curl|bash
+# bootstrap block above intentionally stays self-contained instead.
+INFRA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck source=lib/common.sh
+. "$INFRA_DIR/lib/common.sh"
 HOSTNAME=""
 SKIP_DNS_CHECK=0
 GOOGLE_CLIENT_ID=""
@@ -168,9 +175,8 @@ for a in "$@"; do
         *)   [ -z "$HOSTNAME" ] && HOSTNAME="$a" ;;
     esac
 done
-if [ -n "$TARGET_REF" ] && ! printf '%s' "$TARGET_REF" | grep -qE '^[0-9a-fA-F]{40}$'; then
-    echo "--ref must be a full 40-character commit SHA" >&2
-    exit 1
+if [ -n "$TARGET_REF" ]; then
+    validate_full_sha "$TARGET_REF"
 fi
 if [ -z "$HOSTNAME" ]; then
     read -rp "Public hostname (must already point here in DNS): " HOSTNAME || true
@@ -189,10 +195,7 @@ if printf '%s' "$HOSTNAME" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$|^\[.*\]$'; 
     echo "  Let's Encrypt cannot issue certs for IPs and your site will lose TLS." >&2
     exit 1
 fi
-if [ "$EUID" -ne 0 ]; then
-    echo "this installer needs root; rerun with sudo" >&2
-    exit 1
-fi
+require_root "this installer"
 
 export HOSTNAME GITHUB_TOKEN GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET
 if [ -n "$TARGET_REF" ]; then
@@ -200,7 +203,8 @@ if [ -n "$TARGET_REF" ]; then
 fi
 
 # ───────────────── globals ─────────────────
-INFRA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# INFRA_DIR was resolved before argument parsing (see above) so the shared
+# helpers are available to every validation gate.
 INSTALL_DIR="${FUTRX_INSTALL_DIR:-/opt/remote.futrx}"
 LEGACY_INSTALL_DIR="${FUTRX_LEGACY_INSTALL_DIR:-/opt/remote.futrx.dev}"
 REPO_URL="https://github.com/futrx-com/remote.futrx.git"
@@ -221,10 +225,8 @@ export INFRA_DIR INSTALL_DIR LEGACY_INSTALL_DIR REPO_URL SERVICE_PORT HOSTNAME_R
 export HOST_CLI_PREFIX HOST_CLI_BIN_DIR PATH
 
 # ───────────────── helpers (sourced by steps) ─────────────────
-log()  { printf "\n\033[1;36m==> %s\033[0m\n" "$*"; }
-warn() { printf "\n\033[1;33m!! %s\033[0m\n" "$*"; }
-ok()   { printf "\033[1;32m✓\033[0m %s\n" "$*"; }
-err()  { printf "\n\033[1;31m✗ %s\033[0m\n" "$*" >&2; }
+# log/warn/ok/err come from lib/common.sh (sourced above); re-export them so
+# the sourced convergence steps can use them in subshells.
 export -f log warn ok err
 
 # render_template TEMPLATE_PATH DEST_PATH

--- a/infra/lib/common.sh
+++ b/infra/lib/common.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Shared output, guard, and validation helpers for the infra entry points
+# (install.sh, update.sh, deploy-app.sh, upgrade-workspaces.sh).
+#
+# Source this file — it executes nothing on its own. Callers are expected to
+# run under `set -euo pipefail`. The curl|bash bootstrap block at the top of
+# install.sh intentionally stays self-contained and must not source this file
+# (no checkout exists on disk yet at that point).
+
+# Colored status output. Steps (infra/steps/*.sh) rely on these via
+# `export -f` from the entry point that sources them.
+log()  { printf "\n\033[1;36m==> %s\033[0m\n" "$*"; }
+warn() { printf "\n\033[1;33m!! %s\033[0m\n" "$*"; }
+ok()   { printf "\033[1;32m✓\033[0m %s\n" "$*"; }
+err()  { printf "\n\033[1;31m✗ %s\033[0m\n" "$*" >&2; }
+
+# die MESSAGE...
+# Print a plain error to stderr and exit 1. Use err() + exit for styled or
+# non-1 exits instead.
+die() {
+    printf '%s\n' "$*" >&2
+    exit 1
+}
+
+# require_root SUBJECT
+# Abort unless running as root, e.g. require_root "this installer" prints
+# "this installer needs root; rerun with sudo".
+require_root() {
+    if [ "$EUID" -ne 0 ]; then
+        printf '%s needs root; rerun with sudo\n' "$1" >&2
+        exit 1
+    fi
+}
+
+# validate_full_sha VALUE
+# Abort unless VALUE is a full 40-character commit SHA. The error text is
+# pinned by infra/tests/qa-scripts-test.sh — keep it byte-identical.
+validate_full_sha() {
+    if ! printf '%s' "${1:-}" | grep -qE '^[0-9a-fA-F]{40}$'; then
+        printf -- '--ref must be a full 40-character commit SHA\n' >&2
+        exit 1
+    fi
+}
+
+# script_dir
+# Print the directory containing the calling script. Call at the caller's top
+# level so BASH_SOURCE[1] is the caller's file.
+script_dir() {
+    ( cd "$(dirname "${BASH_SOURCE[1]}")" >/dev/null 2>&1 && pwd )
+}

--- a/infra/update.sh
+++ b/infra/update.sh
@@ -71,12 +71,11 @@ for a in "$@"; do
     esac
 done
 
-if [ "$EUID" -ne 0 ]; then
-    echo "this updater needs root; rerun with sudo" >&2
-    exit 1
-fi
-
 SCRIPT_INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=lib/common.sh
+. "$SCRIPT_INFRA_DIR/lib/common.sh"
+
+require_root "this updater"
 # shellcheck source=lib/install-migration.sh
 . "$SCRIPT_INFRA_DIR/lib/install-migration.sh"
 # shellcheck source=lib/update-progress.sh

--- a/infra/upgrade-workspaces.sh
+++ b/infra/upgrade-workspaces.sh
@@ -28,13 +28,10 @@
 set -euo pipefail
 
 INFRA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck source=lib/common.sh
+. "$INFRA_DIR/lib/common.sh"
 DATA_DIR="${FUTRX_DATA_DIR:-/opt/remote.futrx/data}"
 MAINTENANCE_FILE="${FUTRX_MAINTENANCE_FILE:-$DATA_DIR/self-update/maintenance.json}"
-
-log()  { printf "\n\033[1;36m==> %s\033[0m\n" "$*"; }
-warn() { printf "\033[1;33m!! %s\033[0m\n" "$*"; }
-ok()   { printf "\033[1;32m✓\033[0m %s\n" "$*"; }
-err()  { printf "\n\033[1;31m✗ %s\033[0m\n" "$*" >&2; }
 
 DRY_RUN=0
 REBAKE=1
@@ -48,10 +45,7 @@ for a in "$@"; do
     esac
 done
 
-if [ "$EUID" -ne 0 ]; then
-    err "needs root; rerun with sudo"
-    exit 1
-fi
+require_root "upgrade-workspaces"
 if ! command -v lxc >/dev/null; then
     err "lxc CLI not found"
     exit 1


### PR DESCRIPTION
Responds to the refactor request on #176. Moves the helpers duplicated across the infra entry points into one sourced file, infra/lib/common.sh: log/warn/ok/err output, require_root guard, validate_full_sha check, plus new die and script_dir helpers. install.sh, update.sh, deploy-app.sh, and upgrade-workspaces.sh now source it instead of redefining the same blocks. The curl-piped bootstrap block in install.sh stays self-contained (no checkout on disk there yet) with a comment saying so. Behavior is unchanged except upgrade-workspaces root/usage errors now use the shared plain message instead of the styled err prefix. deploy-app.sh keeps its FUTRX_INSTALL_DIR test-harness root bypass and check ordering. Verification: bash -n clean on all touched files; infra/tests/qa-scripts-test.sh passes (covers the pinned --ref error in direct and curl-piped modes); full infra shell suite results are byte-identical to the clean tree (install-migration symlink and go-toolchain versions.env failures pre-exist on this machine). Happy to split further (e.g. per-area lib files) if you want this in smaller steps.