### PR TITLE
Delete associated chats with a project

### DIFF
--- a/backend/internal/service/project/ports.go
+++ b/backend/internal/service/project/ports.go
@@ -12,6 +12,13 @@ type Repository interface {
 	Delete(ctx context.Context, id ID) error
 }
 
+// ChatCleanup removes the conversations owned by a project before the project
+// itself is destroyed. Keeping this as a narrow port avoids coupling project
+// policy to chat persistence details.
+type ChatCleanup interface {
+	DeleteProjectChats(ctx context.Context, projectID ID) error
+}
+
 // ContainerLifecycle is the project service's container state-transition port.
 // Implementations may use LXD or any other runtime; project policy only relies
 // on these lifecycle operations.

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -3,6 +3,7 @@ package project
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"regexp"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 
 type Service struct {
 	repo               Repository
+	chats              ChatCleanup
 	containerLifecycle ContainerLifecycle
 	containerInspector ContainerInspector
 	containerNetwork   ContainerNetwork
@@ -40,8 +42,9 @@ func New(
 	containers ContainerDependencies,
 	secrets SecretsRepository,
 	access AccessRepository,
+	options ...Option,
 ) *Service {
-	return &Service{
+	service := &Service{
 		repo:               repo,
 		containerLifecycle: containers.Lifecycle,
 		containerInspector: containers.Inspector,
@@ -50,6 +53,20 @@ func New(
 		access:             newAccessList(access),
 		secrets:            newSecretStore(secrets, containers.Environment),
 		browsers:           newAgentBrowsers(containers.Browser, repo),
+	}
+	for _, option := range options {
+		option(service)
+	}
+	return service
+}
+
+type Option func(*Service)
+
+// WithChatCleanup makes project deletion remove every associated chat before
+// destroying the container or project record.
+func WithChatCleanup(chats ChatCleanup) Option {
+	return func(service *Service) {
+		service.chats = chats
 	}
 }
 
@@ -288,6 +305,11 @@ func (s *Service) Delete(ctx context.Context, id ID) error {
 	m, err := s.repo.Get(ctx, id)
 	if err != nil {
 		return err
+	}
+	if s.chats != nil {
+		if err := s.chats.DeleteProjectChats(ctx, id); err != nil {
+			return fmt.Errorf("delete project chats: %w", err)
+		}
 	}
 	s.browsers.clearState(id)
 	if s.containerLifecycle != nil && m.ContainerName != "" {

--- a/backend/internal/service/project/service_delete_test.go
+++ b/backend/internal/service/project/service_delete_test.go
@@ -1,0 +1,75 @@
+package project
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type deleteTestRepository struct {
+	Repository
+	meta    Meta
+	deleted bool
+}
+
+func (repository *deleteTestRepository) Get(context.Context, ID) (Meta, error) {
+	return repository.meta, nil
+}
+
+func (repository *deleteTestRepository) Delete(context.Context, ID) error {
+	repository.deleted = true
+	return nil
+}
+
+type deleteTestChatCleanup struct {
+	projectID ID
+	err       error
+}
+
+func (cleanup *deleteTestChatCleanup) DeleteProjectChats(_ context.Context, projectID ID) error {
+	cleanup.projectID = projectID
+	return cleanup.err
+}
+
+func TestDeleteRemovesAssociatedChats(t *testing.T) {
+	repository := &deleteTestRepository{meta: Meta{ID: "deadbeef"}}
+	chats := &deleteTestChatCleanup{}
+	service := New(
+		repository,
+		ContainerDependencies{},
+		nil,
+		nil,
+		WithChatCleanup(chats),
+	)
+
+	if err := service.Delete(context.Background(), repository.meta.ID); err != nil {
+		t.Fatal(err)
+	}
+	if chats.projectID != repository.meta.ID {
+		t.Fatalf("chat cleanup project = %q, want %q", chats.projectID, repository.meta.ID)
+	}
+	if !repository.deleted {
+		t.Fatal("project record was not deleted after chat cleanup")
+	}
+}
+
+func TestDeletePreservesProjectWhenChatCleanupFails(t *testing.T) {
+	repository := &deleteTestRepository{meta: Meta{ID: "deadbeef"}}
+	wantErr := errors.New("disk full")
+	service := New(
+		repository,
+		ContainerDependencies{},
+		nil,
+		nil,
+		WithChatCleanup(&deleteTestChatCleanup{err: wantErr}),
+	)
+
+	err := service.Delete(context.Background(), repository.meta.ID)
+	if !errors.Is(err, wantErr) || !strings.Contains(err.Error(), "delete project chats") {
+		t.Fatalf("Delete() error = %v, want wrapped chat cleanup error", err)
+	}
+	if repository.deleted {
+		t.Fatal("project record was deleted after chat cleanup failed")
+	}
+}

--- a/backend/internal/service/project_chat_cleanup.go
+++ b/backend/internal/service/project_chat_cleanup.go
@@ -12,9 +12,8 @@ import (
 // projectChatCleanup adapts the chat service's persistence and run controls to
 // the narrow cleanup contract owned by the project service.
 type projectChatCleanup struct {
-	chats     servicechat.Repository
-	isRunning func(servicechat.ID) bool
-	cancel    func(context.Context, servicechat.ID) error
+	chats  servicechat.Repository
+	cancel func(context.Context, servicechat.ID) error
 }
 
 func (cleanup projectChatCleanup) DeleteProjectChats(
@@ -31,11 +30,13 @@ func (cleanup projectChatCleanup) DeleteProjectChats(
 		if chat.ProjectID != servicechat.ProjectID(projectID) {
 			continue
 		}
-		if cleanup.isRunning != nil && cleanup.isRunning(chat.ID) && cleanup.cancel != nil {
-			if err := cleanup.cancel(ctx, chat.ID); err != nil {
-				failures = append(failures, fmt.Errorf("cancel chat %s: %w", chat.ID, err))
-				continue
-			}
+		if cleanup.cancel == nil {
+			failures = append(failures, fmt.Errorf("cancel chat %s: cancellation unavailable", chat.ID))
+			continue
+		}
+		if err := cleanup.cancel(ctx, chat.ID); err != nil {
+			failures = append(failures, fmt.Errorf("cancel chat %s: %w", chat.ID, err))
+			continue
 		}
 		if err := cleanup.chats.Delete(ctx, chat.ID); err != nil {
 			failures = append(failures, fmt.Errorf("delete chat %s: %w", chat.ID, err))

--- a/backend/internal/service/project_chat_cleanup.go
+++ b/backend/internal/service/project_chat_cleanup.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
+)
+
+// projectChatCleanup adapts the chat service's persistence and run controls to
+// the narrow cleanup contract owned by the project service.
+type projectChatCleanup struct {
+	chats     servicechat.Repository
+	isRunning func(servicechat.ID) bool
+	cancel    func(context.Context, servicechat.ID) error
+}
+
+func (cleanup projectChatCleanup) DeleteProjectChats(
+	ctx context.Context,
+	projectID serviceproject.ID,
+) error {
+	chats, err := cleanup.chats.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list chats: %w", err)
+	}
+
+	var failures []error
+	for _, chat := range chats {
+		if chat.ProjectID != servicechat.ProjectID(projectID) {
+			continue
+		}
+		if cleanup.isRunning != nil && cleanup.isRunning(chat.ID) && cleanup.cancel != nil {
+			if err := cleanup.cancel(ctx, chat.ID); err != nil {
+				failures = append(failures, fmt.Errorf("cancel chat %s: %w", chat.ID, err))
+				continue
+			}
+		}
+		if err := cleanup.chats.Delete(ctx, chat.ID); err != nil {
+			failures = append(failures, fmt.Errorf("delete chat %s: %w", chat.ID, err))
+		}
+	}
+	return errors.Join(failures...)
+}

--- a/backend/internal/service/project_chat_cleanup_test.go
+++ b/backend/internal/service/project_chat_cleanup_test.go
@@ -1,0 +1,101 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
+)
+
+type cleanupChatRepository struct {
+	servicechat.Repository
+	chats     []servicechat.Meta
+	listErr   error
+	deleteErr map[servicechat.ID]error
+	deleted   []servicechat.ID
+}
+
+func (repository *cleanupChatRepository) List(context.Context) ([]servicechat.Meta, error) {
+	return repository.chats, repository.listErr
+}
+
+func (repository *cleanupChatRepository) Delete(_ context.Context, id servicechat.ID) error {
+	if err := repository.deleteErr[id]; err != nil {
+		return err
+	}
+	repository.deleted = append(repository.deleted, id)
+	return nil
+}
+
+func TestProjectChatCleanupDeletesOnlyMatchingChatsAndCancelsRuns(t *testing.T) {
+	repository := &cleanupChatRepository{chats: []servicechat.Meta{
+		{ID: "aaaaaaaa", ProjectID: "deadbeef"},
+		{ID: "bbbbbbbb", ProjectID: "feedface"},
+		{ID: "cccccccc", ProjectID: "deadbeef"},
+	}}
+	var cancelled []servicechat.ID
+	cleanup := projectChatCleanup{
+		chats: repository,
+		isRunning: func(id servicechat.ID) bool {
+			return id == "cccccccc"
+		},
+		cancel: func(_ context.Context, id servicechat.ID) error {
+			cancelled = append(cancelled, id)
+			return nil
+		},
+	}
+
+	if err := cleanup.DeleteProjectChats(context.Background(), serviceproject.ID("deadbeef")); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(repository.deleted, []servicechat.ID{"aaaaaaaa", "cccccccc"}) {
+		t.Fatalf("deleted chats = %v", repository.deleted)
+	}
+	if !slices.Equal(cancelled, []servicechat.ID{"cccccccc"}) {
+		t.Fatalf("cancelled chats = %v", cancelled)
+	}
+}
+
+func TestProjectChatCleanupReportsFailuresAndContinues(t *testing.T) {
+	wantDeleteErr := errors.New("delete failed")
+	wantCancelErr := errors.New("cancel failed")
+	repository := &cleanupChatRepository{
+		chats: []servicechat.Meta{
+			{ID: "aaaaaaaa", ProjectID: "deadbeef"},
+			{ID: "bbbbbbbb", ProjectID: "deadbeef"},
+			{ID: "cccccccc", ProjectID: "deadbeef"},
+		},
+		deleteErr: map[servicechat.ID]error{"aaaaaaaa": wantDeleteErr},
+	}
+	cleanup := projectChatCleanup{
+		chats:     repository,
+		isRunning: func(servicechat.ID) bool { return true },
+		cancel: func(_ context.Context, id servicechat.ID) error {
+			if id == "bbbbbbbb" {
+				return wantCancelErr
+			}
+			return nil
+		},
+	}
+
+	err := cleanup.DeleteProjectChats(context.Background(), "deadbeef")
+	if !errors.Is(err, wantDeleteErr) || !errors.Is(err, wantCancelErr) {
+		t.Fatalf("cleanup error = %v, want both failures", err)
+	}
+	if !slices.Equal(repository.deleted, []servicechat.ID{"cccccccc"}) {
+		t.Fatalf("successful deletions = %v, want cleanup to continue", repository.deleted)
+	}
+}
+
+func TestProjectChatCleanupStopsWhenChatsCannotBeListed(t *testing.T) {
+	wantErr := errors.New("read failed")
+	cleanup := projectChatCleanup{chats: &cleanupChatRepository{listErr: wantErr}}
+
+	err := cleanup.DeleteProjectChats(context.Background(), "deadbeef")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("cleanup error = %v, want %v", err, wantErr)
+	}
+}

--- a/backend/internal/service/project_chat_cleanup_test.go
+++ b/backend/internal/service/project_chat_cleanup_test.go
@@ -12,10 +12,11 @@ import (
 
 type cleanupChatRepository struct {
 	servicechat.Repository
-	chats     []servicechat.Meta
-	listErr   error
-	deleteErr map[servicechat.ID]error
-	deleted   []servicechat.ID
+	chats      []servicechat.Meta
+	listErr    error
+	deleteErr  map[servicechat.ID]error
+	deleted    []servicechat.ID
+	operations *[]string
 }
 
 func (repository *cleanupChatRepository) List(context.Context) ([]servicechat.Meta, error) {
@@ -26,24 +27,26 @@ func (repository *cleanupChatRepository) Delete(_ context.Context, id servicecha
 	if err := repository.deleteErr[id]; err != nil {
 		return err
 	}
+	if repository.operations != nil {
+		*repository.operations = append(*repository.operations, "delete:"+string(id))
+	}
 	repository.deleted = append(repository.deleted, id)
 	return nil
 }
 
-func TestProjectChatCleanupDeletesOnlyMatchingChatsAndCancelsRuns(t *testing.T) {
+func TestProjectChatCleanupCancelsThenDeletesOnlyMatchingChats(t *testing.T) {
+	var operations []string
 	repository := &cleanupChatRepository{chats: []servicechat.Meta{
 		{ID: "aaaaaaaa", ProjectID: "deadbeef"},
 		{ID: "bbbbbbbb", ProjectID: "feedface"},
 		{ID: "cccccccc", ProjectID: "deadbeef"},
-	}}
+	}, operations: &operations}
 	var cancelled []servicechat.ID
 	cleanup := projectChatCleanup{
 		chats: repository,
-		isRunning: func(id servicechat.ID) bool {
-			return id == "cccccccc"
-		},
 		cancel: func(_ context.Context, id servicechat.ID) error {
 			cancelled = append(cancelled, id)
+			operations = append(operations, "cancel:"+string(id))
 			return nil
 		},
 	}
@@ -54,8 +57,17 @@ func TestProjectChatCleanupDeletesOnlyMatchingChatsAndCancelsRuns(t *testing.T) 
 	if !slices.Equal(repository.deleted, []servicechat.ID{"aaaaaaaa", "cccccccc"}) {
 		t.Fatalf("deleted chats = %v", repository.deleted)
 	}
-	if !slices.Equal(cancelled, []servicechat.ID{"cccccccc"}) {
+	if !slices.Equal(cancelled, []servicechat.ID{"aaaaaaaa", "cccccccc"}) {
 		t.Fatalf("cancelled chats = %v", cancelled)
+	}
+	wantOperations := []string{
+		"cancel:aaaaaaaa",
+		"delete:aaaaaaaa",
+		"cancel:cccccccc",
+		"delete:cccccccc",
+	}
+	if !slices.Equal(operations, wantOperations) {
+		t.Fatalf("operations = %v, want %v", operations, wantOperations)
 	}
 }
 
@@ -71,8 +83,7 @@ func TestProjectChatCleanupReportsFailuresAndContinues(t *testing.T) {
 		deleteErr: map[servicechat.ID]error{"aaaaaaaa": wantDeleteErr},
 	}
 	cleanup := projectChatCleanup{
-		chats:     repository,
-		isRunning: func(servicechat.ID) bool { return true },
+		chats: repository,
 		cancel: func(_ context.Context, id servicechat.ID) error {
 			if id == "bbbbbbbb" {
 				return wantCancelErr
@@ -87,6 +98,21 @@ func TestProjectChatCleanupReportsFailuresAndContinues(t *testing.T) {
 	}
 	if !slices.Equal(repository.deleted, []servicechat.ID{"cccccccc"}) {
 		t.Fatalf("successful deletions = %v, want cleanup to continue", repository.deleted)
+	}
+}
+
+func TestProjectChatCleanupDoesNotDeleteWithoutCancellation(t *testing.T) {
+	repository := &cleanupChatRepository{chats: []servicechat.Meta{
+		{ID: "aaaaaaaa", ProjectID: "deadbeef"},
+	}}
+	cleanup := projectChatCleanup{chats: repository}
+
+	err := cleanup.DeleteProjectChats(context.Background(), "deadbeef")
+	if err == nil {
+		t.Fatal("cleanup succeeded without a cancellation dependency")
+	}
+	if len(repository.deleted) != 0 {
+		t.Fatalf("deleted chats = %v, want none", repository.deleted)
 	}
 }
 

--- a/backend/internal/service/services.go
+++ b/backend/internal/service/services.go
@@ -167,7 +167,24 @@ func New(ctx context.Context, deps Dependencies) (Services, error) {
 		push: pushNotifier,
 	}
 	projects := notifyingProjectRepository{Repository: deps.Projects, workspace: workspace}
-	projectService := serviceproject.New(projects, deps.ProjectContainers, deps.ProjectSecrets, deps.ProjectAccess)
+	projectService := serviceproject.New(
+		projects,
+		deps.ProjectContainers,
+		deps.ProjectSecrets,
+		deps.ProjectAccess,
+		serviceproject.WithChatCleanup(projectChatCleanup{
+			chats: chats,
+			isRunning: func(id servicechat.ID) bool {
+				return runs != nil && runs.IsRunning(id)
+			},
+			cancel: func(ctx context.Context, id servicechat.ID) error {
+				if runs == nil {
+					return nil
+				}
+				return runs.Cancel(ctx, id)
+			},
+		}),
+	)
 	agentRuntime, err := deps.AgentModules.Build(agentmodule.BuildDependencies{
 		Projects:              agentProjectResolver{projects: projectService},
 		Containers:            deps.AgentContainers,

--- a/backend/internal/service/services.go
+++ b/backend/internal/service/services.go
@@ -174,12 +174,9 @@ func New(ctx context.Context, deps Dependencies) (Services, error) {
 		deps.ProjectAccess,
 		serviceproject.WithChatCleanup(projectChatCleanup{
 			chats: chats,
-			isRunning: func(id servicechat.ID) bool {
-				return runs != nil && runs.IsRunning(id)
-			},
 			cancel: func(ctx context.Context, id servicechat.ID) error {
 				if runs == nil {
-					return nil
+					return errors.New("run controller is unavailable")
 				}
 				return runs.Cancel(ctx, id)
 			},


### PR DESCRIPTION
## Summary
- cascade project deletion to every chat with the matching project ID
- cancel active chat runs before removing their persisted transcripts
- stop project deletion when chat cleanup cannot complete
- publish the existing chat deletion events so open clients update immediately

## Tests
- `npm test`
- `npm run build`
- `go test ./...`