### PR TITLE
feat(devin): add Devin CLI as a compiled-in agent provider

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,7 +5,7 @@ This document describes how remote.futrx is put together: its runtime topology, 
 ## What it is
 
 remote.futrx is a **single-server, self-hosted** workspace for Claude Code,
-Codex, MiniMax through the Codex harness, Kimi Code, and Antigravity. A user creates a project,
+Codex, MiniMax through the Codex harness, Kimi Code, Antigravity, and Devin. A user creates a project,
 the platform gives that project an isolated Linux container, and the user
 drives interactive or scheduled agent turns against the project's files from
 the browser—with chat, terminal, code editor, file manager, Git history, task
@@ -98,10 +98,10 @@ Three **separate** concerns, deliberately not conflated ([deep dive](docs/02-wor
 1. **Platform identity.** Exactly one local-admin account (email + password, argon2id, min 12 chars, in `local-admin.json`); every other user signs in through **Google OAuth only** and must be invited first. There is no self-signup. The first claim is gated on a one-time token generated at startup and printed only to the server terminal (`setup-token.json` holds its SHA-256, never the token), so an unclaimed server cannot be taken over by whoever loads the page first; once an administrator exists, that administrator authorises any further claim instead.
 2. **Agent-provider credentials.** Host-wide OAuth tokens for
    Claude/Codex/Kimi, connected once by an admin and **shared by all projects
-   and users** on the box. MiniMax instead reads `MINIMAX_API_KEY` from each
-   project's secret store, while Antigravity authenticates through `agy`
-   inside one project and stores that state in its project-specific durable
-   provider mount.
+   and users** on the box. Devin uses a host-managed manual token flow. MiniMax
+   instead reads `MINIMAX_API_KEY` from each project's secret store, while
+   Antigravity authenticates through `agy` inside one project and stores that
+   state in its project-specific durable provider mount.
 3. **Per-project membership.** A flat email access-list per project (`projectaccess/<id>.json`). Any member — not only admins — can read/write that project's secrets and edit its member list.
 
 **Sessions** are stateless HMAC-SHA256 tokens (`{email, sub, iat, exp, sid}`, 30-day expiry) signed by a random key at `DATA_DIR/session.key` ([`session_codec.go`](backend/internal/service/auth/session_codec.go)). The cookie is `HttpOnly; Secure; SameSite=Lax` and **domain-scoped to the base host** so it reaches the preview/IDE subdomains for `forward_auth`. By default there is still no server-side session store: logout only clears the cookie, and per-request `IsRegistered` checks are the only way a session is invalidated early.
@@ -248,9 +248,9 @@ JSON and metadata writes use temp-file + rename. Chat events are different: they
 
 Containers are **cattle**; durable state lives on the host and is bind-mounted in ([deep dive](docs/02-workspaces/03-projects-and-containers.md), [`lifecycle/service.go`](backend/internal/service/container/lifecycle/service.go)):
 
-- **Six bind mounts per project:** `workspace` → `/workspace`, plus the
+- **Seven bind mounts per project:** `workspace` → `/workspace`, plus the
   provider-declared persistent directories for Claude, Codex, MiniMax, Kimi,
-  and Antigravity. Antigravity mounts only `/root/.gemini/antigravity-cli`, not the
+  Antigravity, and Devin. Antigravity mounts only `/root/.gemini/antigravity-cli`, not the
   whole `.gemini` tree. Host dirs are chowned to uid/gid `1000000` (the
   unprivileged-root idmap) via `os.OpenRoot`+`Lchown` to defeat symlink-swap
   races.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to remote.futrx
 
-Thanks for your interest in improving remote.futrx — a self-hosted workspace for Claude Code, Codex, MiniMax, Kimi Code, Antigravity, and future agent integrations.
+Thanks for your interest in improving remote.futrx — a self-hosted workspace for Claude Code, Codex, MiniMax, Kimi Code, Antigravity, Devin, and future agent integrations.
 
 Before you start, please read this document. It covers how the repository is laid out, how to build and test each part, and what we expect from commits and pull requests.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">Give every AI project its own computer.</h1>
 
 <p align="center">
-  Run Codex, MiniMax, Claude Code, Kimi, and Antigravity in separate, always-on Linux workspaces on your own server.
+  Run Codex, MiniMax, Claude Code, Kimi, Antigravity, and Devin in separate, always-on Linux workspaces on your own server.
   Use everything from one browser: chat, IDE, terminal, files, Git, live previews, and a shared browser.
 </p>
 
@@ -30,7 +30,7 @@ Remote is an open-source, self-hosted home for AI coding agents.
 Think of every project as its own server-side computer:
 
 - It has a durable workspace, processes, ports, settings, and agent sessions.
-- Codex, MiniMax, Claude Code, Kimi, and Antigravity can work in the same project without moving files between tools.
+- Codex, MiniMax, Claude Code, Kimi, Antigravity, and Devin can work in the same project without moving files between tools.
 - The work keeps running on your server when you close your laptop.
 - You can watch, review, edit, restart, or take over from any browser.
 
@@ -74,10 +74,10 @@ mark it read or unread, fork its history, or delete it.
 <table>
   <tr>
     <td width="50%" valign="top">
-      <img src="docs/assets/readme/feature-model-picker.webp" alt="Remote provider and model picker showing Codex, Claude, MiniMax, Kimi, and Antigravity">
+      <img src="docs/assets/readme/feature-model-picker.webp" alt="Remote provider and model picker showing Codex, Claude, MiniMax, Kimi, Antigravity, and Devin">
       <br>
-      <strong>Five agent integrations</strong><br>
-      Switch among Codex, MiniMax, Claude Code, Kimi, and Antigravity. Model choices come from the provider tooling installed in the current project.
+      <strong>Six agent integrations</strong><br>
+      Switch among Codex, MiniMax, Claude Code, Kimi, Antigravity, and Devin. Model choices come from the provider tooling installed in the current project.
     </td>
     <td width="50%" valign="top">
       <img src="docs/assets/readme/feature-skills-and-controls.webp" alt="Remote skill picker and per-run controls">
@@ -248,7 +248,7 @@ See the continuous five-step product tour at [remote.futrx.com](https://remote.f
 ## What you get
 
 - **One project computer per project** — an unprivileged LXC container with durable files and agent homes.
-- **Your choice of agent** — use Codex, MiniMax, Claude Code, Kimi, or Antigravity with provider-specific models, thinking, speed, mode, approval, and sandbox controls where supported.
+- **Your choice of agent** — use Codex, MiniMax, Claude Code, Kimi, Antigravity, or Devin with provider-specific models, thinking, speed, mode, approval, and sandbox controls where supported.
 - **Durable, inspectable conversations** — stream Markdown, reasoning, tools, questions, errors, and usage; queue, cancel, rewind, fork, mark unread, or continue later.
 - **A complete development surface** — chat, browser IDE, root terminal, files, uploads, Git history, structured diffs, and reusable skills.
 - **Live applications** — Remote finds listening ports, creates project URLs, adds HTTPS, and shows the app beside the conversation.
@@ -262,7 +262,7 @@ See the continuous five-step product tour at [remote.futrx.com](https://remote.f
 flowchart LR
     A["You<br>any browser"] --> B["Remote host<br>identity, routing, lifecycle"]
     B --> C["Project computer<br>one unprivileged LXC container"]
-    C --> D["Codex · MiniMax · Claude · Kimi · Antigravity"]
+    C --> D["Codex · MiniMax · Claude · Kimi · Antigravity · Devin"]
     C --> E["IDE · terminal · Git · files"]
     C --> F["Browser · apps · HTTPS previews"]
 ```

--- a/backend/internal/agent/model.go
+++ b/backend/internal/agent/model.go
@@ -17,6 +17,7 @@ const (
 	ProviderMiniMax     ProviderID = "minimax"
 	ProviderKimi        ProviderID = "kimi"
 	ProviderAntigravity ProviderID = "antigravity"
+	ProviderDevin       ProviderID = "devin"
 )
 
 type EventType string

--- a/backend/internal/agent/provisioning/assets/AGENTS.md
+++ b/backend/internal/agent/provisioning/assets/AGENTS.md
@@ -9,18 +9,18 @@ crashed processes, and deleted files stay within this project.
 
 - `/workspace` - your project files. Persistent, survives container
   restarts and reprovisions.
-- `/root/.codex`, `/root/.minimax`, `/root/.claude`, `/root/.kimi-code`, and
-  `/root/.gemini/antigravity-cli` - persistent, project-specific provider
-  homes. The host mounts and manages these paths so provider configuration,
-  authentication, and session state survive container replacement. Only the
-  Antigravity subdirectory is mounted, not all of `/root/.gemini`. Keep project
-  artifacts in `/workspace`, not in these homes.
-- `/root/.claude/CLAUDE.md`, `/root/.codex/AGENTS.md`, AND
-  `/root/.minimax/AGENTS.md` - this file (identical content, three paths so
-  Claude, Codex, and MiniMax pick it up). The host re-pushes all three whenever
-  the template changes; don't edit
+- `/root/.codex`, `/root/.minimax`, `/root/.claude`, `/root/.kimi-code`,
+  `/root/.gemini/antigravity-cli`, and `/root/.local/share/devin` - persistent,
+  project-specific provider homes. The host mounts and manages these paths so
+  provider configuration, authentication, and session state survive container
+  replacement. Only the Antigravity subdirectory is mounted, not all of
+  `/root/.gemini`. Keep project artifacts in `/workspace`, not in these homes.
+- `/root/.claude/CLAUDE.md`, `/root/.codex/AGENTS.md`,
+  `/root/.minimax/AGENTS.md`, AND `/root/.config/devin/AGENTS.md` - this file
+  (identical content, four paths so Claude, Codex, MiniMax, and Devin pick it
+  up). The host re-pushes all four whenever the template changes; don't edit
   them expecting changes to stick.
-- Everything else outside the six durable mounts: replaceable.
+- Everything else outside the seven durable mounts: replaceable.
 
 ## Capabilities
 
@@ -42,14 +42,14 @@ crashed processes, and deleted files stay within this project.
 ## Pre-installed tools
 
 `git`, `gh`, `openssh-client`, `jq`, `build-essential`,
-`python3` + `pip`, `node 22` + `npm`, `claude`, `codex`, `kimi`, `agy`. Anything else:
+`python3` + `pip`, `node 22` + `npm`, `claude`, `codex`, `kimi`, `agy`, `devin`. Anything else:
 `apt-get install` or `npm i -g` freely.
 
 The MiniMax agent also uses the `codex` binary, with isolated state under
 `/root/.minimax`. Remote injects its host-managed Token Plan subscription key only into MiniMax
 runs; do not ask users to add it as a project secret.
 
-**Persistence rule.** `/workspace/**` and the five provider homes listed
+**Persistence rule.** `/workspace/**` and the six provider homes listed
 above are host bind-mounts and survive container replacement. Other paths
 (`/usr/local/`, unmounted paths under `/root/`, and packages you apt-install)
 are gone if the container is recreated. If you install a tool the project

--- a/backend/internal/agent/provisioning/versions.env
+++ b/backend/internal/agent/provisioning/versions.env
@@ -18,6 +18,11 @@ KIMI_CODE_VERSION=0.40.1
 ANTIGRAVITY_CLI_VERSION=1.1.25
 ANTIGRAVITY_LINUX_X64_SHA512=c5af6d1cfc2faf3d183b3497c56cb4951067bb56e8a1d1e5a4f081875aac2b073bd97d0eb9458b772f2ddb934222372935f48ae2c7893d7013d975afd7516e6c
 ANTIGRAVITY_LINUX_ARM64_SHA512=450d549aa315bcc363b95bfc59419826274e900d14cc701ebf20922c061efe04c569c136645ddffef1b411e05a4c2e45a6e8409300bd8b0c07abcb0f6925483c
+# Devin ships standalone per-architecture release archives with a versioned
+# manifest at https://static.devin.ai/cli/<version>/manifest.json. The install
+# script fetches the manifest and verifies SHA-256, so no separate checksum
+# pins are needed (unlike Antigravity's hardcoded SHA-512 pins).
+DEVIN_CLI_VERSION=3000.6.14
 
 # ── Host toolchain ──
 # NodeSource major stream (latest minor within it); also the Node major

--- a/backend/internal/config/agents.go
+++ b/backend/internal/config/agents.go
@@ -8,6 +8,7 @@ import (
 	antigravityagent "github.com/futrx-com/remote.futrx.com/internal/integration/agents/antigravity"
 	claudeagent "github.com/futrx-com/remote.futrx.com/internal/integration/agents/claude"
 	codexagent "github.com/futrx-com/remote.futrx.com/internal/integration/agents/codex"
+	devinagent "github.com/futrx-com/remote.futrx.com/internal/integration/agents/devin"
 	kimiagent "github.com/futrx-com/remote.futrx.com/internal/integration/agents/kimi"
 	minimaxagent "github.com/futrx-com/remote.futrx.com/internal/integration/agents/minimax"
 	agentmodule "github.com/futrx-com/remote.futrx.com/internal/service/agent/module"
@@ -20,6 +21,7 @@ func NewAgentModules() (*agentmodule.Catalog, error) {
 		minimaxagent.NewFactory,
 		kimiagent.NewFactory,
 		antigravityagent.NewFactory,
+		devinagent.NewFactory,
 	}
 	factories := make([]agentmodule.Factory, 0, len(builders))
 	for _, build := range builders {

--- a/backend/internal/config/agents_test.go
+++ b/backend/internal/config/agents_test.go
@@ -29,6 +29,7 @@ func TestCatalogBuildsEveryDeclaredAgentInStableOrder(t *testing.T) {
 		agent.ProviderMiniMax,
 		agent.ProviderKimi,
 		agent.ProviderAntigravity,
+		agent.ProviderDevin,
 	}
 	if !slices.Equal(ids, want) {
 		t.Fatalf("agent order = %v, want %v", ids, want)
@@ -46,7 +47,8 @@ func TestCatalogBuildsEveryDeclaredAgentInStableOrder(t *testing.T) {
 		!catalog.SupportsNativeFork(string(agent.ProviderCodex)) ||
 		!catalog.SupportsNativeFork(string(agent.ProviderMiniMax)) ||
 		catalog.SupportsNativeFork(string(agent.ProviderKimi)) ||
-		catalog.SupportsNativeFork(string(agent.ProviderAntigravity)) {
+		catalog.SupportsNativeFork(string(agent.ProviderAntigravity)) ||
+		catalog.SupportsNativeFork(string(agent.ProviderDevin)) {
 		t.Fatal("catalog native-fork policies do not match provider behavior")
 	}
 	hostProfiles := catalog.HostProfiles()
@@ -54,12 +56,21 @@ func TestCatalogBuildsEveryDeclaredAgentInStableOrder(t *testing.T) {
 	for index, profile := range hostProfiles {
 		hostIDs[index] = profile.ID
 	}
-	if !slices.Equal(hostIDs, []string{"claude", "codex", "kimi", "antigravity"}) {
+	if !slices.Equal(hostIDs, []string{"claude", "codex", "kimi", "antigravity", "devin"}) {
 		t.Fatalf("host profile order = %v", hostIDs)
 	}
-	antigravityCLI := hostProfiles[len(hostProfiles)-1].CLI
+	var antigravityCLI provisioning.CLISpec
+	for _, profile := range hostProfiles {
+		if profile.ID == "antigravity" {
+			antigravityCLI = profile.CLI
+		}
+	}
 	if antigravityCLI.Binary != "agy" || antigravityCLI.InstallMode != provisioning.InstallWithScript || antigravityCLI.InstallScript == "" {
 		t.Fatalf("Antigravity host CLI policy = %#v", antigravityCLI)
+	}
+	devinCLI := hostProfiles[len(hostProfiles)-1].CLI
+	if devinCLI.Binary != "devin" || devinCLI.InstallMode != provisioning.InstallWithScript || devinCLI.InstallScript == "" {
+		t.Fatalf("Devin host CLI policy = %#v", devinCLI)
 	}
 
 	runtime, err := catalog.Build(agentmodule.BuildDependencies{})

--- a/backend/internal/integration/agents/devin/auth.go
+++ b/backend/internal/integration/agents/devin/auth.go
@@ -1,0 +1,110 @@
+package devin
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	agentauth "github.com/futrx-com/remote.futrx.com/internal/service/agent/auth"
+)
+
+const (
+	devinLoginTimeout = 10 * time.Minute
+	devinURLReadWait  = 15 * time.Second
+	devinExitWait     = 30 * time.Second
+)
+
+var (
+	ErrCodeRequired  = errors.New("code is required")
+	ErrNoSession     = errors.New("no login session in progress - call /api/devin/login/start first")
+	ErrDevinNotFound = errors.New("devin CLI not found on PATH - install it first")
+
+	// devinAuthURLRE matches the manual-token-flow URL printed by
+	// `devin auth login --force-manual-token-flow`.
+	devinAuthURLRE = regexp.MustCompile(`https://app\.devin\.ai/auth/cli/continue\?[\w=&.-]+`)
+)
+
+type Auth = agentauth.CodeService
+type AuthStatus = agentauth.CodeStatus
+type LoginState = agentauth.CodeLoginState
+type StartResult = agentauth.CodeStartResult
+
+// NewAuth configures the shared authorization-code service for the Devin CLI.
+// The manual token flow prints a URL, waits for the user to sign in via browser
+// and paste the resulting code, then persists credentials.toml.
+func NewAuth() *Auth {
+	return agentauth.NewCodeService(agentauth.CodeConfig{
+		Command:        "devin",
+		Args:           []string{"auth", "login", "--force-manual-token-flow"},
+		URLPattern:     devinAuthURLRE,
+		LoginTimeout:   devinLoginTimeout,
+		URLReadTimeout: devinURLReadWait,
+		ExitTimeout:    devinExitWait,
+		Authenticated:  authenticated,
+		NotFound:       ErrDevinNotFound,
+		CodeRequired:   ErrCodeRequired,
+		NoSession:      ErrNoSession,
+		Errors: agentauth.CodeErrorFormatters{
+			PTYStart: func(err error) error {
+				return fmt.Errorf("pty start: %w", err)
+			},
+			URLReadTimeout: func(wait time.Duration, output string) error {
+				return fmt.Errorf(
+					"did not see Devin auth URL within %s; first 500 bytes of devin output: %s",
+					wait,
+					output,
+				)
+			},
+			ExitBeforeURL: func(err error, output string) error {
+				message := "devin exited before printing auth URL"
+				if err != nil {
+					message += " (" + err.Error() + ")"
+				}
+				return fmt.Errorf("%s; output: %s", message, output)
+			},
+			WriteCode: func(err error) error {
+				return fmt.Errorf("write to devin stdin: %w", err)
+			},
+			ExitTimeout: func(wait time.Duration, output string) error {
+				return fmt.Errorf(
+					"devin did not exit within %s after code paste; last output: %s",
+					wait,
+					output,
+				)
+			},
+			Exit: func(err error, output string) error {
+				return fmt.Errorf("devin exited with error: %w; output: %s", err, output)
+			},
+			MissingCredentials: func(output string) error {
+				return fmt.Errorf(
+					"devin exited cleanly but no credentials file was written; output: %s",
+					output,
+				)
+			},
+		},
+	})
+}
+
+// authenticated reports whether the Devin credential file exists. Confirmed by
+// `devin auth status`: credentials are stored at
+// ~/.local/share/devin/credentials.toml (XDG_DATA_HOME).
+func authenticated() bool {
+	_, err := os.Stat(filepath.Join(devinDataDir(), "credentials.toml"))
+	return err == nil
+}
+
+// devinDataDir returns the directory holding Devin's credential file. It
+// respects XDG_DATA_HOME and falls back to ~/.local/share/devin, matching the
+// path reported by `devin auth status`.
+func devinDataDir() string {
+	if value := os.Getenv("XDG_DATA_HOME"); value != "" {
+		return filepath.Join(value, "devin")
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		return filepath.Join(home, ".local", "share", "devin")
+	}
+	return "/root/.local/share/devin"
+}

--- a/backend/internal/integration/agents/devin/capabilities.go
+++ b/backend/internal/integration/agents/devin/capabilities.go
@@ -1,0 +1,62 @@
+package devin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+	agentruntime "github.com/futrx-com/remote.futrx.com/internal/integration/agents/runtime"
+)
+
+// Capabilities discovers the Devin model catalog by probing
+// `devin models list --format json`. The probe requires authentication; if the
+// CLI is not logged in, the probe fails and the fallback capabilities are
+// returned with a warning.
+func (p *Provider) Capabilities(ctx context.Context, req agent.CapabilityRequest) (agent.Capabilities, error) {
+	cmd := agentruntime.NewCapabilityCommand(
+		ctx,
+		req,
+		[]string{"HOME=/root", "XDG_DATA_HOME=/root/.local/share"},
+		p.profile.CLI.Binary,
+		"models", "list", "--format", "json",
+	)
+	output, err := cmd.Output()
+	if err != nil {
+		caps := fallbackCapabilities()
+		caps.Warning = "Devin capabilities could not be read from the CLI (is devin logged in?)"
+		return caps, fmt.Errorf("devin capability discovery: %w", err)
+	}
+	caps, parseErr := parseModelCatalog(output)
+	if parseErr != nil {
+		fallback := fallbackCapabilities()
+		fallback.Warning = "Devin returned an unreadable model catalog"
+		return fallback, parseErr
+	}
+	return caps, nil
+}
+
+// fallbackCapabilities returns a minimal capability set when the live probe
+// fails. Devin supports default and plan modes.
+func fallbackCapabilities() agent.Capabilities {
+	return agent.Capabilities{
+		Provider:    agent.ProviderDevin,
+		Label:       "Devin",
+		Source:      agent.CapabilitySourceFallback,
+		Models:      agent.WithAutoModel(nil, "Devin default"),
+		Modes:       agent.ProviderModes(true),
+		DefaultMode: agent.RunModeDefault,
+	}
+}
+
+// isNotLoggedInError reports whether a capability probe error indicates the
+// CLI is not authenticated. This is used to produce a user-friendly warning.
+func isNotLoggedInError(err error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "not logged in") ||
+		strings.Contains(lower, "not authenticated") ||
+		strings.Contains(lower, "no credentials")
+}

--- a/backend/internal/integration/agents/devin/capabilities_test.go
+++ b/backend/internal/integration/agents/devin/capabilities_test.go
@@ -1,0 +1,210 @@
+package devin
+
+import (
+	"testing"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+)
+
+func TestParseModelCatalogFromArray(t *testing.T) {
+	caps, err := parseModelCatalog([]byte(`[
+		{"id":"devin-pro","name":"Devin Pro","description":"Pro model"},
+		{"id":"devin-lite","name":"Devin Lite"}
+	]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if caps.Provider != agent.ProviderDevin || caps.Label != "Devin" {
+		t.Fatalf("caps identity = %#v", caps)
+	}
+	if caps.Source != agent.CapabilitySourceLive {
+		t.Fatalf("source = %q, want live", caps.Source)
+	}
+	// Auto model prepended + 2 models = 3
+	if len(caps.Models) != 3 {
+		t.Fatalf("models = %#v", caps.Models)
+	}
+	if caps.Models[0].ID != "" || caps.Models[0].Label != "Auto" {
+		t.Fatalf("auto model = %#v", caps.Models[0])
+	}
+	// Models are sorted by ID: devin-lite, devin-pro
+	if caps.Models[1].ID != "devin-lite" || caps.Models[1].Label != "Devin Lite" {
+		t.Fatalf("first model = %#v", caps.Models[1])
+	}
+	if caps.Models[2].ID != "devin-pro" || caps.Models[2].Label != "Devin Pro" {
+		t.Fatalf("second model = %#v", caps.Models[2])
+	}
+	if caps.Models[2].Description != "Pro model" {
+		t.Fatalf("description = %q", caps.Models[2].Description)
+	}
+}
+
+func TestParseModelCatalogFromObjectWithModels(t *testing.T) {
+	caps, err := parseModelCatalog([]byte(`{
+		"models": [
+			{"id":"devin-pro","name":"Devin Pro"},
+			{"id":"devin-lite","name":"Devin Lite"}
+		],
+		"default": "devin-pro"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Auto + 2 models = 3
+	if len(caps.Models) != 3 {
+		t.Fatalf("models = %#v", caps.Models)
+	}
+	// devin-pro should be marked as provider default
+	found := false
+	for _, model := range caps.Models {
+		if model.ID == "devin-pro" && model.ProviderDefault {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("devin-pro not marked as provider default")
+	}
+}
+
+func TestParseModelCatalogFromObjectWithData(t *testing.T) {
+	caps, err := parseModelCatalog([]byte(`{
+		"data": [
+			{"name":"devin-pro","displayName":"Devin Pro"},
+			{"name":"devin-lite","displayName":"Devin Lite"}
+		]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(caps.Models) != 3 {
+		t.Fatalf("models = %#v", caps.Models)
+	}
+}
+
+func TestParseModelCatalogWithAlternativeFieldNames(t *testing.T) {
+	caps, err := parseModelCatalog([]byte(`[
+		{"model":"devin-pro","title":"Devin Pro"},
+		{"value":"devin-lite","label":"Devin Lite"}
+	]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(caps.Models) != 3 {
+		t.Fatalf("models = %#v", caps.Models)
+	}
+	// Sorted: devin-lite, devin-pro
+	if caps.Models[1].ID != "devin-lite" || caps.Models[1].Label != "Devin Lite" {
+		t.Fatalf("first model = %#v", caps.Models[1])
+	}
+	if caps.Models[2].ID != "devin-pro" || caps.Models[2].Label != "Devin Pro" {
+		t.Fatalf("second model = %#v", caps.Models[2])
+	}
+}
+
+func TestParseModelCatalogEmptyReturnsFallback(t *testing.T) {
+	caps, err := parseModelCatalog([]byte(``))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if caps.Source != agent.CapabilitySourceFallback {
+		t.Fatalf("source = %q, want fallback", caps.Source)
+	}
+	if len(caps.Models) != 1 || caps.Models[0].ID != "" {
+		t.Fatalf("models = %#v", caps.Models)
+	}
+}
+
+func TestParseModelCatalogEmptyArrayReturnsAutoOnly(t *testing.T) {
+	caps, err := parseModelCatalog([]byte(`[]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(caps.Models) != 1 || caps.Models[0].ID != "" {
+		t.Fatalf("models = %#v, want only auto model", caps.Models)
+	}
+}
+
+func TestParseModelCatalogInvalidJSONReturnsError(t *testing.T) {
+	_, err := parseModelCatalog([]byte(`not valid json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestParseModelCatalogDeduplicatesModels(t *testing.T) {
+	caps, err := parseModelCatalog([]byte(`[
+		{"id":"devin-pro","name":"Devin Pro"},
+		{"id":"devin-pro","name":"Duplicate"}
+	]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Auto + 1 unique model = 2
+	if len(caps.Models) != 2 {
+		t.Fatalf("models = %#v, want 2 (auto + 1 unique)", caps.Models)
+	}
+}
+
+func TestParseModelCatalogIncludesPlanMode(t *testing.T) {
+	caps, err := parseModelCatalog([]byte(`[{"id":"devin-pro","name":"Devin Pro"}]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(caps.Modes) != 2 {
+		t.Fatalf("modes = %#v, want default + plan", caps.Modes)
+	}
+	if caps.Modes[0].Value != string(agent.RunModeDefault) {
+		t.Fatalf("first mode = %q, want default", caps.Modes[0].Value)
+	}
+	if caps.Modes[1].Value != string(agent.RunModePlan) {
+		t.Fatalf("second mode = %q, want plan", caps.Modes[1].Value)
+	}
+	if caps.DefaultMode != agent.RunModeDefault {
+		t.Fatalf("default mode = %q", caps.DefaultMode)
+	}
+}
+
+func TestFallbackCapabilities(t *testing.T) {
+	caps := fallbackCapabilities()
+	if caps.Provider != agent.ProviderDevin || caps.Label != "Devin" {
+		t.Fatalf("identity = %#v", caps)
+	}
+	if caps.Source != agent.CapabilitySourceFallback {
+		t.Fatalf("source = %q", caps.Source)
+	}
+	if len(caps.Models) != 1 || caps.Models[0].ID != "" || caps.Models[0].Label != "Auto" {
+		t.Fatalf("models = %#v", caps.Models)
+	}
+	if caps.Models[0].Description != "Devin default" {
+		t.Fatalf("auto model description = %q", caps.Models[0].Description)
+	}
+	if len(caps.Modes) != 2 {
+		t.Fatalf("modes = %#v, want default + plan", caps.Modes)
+	}
+}
+
+func TestIsNotLoggedInError(t *testing.T) {
+	tests := []struct {
+		err      string
+		expected bool
+	}{
+		{"not logged in", true},
+		{"not authenticated", true},
+		{"no credentials found", true},
+		{"command not found", false},
+		{"", false},
+	}
+	for _, test := range tests {
+		var err error
+		if test.err != "" {
+			err = &simpleError{test.err}
+		}
+		if got := isNotLoggedInError(err); got != test.expected {
+			t.Fatalf("isNotLoggedInError(%q) = %t, want %t", test.err, got, test.expected)
+		}
+	}
+}
+
+type simpleError struct{ msg string }
+
+func (e *simpleError) Error() string { return e.msg }

--- a/backend/internal/integration/agents/devin/capabilities_test.go
+++ b/backend/internal/integration/agents/devin/capabilities_test.go
@@ -66,6 +66,64 @@ func TestParseModelCatalogFromObjectWithModels(t *testing.T) {
 	}
 }
 
+func TestParseModelCatalogFromDevinNativeFamilies(t *testing.T) {
+	caps, err := parseModelCatalog([]byte(`{
+		"families": [
+			{
+				"family_label": "Claude Opus 5",
+				"family_uid": "claude-opus-5",
+				"variants": [
+					{"model_uid": "claude-opus-5-medium", "label": "Claude Opus 5 Medium"},
+					{"model_uid": "claude-opus-5-low", "label": "Claude Opus 5 Low"}
+				]
+			},
+			{
+				"family_label": "GPT-5.2",
+				"family_uid": "gpt-5.2",
+				"variants": [
+					{"model_uid": "MODEL_GPT_5_2_NONE", "label": "GPT-5.2 No Thinking"}
+				]
+			}
+		]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if caps.Source != agent.CapabilitySourceLive {
+		t.Fatalf("source = %q, want live", caps.Source)
+	}
+	// Auto + 3 models = 4
+	if len(caps.Models) != 4 {
+		t.Fatalf("models = %#v, want 4 (auto + 3)", caps.Models)
+	}
+	// Sorted by ID: MODEL_GPT_5_2_NONE, claude-opus-5-low, claude-opus-5-medium
+	if caps.Models[1].ID != "MODEL_GPT_5_2_NONE" || caps.Models[1].Label != "GPT-5.2 No Thinking" {
+		t.Fatalf("first model = %#v", caps.Models[1])
+	}
+	if caps.Models[2].ID != "claude-opus-5-low" || caps.Models[2].Label != "Claude Opus 5 Low" {
+		t.Fatalf("second model = %#v", caps.Models[2])
+	}
+	if caps.Models[3].ID != "claude-opus-5-medium" || caps.Models[3].Label != "Claude Opus 5 Medium" {
+		t.Fatalf("third model = %#v", caps.Models[3])
+	}
+}
+
+func TestParseModelCatalogFromFamiliesWithEmptyVariants(t *testing.T) {
+	caps, err := parseModelCatalog([]byte(`{
+		"families": [
+			{"family_label": "Empty", "variants": []},
+			{"family_label": "Also Empty", "variants": null}
+		]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No models found — should return auto-only (fallback through empty path)
+	if len(caps.Models) != 1 || caps.Models[0].ID != "" {
+		t.Fatalf("models = %#v, want only auto model", caps.Models)
+	}
+}
+
 func TestParseModelCatalogFromObjectWithData(t *testing.T) {
 	caps, err := parseModelCatalog([]byte(`{
 		"data": [

--- a/backend/internal/integration/agents/devin/capability_parser.go
+++ b/backend/internal/integration/agents/devin/capability_parser.go
@@ -1,0 +1,136 @@
+package devin
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+)
+
+// parseModelCatalog parses the output of `devin models list --format json` into
+// agent.Capabilities. The exact JSON shape requires authentication to observe
+// (see Phase 0.5 of the plan), so this parser handles common shapes
+// conservatively and falls back gracefully.
+//
+// Supported shapes:
+//   - Array of model objects: [{"id":"...","name":"..."}, ...]
+//   - Object with "models" array: {"models":[...], "default":"..."}
+//   - Object with "data" array: {"data":[...]}
+//
+// Each model object may use any of these field names for its identifier:
+// id, name, model, value. For its display label: name, displayName, label, title.
+func parseModelCatalog(raw []byte) (agent.Capabilities, error) {
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return fallbackCapabilities(), nil
+	}
+
+	models, defaultID, err := extractModels(raw)
+	if err != nil {
+		return agent.Capabilities{}, err
+	}
+
+	caps := agent.Capabilities{
+		Provider:    agent.ProviderDevin,
+		Label:       "Devin",
+		Source:      agent.CapabilitySourceLive,
+		Models:      agent.WithAutoModel(models, "Devin default"),
+		Modes:       agent.ProviderModes(true),
+		DefaultMode: agent.RunModeDefault,
+	}
+	if defaultID != "" {
+		for i := range caps.Models {
+			if caps.Models[i].ID == defaultID {
+				caps.Models[i].ProviderDefault = true
+			}
+		}
+	}
+	return caps, nil
+}
+
+func extractModels(raw []byte) ([]agent.ModelCapability, string, error) {
+	// Try array first: [{"id":"..."}, ...]
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err == nil {
+		models := parseModelItems(items, "")
+		return models, "", nil
+	}
+
+	// Try object with known array keys.
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, "", fmt.Errorf("decode devin model catalog: %w", err)
+	}
+
+	defaultID := ""
+	if rawDefault, ok := root["default"]; ok {
+		_ = json.Unmarshal(rawDefault, &defaultID)
+		defaultID = strings.TrimSpace(defaultID)
+	}
+	if rawDefault, ok := root["defaultModel"]; ok {
+		var dm string
+		if json.Unmarshal(rawDefault, &dm) == nil && dm != "" {
+			defaultID = strings.TrimSpace(dm)
+		}
+	}
+
+	for _, key := range []string{"models", "data", "items"} {
+		if rawArray, ok := root[key]; ok && len(rawArray) > 0 && string(rawArray) != "null" {
+			if err := json.Unmarshal(rawArray, &items); err != nil {
+				continue
+			}
+			models := parseModelItems(items, defaultID)
+			return models, defaultID, nil
+		}
+	}
+
+	// No models found — return empty (caller will use auto model).
+	return nil, defaultID, nil
+}
+
+func parseModelItems(items []json.RawMessage, defaultID string) []agent.ModelCapability {
+	models := make([]agent.ModelCapability, 0, len(items))
+	seen := make(map[string]bool)
+	for _, item := range items {
+		var obj map[string]json.RawMessage
+		if json.Unmarshal(item, &obj) != nil {
+			continue
+		}
+		id := rawString(obj, "id", "name", "model", "value")
+		id = strings.TrimSpace(id)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		label := rawString(obj, "name", "displayName", "label", "title")
+		if label == "" {
+			label = id
+		}
+		description := rawString(obj, "description", "details")
+		models = append(models, agent.ModelCapability{
+			ID:              id,
+			Label:           label,
+			Description:     description,
+			ProviderDefault: id == defaultID,
+		})
+	}
+	sort.Slice(models, func(i, j int) bool { return models[i].ID < models[j].ID })
+	return models
+}
+
+func rawString(obj map[string]json.RawMessage, keys ...string) string {
+	for _, key := range keys {
+		raw, ok := obj[key]
+		if !ok || len(raw) == 0 {
+			continue
+		}
+		var value string
+		if json.Unmarshal(raw, &value) == nil {
+			if value = strings.TrimSpace(value); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}

--- a/backend/internal/integration/agents/devin/capability_parser.go
+++ b/backend/internal/integration/agents/devin/capability_parser.go
@@ -10,17 +10,22 @@ import (
 )
 
 // parseModelCatalog parses the output of `devin models list --format json` into
-// agent.Capabilities. The exact JSON shape requires authentication to observe
-// (see Phase 0.5 of the plan), so this parser handles common shapes
-// conservatively and falls back gracefully.
+// agent.Capabilities. The authenticated Devin CLI returns a nested structure:
+//
+//   {"families":[{"family_label":"...","variants":[{"model_uid":"...","label":"..."}]}]}
+//
+// This parser also handles simpler flat shapes conservatively and falls back
+// gracefully when the output is empty or unparseable.
 //
 // Supported shapes:
+//   - Devin native: {"families":[{"variants":[...]}]} with model_uid/label fields
 //   - Array of model objects: [{"id":"...","name":"..."}, ...]
 //   - Object with "models" array: {"models":[...], "default":"..."}
 //   - Object with "data" array: {"data":[...]}
 //
 // Each model object may use any of these field names for its identifier:
-// id, name, model, value. For its display label: name, displayName, label, title.
+// id, name, model, value, model_uid. For its display label: name, displayName,
+// label, title.
 func parseModelCatalog(raw []byte) (agent.Capabilities, error) {
 	if len(strings.TrimSpace(string(raw))) == 0 {
 		return fallbackCapabilities(), nil
@@ -85,6 +90,17 @@ func extractModels(raw []byte) ([]agent.ModelCapability, string, error) {
 		}
 	}
 
+	// Try Devin native shape: {"families":[{"variants":[...]}]}
+	if rawFamilies, ok := root["families"]; ok && len(rawFamilies) > 0 && string(rawFamilies) != "null" {
+		var families []map[string]json.RawMessage
+		if err := json.Unmarshal(rawFamilies, &families); err == nil && len(families) > 0 {
+			models := parseFamilyVariants(families, defaultID)
+			if len(models) > 0 {
+				return models, defaultID, nil
+			}
+		}
+	}
+
 	// No models found — return empty (caller will use auto model).
 	return nil, defaultID, nil
 }
@@ -97,7 +113,7 @@ func parseModelItems(items []json.RawMessage, defaultID string) []agent.ModelCap
 		if json.Unmarshal(item, &obj) != nil {
 			continue
 		}
-		id := rawString(obj, "id", "name", "model", "value")
+		id := rawString(obj, "id", "name", "model", "value", "model_uid")
 		id = strings.TrimSpace(id)
 		if id == "" || seen[id] {
 			continue
@@ -117,6 +133,24 @@ func parseModelItems(items []json.RawMessage, defaultID string) []agent.ModelCap
 	}
 	sort.Slice(models, func(i, j int) bool { return models[i].ID < models[j].ID })
 	return models
+}
+
+// parseFamilyVariants extracts models from Devin's native nested shape:
+// {"families":[{"variants":[{"model_uid":"...","label":"..."}]}]}.
+func parseFamilyVariants(families []map[string]json.RawMessage, defaultID string) []agent.ModelCapability {
+	var allItems []json.RawMessage
+	for _, family := range families {
+		rawVariants, ok := family["variants"]
+		if !ok || len(rawVariants) == 0 || string(rawVariants) == "null" {
+			continue
+		}
+		var variants []json.RawMessage
+		if json.Unmarshal(rawVariants, &variants) != nil {
+			continue
+		}
+		allItems = append(allItems, variants...)
+	}
+	return parseModelItems(allItems, defaultID)
 }
 
 func rawString(obj map[string]json.RawMessage, keys ...string) string {

--- a/backend/internal/integration/agents/devin/command.go
+++ b/backend/internal/integration/agents/devin/command.go
@@ -1,0 +1,95 @@
+package devin
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+	agentruntime "github.com/futrx-com/remote.futrx.com/internal/integration/agents/runtime"
+)
+
+// args builds the `devin acp` argument list. ACP is a stdio JSON-RPC protocol,
+// so the only argument is the subcommand. Model and trust flags are passed via
+// the CLI's global flags before the subcommand.
+func (p *Provider) args(req agent.RunRequest) []string {
+	args := []string{"acp"}
+	if model := strings.TrimSpace(req.Model); model != "" {
+		args = append([]string{"--model", model}, args...)
+	}
+	// Headless non-interactive mode: do not prompt for workspace trust.
+	args = append([]string{"--respect-workspace-trust", "false"}, args...)
+	return args
+}
+
+// buildCmd constructs the exec.Cmd for a host or project run. The process must
+// outlive request cancellation long enough for the harness to send
+// session/cancel and receive the terminal stopReason, so the command context
+// uses context.WithoutCancel.
+func (p *Provider) buildCmd(
+	ctx context.Context,
+	req agent.RunRequest,
+	args []string,
+	emit func(agent.Event),
+) (*exec.Cmd, string, error) {
+	cwd := req.Cwd
+	if cwd == "" {
+		cwd = os.Getenv("HOME")
+		if cwd == "" {
+			cwd = "/root"
+		}
+	}
+
+	if req.ProjectID == "" || p.projectPreparer == nil {
+		cmd := exec.CommandContext(context.WithoutCancel(ctx), p.profile.CLI.Binary, args...)
+		cmd.Dir = cwd
+		cmd.Env = agent.WithRuntimeEnvironment(devinEnv(os.Environ()), req.RuntimeEnv)
+		return cmd, "", nil
+	}
+
+	project, err := p.projectPreparer.Prepare(ctx, agent.ProjectPreparationRequest{
+		ProjectID:           agent.ProjectID(req.ProjectID),
+		ConversationID:      req.ConversationID,
+		EnableBrowser:       req.EnableBrowser,
+		EnableScheduleTools: req.EnableScheduleTools,
+	}, emit)
+	if err != nil {
+		return nil, "", err
+	}
+	cmd := agentruntime.BuildContainerCommand(context.WithoutCancel(ctx), agentruntime.ContainerCommandSpec{
+		ContainerName:      project.ContainerName,
+		PrefixEnvironment:  []string{"HOME=/root", "XDG_DATA_HOME=/root/.local/share"},
+		Secrets:            project.Secrets,
+		RuntimeEnvironment: req.RuntimeEnv,
+		Binary:             p.profile.CLI.Binary,
+		Arguments:          args,
+	})
+	return cmd, project.ContainerName, nil
+}
+
+// devinEnv prepares the host environment for `devin acp`. It ensures HOME and
+// XDG_DATA_HOME point at the root credential directory so the CLI can locate
+// credentials.toml without interactive configuration.
+func devinEnv(base []string) []string {
+	out := make([]string, 0, len(base)+2)
+	hasXDG := false
+	home := ""
+	for _, env := range base {
+		if strings.HasPrefix(env, "XDG_DATA_HOME=") {
+			hasXDG = true
+		}
+		if strings.HasPrefix(env, "HOME=") {
+			home = strings.TrimPrefix(env, "HOME=")
+		}
+		out = append(out, env)
+	}
+	if !hasXDG {
+		if home != "" {
+			out = append(out, "XDG_DATA_HOME="+home+"/.local/share")
+		} else {
+			out = append(out, "XDG_DATA_HOME=/root/.local/share")
+		}
+	}
+	return out
+}

--- a/backend/internal/integration/agents/devin/command_test.go
+++ b/backend/internal/integration/agents/devin/command_test.go
@@ -1,0 +1,85 @@
+package devin
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
+	"github.com/futrx-com/remote.futrx.com/internal/integration/agents/devinharness"
+)
+
+func TestArgsIncludeACPSubcommand(t *testing.T) {
+	provider := &Provider{profile: provisioning.Profile{CLI: devinharness.NewCLISpec()}}
+	args := provider.args(agent.RunRequest{Prompt: "hello"})
+	if !slices.Contains(args, "acp") {
+		t.Fatalf("args missing 'acp' subcommand: %#v", args)
+	}
+}
+
+func TestArgsIncludeRespectWorkspaceTrustFalse(t *testing.T) {
+	provider := &Provider{profile: provisioning.Profile{CLI: devinharness.NewCLISpec()}}
+	args := provider.args(agent.RunRequest{Prompt: "hello"})
+	for i, arg := range args {
+		if arg == "--respect-workspace-trust" && i+1 < len(args) && args[i+1] == "false" {
+			return
+		}
+	}
+	t.Fatalf("args missing --respect-workspace-trust false: %#v", args)
+}
+
+func TestArgsIncludeModelWhenSet(t *testing.T) {
+	provider := &Provider{profile: provisioning.Profile{CLI: devinharness.NewCLISpec()}}
+	args := provider.args(agent.RunRequest{Prompt: "hello", Model: "devin-pro"})
+	for i, arg := range args {
+		if arg == "--model" && i+1 < len(args) && args[i+1] == "devin-pro" {
+			return
+		}
+	}
+	t.Fatalf("args missing --model devin-pro: %#v", args)
+}
+
+func TestArgsOmitModelWhenEmpty(t *testing.T) {
+	provider := &Provider{profile: provisioning.Profile{CLI: devinharness.NewCLISpec()}}
+	args := provider.args(agent.RunRequest{Prompt: "hello"})
+	if slices.Contains(args, "--model") {
+		t.Fatalf("args should not contain --model when model is empty: %#v", args)
+	}
+}
+
+func TestArgsPlaceGlobalFlagsBeforeSubcommand(t *testing.T) {
+	provider := &Provider{profile: provisioning.Profile{CLI: devinharness.NewCLISpec()}}
+	args := provider.args(agent.RunRequest{Prompt: "hello", Model: "devin-pro"})
+	acpIdx := slices.Index(args, "acp")
+	modelIdx := slices.Index(args, "--model")
+	trustIdx := slices.Index(args, "--respect-workspace-trust")
+	if acpIdx < 0 || modelIdx < 0 || trustIdx < 0 {
+		t.Fatalf("missing expected args: %#v", args)
+	}
+	if modelIdx > acpIdx || trustIdx > acpIdx {
+		t.Fatalf("global flags must precede 'acp' subcommand: %#v", args)
+	}
+}
+
+func TestDevinEnvSetsXDGDataHome(t *testing.T) {
+	env := devinEnv([]string{"HOME=/root", "PATH=/usr/bin"})
+	found := false
+	for _, entry := range env {
+		if entry == "XDG_DATA_HOME=/root/.local/share" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("XDG_DATA_HOME not set: %#v", env)
+	}
+}
+
+func TestDevinEnvPreservesExistingXDGDataHome(t *testing.T) {
+	env := devinEnv([]string{"HOME=/root", "XDG_DATA_HOME=/custom/xdg"})
+	for _, entry := range env {
+		if entry == "XDG_DATA_HOME=/custom/xdg" {
+			return
+		}
+	}
+	t.Fatalf("existing XDG_DATA_HOME not preserved: %#v", env)
+}

--- a/backend/internal/integration/agents/devin/factory.go
+++ b/backend/internal/integration/agents/devin/factory.go
@@ -1,0 +1,45 @@
+package devin
+
+import (
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
+	agentauth "github.com/futrx-com/remote.futrx.com/internal/service/agent/auth"
+	agentmodule "github.com/futrx-com/remote.futrx.com/internal/service/agent/module"
+)
+
+// NewFactory returns Devin's complete module definition, including its runtime,
+// authentication flow, feature declarations, and provisioning profile.
+func NewFactory() (agentmodule.Factory, error) {
+	profile := Profile()
+	return agentmodule.NewFactory(agentmodule.Descriptor{
+		ID:                  agent.ProviderDevin,
+		Label:               "Devin",
+		ExecutionScopes:     []agentmodule.ExecutionScope{agentmodule.ScopeHost, agentmodule.ScopeProject},
+		Auth:                agentmodule.AuthManagedCode,
+		AuthInstructions:    "Run `devin auth login --force-manual-token-flow` on the host, open the displayed URL, sign in, and paste the returned code.",
+		SatisfiesAccessGate: true,
+		Features: agentmodule.Features{
+			Sessions:       agentmodule.SessionSupport{Resume: true},
+			Skills:         agentmodule.SkillsInstructions,
+			ScheduledTools: true,
+		},
+	}, &profile, func(deps agentmodule.Dependencies, validatedProfile *provisioning.Profile) (agentmodule.Components, error) {
+		binding := agentauth.NewCodeBinding(agent.ProviderDevin, NewAuth())
+		return agentmodule.Components{
+			Provider: newProvider(
+				deps.ProjectPreparer,
+				deps.CredentialCollector,
+				*validatedProfile,
+				deps.CredentialSyncTimeout,
+			),
+			Auth: &binding,
+		}, nil
+	}, agentmodule.WithProjectPreparation(agentmodule.ProjectPreparationPolicy{
+		BrowserAssets: true,
+	}))
+}
+
+var (
+	_ agent.Provider             = (*Provider)(nil)
+	_ agentmodule.FactoryBuilder = NewFactory
+)

--- a/backend/internal/integration/agents/devin/factory_test.go
+++ b/backend/internal/integration/agents/devin/factory_test.go
@@ -1,0 +1,50 @@
+package devin
+
+import (
+	"testing"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+	agentauth "github.com/futrx-com/remote.futrx.com/internal/service/agent/auth"
+	agentmodule "github.com/futrx-com/remote.futrx.com/internal/service/agent/module"
+)
+
+func TestFactoryDeclaresDevinFeatures(t *testing.T) {
+	factory, err := NewFactory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor := factory.Descriptor()
+	if descriptor.ID != agent.ProviderDevin || descriptor.Label != "Devin" || descriptor.Default {
+		t.Fatalf("descriptor = %#v", descriptor)
+	}
+	if len(descriptor.ExecutionScopes) != 2 ||
+		descriptor.ExecutionScopes[0] != agentmodule.ScopeHost ||
+		descriptor.ExecutionScopes[1] != agentmodule.ScopeProject {
+		t.Fatalf("execution scopes = %#v", descriptor.ExecutionScopes)
+	}
+	if descriptor.Auth != agentmodule.AuthManagedCode || !descriptor.SatisfiesAccessGate {
+		t.Fatalf("auth policy = %#v", descriptor)
+	}
+	if !descriptor.Features.Sessions.Resume || descriptor.Features.Sessions.Fork ||
+		descriptor.Features.Skills != agentmodule.SkillsInstructions ||
+		descriptor.Features.BrowserTools || !descriptor.Features.ScheduledTools {
+		t.Fatalf("features = %#v", descriptor.Features)
+	}
+
+	catalog, err := agentmodule.NewCatalog(factory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime, err := catalog.Build(agentmodule.BuildDependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := runtime.Lookup(agent.ProviderDevin)
+	if provider == nil || provider.ID() != agent.ProviderDevin {
+		t.Fatalf("provider = %#v", provider)
+	}
+	binding, ok := runtime.AuthBinding(agent.ProviderDevin)
+	if !ok || binding.Flow() != agentauth.FlowCode {
+		t.Fatalf("binding = (%#v, %t)", binding, ok)
+	}
+}

--- a/backend/internal/integration/agents/devin/parser.go
+++ b/backend/internal/integration/agents/devin/parser.go
@@ -1,0 +1,26 @@
+package devin
+
+import (
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+)
+
+// Parser is a no-op line parser. The ACP harness (devinharness.Run) emits
+// agent.Event values directly from its JSON-RPC state machine — there is no
+// line-oriented stdout output to parse. This parser exists only to satisfy the
+// agent.LineParser contract for callers that request one via Provider.Parser().
+type Parser struct {
+	req agent.RunRequest
+}
+
+func NewParser(req agent.RunRequest) *Parser {
+	if req.Provider == "" {
+		req.Provider = agent.ProviderDevin
+	}
+	return &Parser{req: req}
+}
+
+// ParseLine always returns no events. The ACP harness handles all event
+// translation internally.
+func (p *Parser) ParseLine(line []byte) ([]agent.Event, error) {
+	return nil, nil
+}

--- a/backend/internal/integration/agents/devin/parser_test.go
+++ b/backend/internal/integration/agents/devin/parser_test.go
@@ -1,0 +1,43 @@
+package devin
+
+import (
+	"testing"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+)
+
+func TestParserIsNoOp(t *testing.T) {
+	parser := NewParser(agent.RunRequest{ConversationID: "chat-1"})
+	events, err := parser.ParseLine([]byte(`{"any":"json"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected no events from no-op parser, got %#v", events)
+	}
+}
+
+func TestParserHandlesEmptyLine(t *testing.T) {
+	parser := NewParser(agent.RunRequest{ConversationID: "chat-1"})
+	events, err := parser.ParseLine([]byte{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected no events for empty line, got %#v", events)
+	}
+}
+
+func TestParserSetsDefaultProvider(t *testing.T) {
+	parser := NewParser(agent.RunRequest{ConversationID: "chat-1"})
+	if parser.req.Provider != agent.ProviderDevin {
+		t.Fatalf("provider = %q, want devin", parser.req.Provider)
+	}
+}
+
+func TestParserPreservesExplicitProvider(t *testing.T) {
+	parser := NewParser(agent.RunRequest{Provider: agent.ProviderDevin, ConversationID: "chat-1"})
+	if parser.req.Provider != agent.ProviderDevin {
+		t.Fatalf("provider = %q", parser.req.Provider)
+	}
+}

--- a/backend/internal/integration/agents/devin/profile.go
+++ b/backend/internal/integration/agents/devin/profile.go
@@ -1,0 +1,62 @@
+// Package devin adapts Cognition's Devin CLI (`devin acp`) as a headless agent
+// provider. The CLI speaks the Agent Client Protocol (ACP), a JSON-RPC over
+// stdio protocol, so runs surface structured tool calls, usage, and sessions.
+// Authentication is host-managed: an admin runs
+// `devin auth login --force-manual-token-flow` once on the host and the
+// credential file is synced into project containers.
+package devin
+
+import (
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
+	"github.com/futrx-com/remote.futrx.com/internal/integration/agents/devinharness"
+)
+
+const (
+	hostDevinDir               = "/root/.local/share/devin"
+	hostDevinCredentials       = "/root/.local/share/devin/credentials.toml"
+	containerDevinDir          = "/root/.local/share/devin"
+	containerDevinCredentials  = "/root/.local/share/devin/credentials.toml"
+	containerDevinInstructions = "/root/.config/devin/AGENTS.md"
+	containerInstructionsHash  = "/root/.config/devin/.agents-md.sha256"
+	workspaceDevinHome         = "/workspace/.devin"
+)
+
+var devinProfile = provisioning.Profile{
+	ID:  string(agent.ProviderDevin),
+	CLI: devinharness.NewCLISpec(),
+	Credentials: provisioning.CredentialSpec{
+		Name:         "devin",
+		HostDir:      hostDevinDir,
+		ContainerDir: containerDevinDir,
+		Files: []provisioning.CredentialFile{
+			// Confirmed by `devin auth status`: credentials.toml is the token
+			// store at ~/.local/share/devin/credentials.toml (XDG_DATA_HOME).
+			{
+				HostPath:      hostDevinCredentials,
+				ContainerPath: containerDevinCredentials,
+				Mode:          "600",
+				PushRequired:  true,
+				PullRequired:  true,
+			},
+		},
+		SeedOnLaunch: true,
+	},
+	PersistentState: []provisioning.PersistentDirectory{{
+		Device:        "devin-home",
+		HostDirectory: "devin",
+		ContainerPath: containerDevinDir,
+	}},
+	Instructions: &provisioning.InstructionTarget{
+		Path:     containerDevinInstructions,
+		HashPath: containerInstructionsHash,
+	},
+	WorkspaceSkills: &provisioning.WorkspaceSkills{
+		WorkspaceHome: workspaceDevinHome,
+	},
+}
+
+// Profile returns Devin's complete provisioning policy as a defensive copy.
+func Profile() provisioning.Profile {
+	return devinProfile.Clone()
+}

--- a/backend/internal/integration/agents/devin/profile_test.go
+++ b/backend/internal/integration/agents/devin/profile_test.go
@@ -1,0 +1,80 @@
+package devin
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
+	"github.com/futrx-com/remote.futrx.com/internal/integration/agents/devinharness"
+)
+
+func TestProfilePreservesDevinProvisioningPolicy(t *testing.T) {
+	profile := Profile()
+
+	if profile.ID != "devin" {
+		t.Fatalf("profile ID = %q", profile.ID)
+	}
+
+	wantCLI := devinharness.NewCLISpec()
+	if !reflect.DeepEqual(profile.CLI, wantCLI) {
+		t.Fatalf("CLI profile = %#v, want %#v", profile.CLI, wantCLI)
+	}
+	if profile.CLI.Version != provisioning.MustCLIVersion("DEVIN_CLI_VERSION") {
+		t.Fatalf("CLI version = %q", profile.CLI.Version)
+	}
+	if profile.CLI.InstallMode != provisioning.InstallWithScript {
+		t.Fatalf("install mode = %q", profile.CLI.InstallMode)
+	}
+	if profile.CLI.InstallTimeout != 8*time.Minute || profile.CLI.WaitTimeout != 5*time.Minute {
+		t.Fatalf("timeouts = (%s, %s)", profile.CLI.InstallTimeout, profile.CLI.WaitTimeout)
+	}
+
+	credentials := profile.Credentials
+	if credentials.Name != "devin" ||
+		credentials.HostDir != "/root/.local/share/devin" ||
+		credentials.ContainerDir != "/root/.local/share/devin" {
+		t.Fatalf("credential roots = %#v", credentials)
+	}
+	if !credentials.SeedOnLaunch {
+		t.Fatal("Devin credentials must be seeded on launch")
+	}
+	if len(credentials.Files) != 1 {
+		t.Fatalf("credential files = %#v", credentials.Files)
+	}
+	cred := credentials.Files[0]
+	if cred.HostPath != "/root/.local/share/devin/credentials.toml" ||
+		cred.ContainerPath != "/root/.local/share/devin/credentials.toml" ||
+		cred.Mode != "600" || !cred.PushRequired || !cred.PullRequired {
+		t.Fatalf("credential file = %#v", cred)
+	}
+
+	if len(profile.PersistentState) != 1 || profile.PersistentState[0] != (provisioning.PersistentDirectory{
+		Device: "devin-home", HostDirectory: "devin", ContainerPath: "/root/.local/share/devin",
+	}) {
+		t.Fatalf("persistent state = %#v", profile.PersistentState)
+	}
+
+	if profile.Instructions == nil ||
+		profile.Instructions.Path != "/root/.config/devin/AGENTS.md" ||
+		profile.Instructions.HashPath != "/root/.config/devin/.agents-md.sha256" {
+		t.Fatalf("instruction target = %#v", profile.Instructions)
+	}
+
+	if profile.WorkspaceSkills == nil || profile.WorkspaceSkills.WorkspaceHome != "/workspace/.devin" {
+		t.Fatalf("workspace skills = %#v", profile.WorkspaceSkills)
+	}
+}
+
+func TestProfileReturnsDefensiveCopy(t *testing.T) {
+	profile := Profile()
+	profile.Credentials.Files[0].HostPath = "/changed"
+	profile.PersistentState[0].ContainerPath = "/changed"
+
+	if got := Profile().Credentials.Files[0].HostPath; got != hostDevinCredentials {
+		t.Fatalf("Profile() retained credential mutation: %q", got)
+	}
+	if got := Profile().PersistentState[0].ContainerPath; got != containerDevinDir {
+		t.Fatalf("Profile() retained persistent-state mutation: %q", got)
+	}
+}

--- a/backend/internal/integration/agents/devin/provider.go
+++ b/backend/internal/integration/agents/devin/provider.go
@@ -2,17 +2,19 @@ package devin
 
 import (
 	"context"
-	"errors"
+	"log"
 	"time"
 
 	"github.com/futrx-com/remote.futrx.com/internal/agent"
 	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
+	"github.com/futrx-com/remote.futrx.com/internal/integration/agents/devinharness"
 )
 
-// Provider adapts the Devin CLI as a headless agent provider. The full Run,
-// Capabilities, and Parser implementations arrive in a later phase; this
-// placeholder satisfies the agent.Provider interface so the module can be
-// registered and the host installer can converge the binary.
+// Provider adapts the Devin CLI (`devin acp`) as a headless agent provider.
+// The CLI speaks the Agent Client Protocol (ACP) over stdin/stdout, so runs
+// surface structured tool calls, usage, and sessions. The devinharness package
+// owns the JSON-RPC state machine; this provider owns command construction,
+// credential syncing, and the agent.Provider contract.
 type Provider struct {
 	projectPreparer       agent.ProjectPreparer
 	credentialCollector   provisioning.CredentialCollector
@@ -38,17 +40,40 @@ func (p *Provider) ID() agent.ProviderID {
 	return agent.ProviderDevin
 }
 
-// Parser returns the line parser for a run. Not yet implemented; returns nil.
+// Parser returns the line parser for a run. The ACP harness emits agent.Event
+// values directly from its JSON-RPC state machine, so there is no line-oriented
+// output to parse. The returned parser is a no-op that satisfies the
+// agent.LineParser contract for callers that still request one.
 func (p *Provider) Parser(req agent.RunRequest) agent.LineParser {
-	return nil
+	return NewParser(req)
 }
 
-// Run executes a Devin CLI turn. Not yet implemented.
+// Run executes one Devin ACP turn. It builds the command, delegates to
+// devinharness.Run for the JSON-RPC state machine, and syncs credentials back
+// from the container after a successful project-scoped run.
 func (p *Provider) Run(ctx context.Context, req agent.RunRequest, emit func(agent.Event)) error {
-	return errors.New("devin provider: not yet implemented")
-}
+	if emit == nil {
+		emit = func(agent.Event) {}
+	}
+	if req.Provider == "" {
+		req.Provider = agent.ProviderDevin
+	}
+	// Devin has no fork primitive; a forked chat simply starts fresh.
+	if req.Fork {
+		req.ResumeID = ""
+	}
 
-// Capabilities discovers the Devin model catalog. Not yet implemented.
-func (p *Provider) Capabilities(ctx context.Context, req agent.CapabilityRequest) (agent.Capabilities, error) {
-	return agent.Capabilities{}, errors.New("devin provider: not yet implemented")
+	cmd, containerName, err := p.buildCmd(ctx, req, p.args(req), emit)
+	if err != nil {
+		return err
+	}
+	err = devinharness.Run(ctx, cmd, req, "Devin", emit)
+	if err == nil && containerName != "" && p.credentialCollector != nil {
+		syncCtx, cancel := context.WithTimeout(context.Background(), p.credentialSyncTimeout)
+		defer cancel()
+		if syncErr := p.credentialCollector.SyncFromContainer(syncCtx, containerName, p.profile.Credentials); syncErr != nil {
+			log.Printf("devin[%s] sync auth from %s: %v", req.ConversationID, containerName, syncErr)
+		}
+	}
+	return err
 }

--- a/backend/internal/integration/agents/devin/provider.go
+++ b/backend/internal/integration/agents/devin/provider.go
@@ -1,0 +1,54 @@
+package devin
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
+)
+
+// Provider adapts the Devin CLI as a headless agent provider. The full Run,
+// Capabilities, and Parser implementations arrive in a later phase; this
+// placeholder satisfies the agent.Provider interface so the module can be
+// registered and the host installer can converge the binary.
+type Provider struct {
+	projectPreparer       agent.ProjectPreparer
+	credentialCollector   provisioning.CredentialCollector
+	profile               provisioning.Profile
+	credentialSyncTimeout time.Duration
+}
+
+func newProvider(
+	projectPreparer agent.ProjectPreparer,
+	credentialCollector provisioning.CredentialCollector,
+	profile provisioning.Profile,
+	credentialSyncTimeout time.Duration,
+) *Provider {
+	return &Provider{
+		projectPreparer:       projectPreparer,
+		credentialCollector:   credentialCollector,
+		profile:               profile.Clone(),
+		credentialSyncTimeout: credentialSyncTimeout,
+	}
+}
+
+func (p *Provider) ID() agent.ProviderID {
+	return agent.ProviderDevin
+}
+
+// Parser returns the line parser for a run. Not yet implemented; returns nil.
+func (p *Provider) Parser(req agent.RunRequest) agent.LineParser {
+	return nil
+}
+
+// Run executes a Devin CLI turn. Not yet implemented.
+func (p *Provider) Run(ctx context.Context, req agent.RunRequest, emit func(agent.Event)) error {
+	return errors.New("devin provider: not yet implemented")
+}
+
+// Capabilities discovers the Devin model catalog. Not yet implemented.
+func (p *Provider) Capabilities(ctx context.Context, req agent.CapabilityRequest) (agent.Capabilities, error) {
+	return agent.Capabilities{}, errors.New("devin provider: not yet implemented")
+}

--- a/backend/internal/integration/agents/devinharness/acp_events.go
+++ b/backend/internal/integration/agents/devinharness/acp_events.go
@@ -1,0 +1,256 @@
+package devinharness
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+)
+
+// acpEventParser translates ACP session/update notifications and
+// server-to-client requests into normalized agent.Event values. It owns no
+// run state; the run loop decides which events are terminal.
+type acpEventParser struct {
+	req           agent.RunRequest
+	providerLabel string
+	lastUsage     json.RawMessage
+}
+
+func newACPEventParser(req agent.RunRequest, providerLabel string) *acpEventParser {
+	return &acpEventParser{
+		req:           req,
+		providerLabel: providerLabel,
+	}
+}
+
+// ParseNotification translates one ACP notification (method + params) into zero
+// or more agent events. It handles session/update notifications and filters
+// Devin-specific _cognition.ai/* extension notifications.
+func (parser *acpEventParser) ParseNotification(method string, raw json.RawMessage) []agent.Event {
+	now := time.Now().UnixMilli()
+
+	// Devin-specific extension notifications arrive on the same stdout stream.
+	// They are NOT ACP-standard and must be filtered.
+	if strings.HasPrefix(method, "_cognition.ai/") {
+		return parser.handleCognitionExtension(now, method, raw)
+	}
+
+	switch method {
+	case "session/update":
+		return parser.parseSessionUpdate(now, raw)
+	}
+
+	// Unknown ACP-standard notification → native fallback.
+	return parser.nativeEvent(now, method, raw)
+}
+
+// handleCognitionExtension filters Devin-specific _cognition.ai/* notifications.
+// _cognition.ai/output is an MCP log line — consume silently (log to stderr).
+// _cognition.ai/mcp/serversChanged and _cognition.ai/document/* are not
+// relevant in headless mode — consume silently. Other _cognition.ai/* are
+// forwarded as EventProviderNative.
+func (parser *acpEventParser) handleCognitionExtension(now int64, method string, raw json.RawMessage) []agent.Event {
+	switch method {
+	case "_cognition.ai/output":
+		log.Printf("%s[%s] cognition output: %s", parser.req.Provider, parser.req.ConversationID, truncateJSON(raw, 200))
+		return nil
+	case "_cognition.ai/mcp/serversChanged":
+		return nil
+	}
+	if strings.HasPrefix(method, "_cognition.ai/document/") {
+		return nil
+	}
+	return parser.nativeEvent(now, method, raw)
+}
+
+// parseSessionUpdate decodes the SessionUpdate union and dispatches to the
+// variant handler matching the plan's "ACP → agent.Event mapping" table.
+func (parser *acpEventParser) parseSessionUpdate(now int64, raw json.RawMessage) []agent.Event {
+	var params acpSessionNotificationParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return parser.nativeEvent(now, "session/update", raw)
+	}
+	if len(params.Update) == 0 {
+		return nil
+	}
+
+	var update acpSessionUpdate
+	if err := json.Unmarshal(params.Update, &update); err != nil {
+		return parser.nativeEvent(now, "session/update", raw)
+	}
+
+	switch update.SessionUpdate {
+	case "agent_message_chunk":
+		return parser.agentMessageChunk(now, update, raw)
+
+	case "agent_thought_chunk":
+		return parser.agentThoughtChunk(now, update, raw)
+
+	case "user_message_chunk":
+		// Echo of user input — consume silently, no event needed.
+		return nil
+
+	case "tool_call":
+		return parser.toolCall(now, update, raw)
+
+	case "tool_call_update":
+		return parser.toolCallUpdate(now, update, raw)
+
+	case "plan":
+		return parser.nativeSessionUpdate(now, "plan", update, raw)
+
+	case "available_commands_update":
+		return parser.nativeSessionUpdate(now, "available_commands_update", update, raw)
+
+	case "current_mode_update":
+		return parser.nativeSessionUpdate(now, "current_mode_update", update, raw)
+
+	case "config_option_update":
+		return parser.nativeSessionUpdate(now, "config_option_update", update, raw)
+
+	default:
+		// Unknown sessionUpdate variant → native fallback with the variant
+		// name as the method.
+		return parser.nativeSessionUpdate(now, update.SessionUpdate, update, raw)
+	}
+}
+
+func (parser *acpEventParser) agentMessageChunk(now int64, update acpSessionUpdate, raw json.RawMessage) []agent.Event {
+	text := extractText(update.Content)
+	if text == "" {
+		return nil
+	}
+	return []agent.Event{parser.event(now, "session/update", agent.EventAssistantTextDelta, raw, func(event *agent.Event) {
+		event.ItemKind = agent.ItemMessage
+		event.Text = text
+		event.MessageID = update.MessageID
+	})}
+}
+
+func (parser *acpEventParser) agentThoughtChunk(now int64, update acpSessionUpdate, raw json.RawMessage) []agent.Event {
+	text := extractText(update.Content)
+	if text == "" {
+		return nil
+	}
+	return []agent.Event{parser.event(now, "session/update", agent.EventReasoningDelta, raw, func(event *agent.Event) {
+		event.Text = text
+		event.MessageID = update.MessageID
+	})}
+}
+
+func (parser *acpEventParser) toolCall(now int64, update acpSessionUpdate, raw json.RawMessage) []agent.Event {
+	return []agent.Event{parser.event(now, "session/update", agent.EventToolStarted, raw, func(event *agent.Event) {
+		event.ItemKind = agent.ItemToolCall
+		event.ItemID = update.ToolCallID
+		event.ToolName = update.Title
+		event.Input = cloneRaw(update.RawInput)
+	})}
+}
+
+func (parser *acpEventParser) toolCallUpdate(now int64, update acpSessionUpdate, raw json.RawMessage) []agent.Event {
+	status := strings.ToLower(update.Status)
+	switch status {
+	case "completed", "failed", "cancelled", "denied":
+		output := extractText(update.Content)
+		if output == "" && len(update.RawOutput) > 0 {
+			output = compactJSON(update.RawOutput)
+		}
+		return []agent.Event{parser.event(now, "session/update", agent.EventToolCompleted, raw, func(event *agent.Event) {
+			event.ItemKind = agent.ItemToolCall
+			event.ItemID = update.ToolCallID
+			event.Output = output
+			event.IsError = status == "failed"
+		})}
+	default:
+		// Non-terminal progress update — consume silently.
+		return nil
+	}
+}
+
+// nativeSessionUpdate emits an EventProviderNative for a SessionUpdate variant
+// that has no direct agent.Event mapping.
+func (parser *acpEventParser) nativeSessionUpdate(now int64, method string, update acpSessionUpdate, raw json.RawMessage) []agent.Event {
+	return []agent.Event{parser.event(now, "session/update", agent.EventProviderNative, raw, func(event *agent.Event) {
+		event.Native = &agent.NativeEnvelope{
+			SchemaVersion: agent.NativeEnvelopeSchemaVersion,
+			Method:        method,
+			Payload:       cloneRaw(raw),
+		}
+	})}
+}
+
+func (parser *acpEventParser) nativeEvent(now int64, method string, raw json.RawMessage) []agent.Event {
+	return []agent.Event{parser.event(now, method, agent.EventProviderNative, raw, func(event *agent.Event) {
+		event.Native = &agent.NativeEnvelope{
+			SchemaVersion: agent.NativeEnvelopeSchemaVersion,
+			Method:        method,
+			Payload:       cloneRaw(raw),
+		}
+	})}
+}
+
+func (parser *acpEventParser) event(now int64, method string, eventType agent.EventType, raw json.RawMessage, configure func(*agent.Event)) agent.Event {
+	event := agent.Event{
+		T:              now,
+		Type:           eventType,
+		Provider:       parser.req.Provider,
+		ConversationID: parser.req.ConversationID,
+		Raw:            cloneRaw(raw),
+	}
+	if configure != nil {
+		configure(&event)
+	}
+	return event
+}
+
+// extractText pulls the text field from a ContentBlock JSON blob.
+func extractText(content json.RawMessage) string {
+	if len(content) == 0 {
+		return ""
+	}
+	var block acpContentBlock
+	if json.Unmarshal(content, &block) == nil && block.Type == "text" {
+		return block.Text
+	}
+	// content may be an array of blocks
+	var blocks []acpContentBlock
+	if json.Unmarshal(content, &blocks) == nil {
+		var sb strings.Builder
+		for _, b := range blocks {
+			if b.Type == "text" {
+				sb.WriteString(b.Text)
+			}
+		}
+		return sb.String()
+	}
+	return ""
+}
+
+func cloneRaw(raw json.RawMessage) json.RawMessage {
+	return append(json.RawMessage(nil), raw...)
+}
+
+func compactJSON(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var value any
+	if json.Unmarshal(raw, &value) != nil {
+		return string(raw)
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return string(raw)
+	}
+	return string(data)
+}
+
+func truncateJSON(raw json.RawMessage, limit int) string {
+	s := string(raw)
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "..."
+}

--- a/backend/internal/integration/agents/devinharness/acp_events_test.go
+++ b/backend/internal/integration/agents/devinharness/acp_events_test.go
@@ -1,0 +1,318 @@
+package devinharness
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+)
+
+func newTestParser() *acpEventParser {
+	return newACPEventParser(agent.RunRequest{
+		Provider:       agent.ProviderDevin,
+		ConversationID: "chat-1",
+	}, "Devin")
+}
+
+func TestACPAgentMessageChunk(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"agent_message_chunk",
+			"content":{"type":"text","text":"Hello world"},
+			"messageId":"msg-1"
+		}
+	}`))
+	if len(events) != 1 || events[0].Type != agent.EventAssistantTextDelta {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].Text != "Hello world" {
+		t.Fatalf("text = %q", events[0].Text)
+	}
+	if events[0].MessageID != "msg-1" {
+		t.Fatalf("messageId = %q", events[0].MessageID)
+	}
+	if events[0].ItemKind != agent.ItemMessage {
+		t.Fatalf("itemKind = %q", events[0].ItemKind)
+	}
+}
+
+func TestACPAgentThoughtChunk(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"agent_thought_chunk",
+			"content":{"type":"text","text":"Thinking..."},
+			"messageId":"msg-1"
+		}
+	}`))
+	if len(events) != 1 || events[0].Type != agent.EventReasoningDelta {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].Text != "Thinking..." {
+		t.Fatalf("text = %q", events[0].Text)
+	}
+}
+
+func TestACPUserMessageChunkIsSilent(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"user_message_chunk",
+			"content":{"type":"text","text":"user input echo"}
+		}
+	}`))
+	if len(events) != 0 {
+		t.Fatalf("user_message_chunk should produce no events, got %#v", events)
+	}
+}
+
+func TestACPToolCallStarted(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"tool_call",
+			"toolCallId":"tc-1",
+			"title":"Bash",
+			"kind":"command",
+			"rawInput":{"command":"ls -la"},
+			"status":"inProgress"
+		}
+	}`))
+	if len(events) != 1 || events[0].Type != agent.EventToolStarted {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].ItemID != "tc-1" {
+		t.Fatalf("itemId = %q", events[0].ItemID)
+	}
+	if events[0].ToolName != "Bash" {
+		t.Fatalf("toolName = %q", events[0].ToolName)
+	}
+	if string(events[0].Input) == "" || events[0].ItemKind != agent.ItemToolCall {
+		t.Fatalf("input = %q, itemKind = %q", events[0].Input, events[0].ItemKind)
+	}
+}
+
+func TestACPToolCallUpdateCompleted(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"tool_call_update",
+			"toolCallId":"tc-1",
+			"status":"completed",
+			"content":{"type":"text","text":"file1.txt\nfile2.txt"}
+		}
+	}`))
+	if len(events) != 1 || events[0].Type != agent.EventToolCompleted {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].ItemID != "tc-1" {
+		t.Fatalf("itemId = %q", events[0].ItemID)
+	}
+	if events[0].Output != "file1.txt\nfile2.txt" {
+		t.Fatalf("output = %q", events[0].Output)
+	}
+	if events[0].IsError {
+		t.Fatal("completed should not be error")
+	}
+}
+
+func TestACPToolCallUpdateFailed(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"tool_call_update",
+			"toolCallId":"tc-1",
+			"status":"failed",
+			"content":{"type":"text","text":"command not found"}
+		}
+	}`))
+	if len(events) != 1 || events[0].Type != agent.EventToolCompleted {
+		t.Fatalf("events = %#v", events)
+	}
+	if !events[0].IsError {
+		t.Fatal("failed status should set IsError")
+	}
+	if events[0].Output != "command not found" {
+		t.Fatalf("output = %q", events[0].Output)
+	}
+}
+
+func TestACPToolCallUpdateNonTerminalIsSilent(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"tool_call_update",
+			"toolCallId":"tc-1",
+			"status":"inProgress"
+		}
+	}`))
+	if len(events) != 0 {
+		t.Fatalf("non-terminal tool_call_update should produce no events, got %#v", events)
+	}
+}
+
+func TestACPPlanIsNative(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"plan",
+			"entries":[{"step":"1","description":"do thing"}]
+		}
+	}`))
+	if len(events) != 1 || events[0].Type != agent.EventProviderNative {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].Native == nil || events[0].Native.Method != "plan" {
+		t.Fatalf("native = %#v", events[0].Native)
+	}
+}
+
+func TestACPAvailableCommandsUpdateIsNative(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"available_commands_update",
+			"availableCommands":[{"id":"cmd-1","name":"test"}]
+		}
+	}`))
+	if len(events) != 1 || events[0].Type != agent.EventProviderNative {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].Native == nil || events[0].Native.Method != "available_commands_update" {
+		t.Fatalf("native = %#v", events[0].Native)
+	}
+}
+
+func TestACPCurrentModeUpdateIsNative(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"current_mode_update",
+			"currentModeId":"plan"
+		}
+	}`))
+	if len(events) != 1 || events[0].Type != agent.EventProviderNative {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].Native == nil || events[0].Native.Method != "current_mode_update" {
+		t.Fatalf("native = %#v", events[0].Native)
+	}
+}
+
+func TestACPUnknownSessionUpdateIsNative(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"future_variant",
+			"custom":"data"
+		}
+	}`))
+	if len(events) != 1 || events[0].Type != agent.EventProviderNative {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].Native == nil || events[0].Native.Method != "future_variant" {
+		t.Fatalf("native = %#v", events[0].Native)
+	}
+}
+
+func TestACPCognitionOutputIsSilent(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("_cognition.ai/output", json.RawMessage(`{"message":"MCP connected"}`))
+	if len(events) != 0 {
+		t.Fatalf("_cognition.ai/output should produce no events, got %#v", events)
+	}
+}
+
+func TestACPCognitionMCPServersChangedIsSilent(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("_cognition.ai/mcp/serversChanged", json.RawMessage(`{"servers":[]}`))
+	if len(events) != 0 {
+		t.Fatalf("_cognition.ai/mcp/serversChanged should produce no events, got %#v", events)
+	}
+}
+
+func TestACPCognitionDocumentIsSilent(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("_cognition.ai/document/opened", json.RawMessage(`{"path":"/workspace/file.go"}`))
+	if len(events) != 0 {
+		t.Fatalf("_cognition.ai/document/* should produce no events, got %#v", events)
+	}
+}
+
+func TestACPCognitionOtherIsNative(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("_cognition.ai/customExtension", json.RawMessage(`{"data":true}`))
+	if len(events) != 1 || events[0].Type != agent.EventProviderNative {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].Native == nil || events[0].Native.Method != "_cognition.ai/customExtension" {
+		t.Fatalf("native = %#v", events[0].Native)
+	}
+}
+
+func TestACPUnknownNotificationIsNative(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("future/method", json.RawMessage(`{"data":true}`))
+	if len(events) != 1 || events[0].Type != agent.EventProviderNative {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].Native == nil || events[0].Native.Method != "future/method" {
+		t.Fatalf("native = %#v", events[0].Native)
+	}
+}
+
+func TestACPMalformedSessionUpdateIsNative(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`not valid json`))
+	if len(events) != 1 || events[0].Type != agent.EventProviderNative {
+		t.Fatalf("malformed session/update should fall back to native, got %#v", events)
+	}
+}
+
+func TestACPContentArrayTextExtraction(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"agent_message_chunk",
+			"content":[{"type":"text","text":"part1"},{"type":"text","text":"part2"}],
+			"messageId":"msg-1"
+		}
+	}`))
+	if len(events) != 1 || events[0].Type != agent.EventAssistantTextDelta {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].Text != "part1part2" {
+		t.Fatalf("text = %q, want part1part2", events[0].Text)
+	}
+}
+
+func TestACPProviderLabelInEvents(t *testing.T) {
+	parser := newTestParser()
+	events := parser.ParseNotification("session/update", json.RawMessage(`{
+		"sessionId":"s-1",
+		"update":{
+			"sessionUpdate":"agent_message_chunk",
+			"content":{"type":"text","text":"hi"},
+			"messageId":"msg-1"
+		}
+	}`))
+	if len(events) != 1 || events[0].Provider != agent.ProviderDevin {
+		t.Fatalf("provider = %q, want devin", events[0].Provider)
+	}
+	if events[0].ConversationID != "chat-1" {
+		t.Fatalf("conversationId = %q", events[0].ConversationID)
+	}
+}

--- a/backend/internal/integration/agents/devinharness/acp_process.go
+++ b/backend/internal/integration/agents/devinharness/acp_process.go
@@ -1,0 +1,153 @@
+package devinharness
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os/exec"
+	"strings"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+)
+
+const (
+	acpStdoutInitialBufferSize = 64 * 1024
+	acpStdoutMaxBufferSize     = 16 * 1024 * 1024
+	acpStderrInitialBufferSize = 4 * 1024
+	acpStderrMaxBufferSize     = 1 * 1024 * 1024
+	acpStderrCaptureLimit      = 8 * 1024
+)
+
+type acpScanResult struct {
+	envelope acpEnvelope
+	err      error
+}
+
+// acpProcess owns the pipes and lifecycle of one `devin acp` child. The run
+// state machine consumes decoded envelopes without managing OS resources.
+type acpProcess struct {
+	cmd           *exec.Cmd
+	provider      agent.ProviderID
+	providerLabel string
+	logID         string
+
+	stdin      io.WriteCloser
+	encoder    *json.Encoder
+	scanner    *bufio.Scanner
+	stderrDone chan string
+}
+
+func newACPProcess(
+	cmd *exec.Cmd,
+	provider agent.ProviderID,
+	providerLabel string,
+	logID string,
+) *acpProcess {
+	return &acpProcess{
+		cmd:           cmd,
+		provider:      provider,
+		providerLabel: providerLabel,
+		logID:         logID,
+	}
+}
+
+func (process *acpProcess) start() error {
+	stdin, err := process.cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := process.cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := process.cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	if err := process.cmd.Start(); err != nil {
+		return fmt.Errorf("spawn %s ACP server: %w", process.providerLabel, err)
+	}
+
+	process.stdin = stdin
+	process.encoder = json.NewEncoder(stdin)
+	process.scanner = bufio.NewScanner(stdout)
+	process.scanner.Buffer(
+		make([]byte, acpStdoutInitialBufferSize),
+		acpStdoutMaxBufferSize,
+	)
+	process.stderrDone = make(chan string, 1)
+	go captureACPStderr(stderr, process.provider, process.logID, process.stderrDone)
+	return nil
+}
+
+func (process *acpProcess) write(message any) error {
+	return process.encoder.Encode(message)
+}
+
+func (process *acpProcess) scan(results chan<- acpScanResult, stop <-chan struct{}) {
+	defer close(results)
+	for process.scanner.Scan() {
+		line := append([]byte(nil), process.scanner.Bytes()...)
+		if len(line) == 0 {
+			continue
+		}
+		var envelope acpEnvelope
+		if err := json.Unmarshal(line, &envelope); err != nil {
+			log.Printf("%s[%s] acp parse: %v", process.provider, process.logID, err)
+			continue
+		}
+		select {
+		case results <- acpScanResult{envelope: envelope}:
+		case <-stop:
+			return
+		}
+	}
+	if err := process.scanner.Err(); err != nil {
+		select {
+		case results <- acpScanResult{
+			err: fmt.Errorf("%s ACP server stdout: %w", process.providerLabel, err),
+		}:
+		case <-stop:
+		}
+	}
+}
+
+func (process *acpProcess) closeInput() {
+	_ = process.stdin.Close()
+}
+
+func (process *acpProcess) kill() {
+	if process.cmd.Process != nil {
+		_ = process.cmd.Process.Kill()
+	}
+}
+
+func (process *acpProcess) wait() (error, string) {
+	waitErr := process.cmd.Wait()
+	return waitErr, <-process.stderrDone
+}
+
+func (process *acpProcess) abort() {
+	process.kill()
+	_, _ = process.wait()
+}
+
+func captureACPStderr(reader io.Reader, provider agent.ProviderID, logID string, done chan<- string) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(
+		make([]byte, acpStderrInitialBufferSize),
+		acpStderrMaxBufferSize,
+	)
+	var captured strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		log.Printf("%s[%s] stderr: %s", provider, logID, line)
+		if captured.Len() < acpStderrCaptureLimit {
+			captured.WriteString(line)
+			captured.WriteByte('\n')
+		}
+	}
+	done <- captured.String()
+}

--- a/backend/internal/integration/agents/devinharness/acp_protocol.go
+++ b/backend/internal/integration/agents/devinharness/acp_protocol.go
@@ -166,15 +166,36 @@ type acpSessionUpdate struct {
 // ── session/request_permission (server-to-client request) ──
 
 type acpPermissionOption struct {
-	Outcome string `json:"outcome"`
-	Title   string `json:"title,omitempty"`
-	Description string `json:"description,omitempty"`
+	OptionID string `json:"optionId"`
+	Name     string `json:"name,omitempty"`
+	Kind     string `json:"kind,omitempty"`
 }
 
 type acpRequestPermissionParams struct {
-	SessionID string          `json:"sessionId"`
-	ToolCall  json.RawMessage `json:"toolCall"`
+	SessionID string                `json:"sessionId"`
+	ToolCall  json.RawMessage       `json:"toolCall"`
 	Options   []acpPermissionOption `json:"options"`
+}
+
+// acpPermissionResult is the response sent back to the ACP server. The
+// outcome field is the struct field of RequestPermissionResponse, and its
+// value is the internally-tagged enum RequestPermissionOutcome.
+//
+// ACP v1 schema:
+//   struct RequestPermissionResponse { outcome: RequestPermissionOutcome }
+//   #[serde(tag = "outcome", rename_all = "snake_case")]
+//   enum RequestPermissionOutcome { Cancelled, Selected(SelectedPermissionOutcome) }
+//
+// So the wire format is:
+//   {"outcome": {"outcome": "selected", "optionId": "allow_once"}}
+//   {"outcome": {"outcome": "cancelled"}}
+type acpPermissionResult struct {
+	Outcome acpPermissionOutcome `json:"outcome"`
+}
+
+type acpPermissionOutcome struct {
+	Outcome  string `json:"outcome"`
+	OptionID string `json:"optionId,omitempty"`
 }
 
 // ── session/elicitation/create (server-to-client request) ──

--- a/backend/internal/integration/agents/devinharness/acp_protocol.go
+++ b/backend/internal/integration/agents/devinharness/acp_protocol.go
@@ -85,12 +85,6 @@ type acpInitializeResult struct {
 	AgentInfo        acpAgentInfo        `json:"agentInfo"`
 }
 
-// ── authenticate ──
-
-type acpAuthenticateParams struct {
-	MethodID string `json:"methodId"`
-}
-
 // ── session/new and session/resume ──
 
 type acpSessionNewParams struct {

--- a/backend/internal/integration/agents/devinharness/acp_protocol.go
+++ b/backend/internal/integration/agents/devinharness/acp_protocol.go
@@ -1,0 +1,197 @@
+package devinharness
+
+import (
+	"encoding/json"
+)
+
+// acpEnvelope is the JSON-RPC 2.0 envelope shared by requests, responses, and
+// notifications. A message with Method and ID is a request; with Method and no
+// ID is a notification; with ID and no Method is a response.
+type acpEnvelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *acpError       `json:"error,omitempty"`
+}
+
+type acpError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+// ── initialize ──
+
+type acpClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type acpClientCapabilities struct {
+	Elicitation *acpElicitationCapability `json:"elicitation,omitempty"`
+	FS          *acpFSCapability          `json:"fs,omitempty"`
+}
+
+type acpElicitationCapability struct {
+	Form struct{} `json:"form"`
+}
+
+type acpFSCapability struct {
+	ReadTextFile  bool `json:"readTextFile"`
+	WriteTextFile bool `json:"writeTextFile"`
+}
+
+type acpInitializeParams struct {
+	ProtocolVersion    int                   `json:"protocolVersion"`
+	ClientCapabilities acpClientCapabilities `json:"clientCapabilities"`
+	ClientInfo         acpClientInfo         `json:"clientInfo"`
+}
+
+type acpAgentCapabilities struct {
+	LoadSession        bool                  `json:"loadSession"`
+	PromptCapabilities acpPromptCapabilities `json:"promptCapabilities"`
+	MCPCapabilities    acpMCPCapabilities    `json:"mcpCapabilities"`
+}
+
+type acpPromptCapabilities struct {
+	Image           bool `json:"image"`
+	Audio           bool `json:"audio"`
+	EmbeddedContext bool `json:"embeddedContext"`
+}
+
+type acpMCPCapabilities struct {
+	HTTP bool `json:"http"`
+	SSE  bool `json:"sse"`
+}
+
+type acpAuthMethod struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type acpAgentInfo struct {
+	Name    string `json:"name"`
+	Title   string `json:"title"`
+	Version string `json:"version"`
+}
+
+type acpInitializeResult struct {
+	ProtocolVersion  int                 `json:"protocolVersion"`
+	AgentCapabilities acpAgentCapabilities `json:"agentCapabilities"`
+	AuthMethods      []acpAuthMethod     `json:"authMethods"`
+	AgentInfo        acpAgentInfo        `json:"agentInfo"`
+}
+
+// ── authenticate ──
+
+type acpAuthenticateParams struct {
+	MethodID string `json:"methodId"`
+}
+
+// ── session/new and session/resume ──
+
+type acpSessionNewParams struct {
+	Cwd        string             `json:"cwd"`
+	McpServers []json.RawMessage  `json:"mcpServers"`
+}
+
+type acpSessionResumeParams struct {
+	SessionID  string            `json:"sessionId"`
+	Cwd        string            `json:"cwd"`
+	McpServers []json.RawMessage `json:"mcpServers"`
+}
+
+type acpSessionResult struct {
+	SessionID       string          `json:"sessionId"`
+	ConfigOptions   json.RawMessage `json:"configOptions,omitempty"`
+}
+
+// ── session/prompt ──
+
+type acpContentBlock struct {
+	Type         string          `json:"type"`
+	Text         string          `json:"text,omitempty"`
+	Image        json.RawMessage `json:"image,omitempty"`
+	ResourceLink json.RawMessage `json:"resourceLink,omitempty"`
+}
+
+type acpSessionPromptParams struct {
+	SessionID string             `json:"sessionId"`
+	Prompt    []acpContentBlock  `json:"prompt"`
+}
+
+type acpStopReason string
+
+const (
+	StopReasonEndTurn          acpStopReason = "end_turn"
+	StopReasonMaxTokens        acpStopReason = "max_tokens"
+	StopReasonMaxTurnRequests  acpStopReason = "max_turn_requests"
+	StopReasonRefusal          acpStopReason = "refusal"
+	StopReasonCancelled        acpStopReason = "cancelled"
+)
+
+type acpSessionPromptResult struct {
+	StopReason acpStopReason   `json:"stopReason"`
+	Usage      json.RawMessage `json:"usage,omitempty"`
+}
+
+// ── session/cancel (notification) ──
+
+type acpSessionCancelParams struct {
+	SessionID string `json:"sessionId"`
+}
+
+// ── session/update notification ──
+
+type acpSessionNotificationParams struct {
+	SessionID string          `json:"sessionId"`
+	Update    json.RawMessage `json:"update"`
+}
+
+// SessionUpdate is the union discriminated by the sessionUpdate string field.
+// We decode the discriminator first, then parse the variant.
+type acpSessionUpdate struct {
+	SessionUpdate string          `json:"sessionUpdate"`
+	Content       json.RawMessage `json:"content,omitempty"`
+	MessageID     string          `json:"messageId,omitempty"`
+	ToolCallID    string          `json:"toolCallId,omitempty"`
+	Title         string          `json:"title,omitempty"`
+	Kind          string          `json:"kind,omitempty"`
+	RawInput      json.RawMessage `json:"rawInput,omitempty"`
+	RawOutput     json.RawMessage `json:"rawOutput,omitempty"`
+	Status        string          `json:"status,omitempty"`
+	Entries       json.RawMessage `json:"entries,omitempty"`
+	AvailableCommands json.RawMessage `json:"availableCommands,omitempty"`
+	CurrentModeID string          `json:"currentModeId,omitempty"`
+	ConfigOptions json.RawMessage `json:"configOptions,omitempty"`
+}
+
+// ── session/request_permission (server-to-client request) ──
+
+type acpPermissionOption struct {
+	Outcome string `json:"outcome"`
+	Title   string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type acpRequestPermissionParams struct {
+	SessionID string          `json:"sessionId"`
+	ToolCall  json.RawMessage `json:"toolCall"`
+	Options   []acpPermissionOption `json:"options"`
+}
+
+// ── session/elicitation/create (server-to-client request) ──
+
+type acpCreateElicitationParams struct {
+	ElicitationID   string          `json:"elicitationId"`
+	RequestedSchema json.RawMessage `json:"requestedSchema"`
+	ToolCallID      string          `json:"toolCallId,omitempty"`
+}
+
+type acpElicitationResult struct {
+	Action  string          `json:"action"`
+	Content json.RawMessage `json:"content,omitempty"`
+}

--- a/backend/internal/integration/agents/devinharness/acp_protocol_test.go
+++ b/backend/internal/integration/agents/devinharness/acp_protocol_test.go
@@ -159,21 +159,6 @@ func TestACPInitializeResultAcceptsProtocolVersion1(t *testing.T) {
 	}
 }
 
-func TestACPAuthenticateParamsRoundTrip(t *testing.T) {
-	params := acpAuthenticateParams{MethodID: "devin-browser"}
-	data, err := json.Marshal(params)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var decoded acpAuthenticateParams
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatal(err)
-	}
-	if decoded.MethodID != "devin-browser" {
-		t.Fatalf("methodId = %q", decoded.MethodID)
-	}
-}
-
 func TestACPSessionNewParamsRoundTrip(t *testing.T) {
 	params := acpSessionNewParams{
 		Cwd:        "/workspace",

--- a/backend/internal/integration/agents/devinharness/acp_protocol_test.go
+++ b/backend/internal/integration/agents/devinharness/acp_protocol_test.go
@@ -102,10 +102,6 @@ func TestACPInitializeParamsRoundTrip(t *testing.T) {
 		ProtocolVersion: 2,
 		ClientCapabilities: acpClientCapabilities{
 			Elicitation: &acpElicitationCapability{},
-			FS: &acpFSCapability{
-				ReadTextFile:  true,
-				WriteTextFile: true,
-			},
 		},
 		ClientInfo: acpClientInfo{
 			Name:    "remote.futrx",
@@ -126,11 +122,11 @@ func TestACPInitializeParamsRoundTrip(t *testing.T) {
 	if decoded.ClientInfo.Name != "remote.futrx" || decoded.ClientInfo.Version != "0.1.0" {
 		t.Fatalf("clientInfo = %#v", decoded.ClientInfo)
 	}
-	if decoded.ClientCapabilities.Elicitation == nil || decoded.ClientCapabilities.FS == nil {
+	if decoded.ClientCapabilities.Elicitation == nil {
 		t.Fatalf("capabilities = %#v", decoded.ClientCapabilities)
 	}
-	if !decoded.ClientCapabilities.FS.ReadTextFile || !decoded.ClientCapabilities.FS.WriteTextFile {
-		t.Fatalf("fs capability = %#v", decoded.ClientCapabilities.FS)
+	if decoded.ClientCapabilities.FS != nil {
+		t.Fatalf("fs capability should be nil, got %#v", decoded.ClientCapabilities.FS)
 	}
 }
 

--- a/backend/internal/integration/agents/devinharness/acp_protocol_test.go
+++ b/backend/internal/integration/agents/devinharness/acp_protocol_test.go
@@ -254,7 +254,7 @@ func TestACPRequestPermissionParamsRoundTrip(t *testing.T) {
 	raw := json.RawMessage(`{
 		"sessionId":"s-1",
 		"toolCall":{"toolCallId":"tc-1","title":"Bash","status":"pending"},
-		"options":[{"outcome":"allow","title":"Allow"},{"outcome":"deny","title":"Deny"}]
+		"options":[{"optionId":"allow_once","name":"Allow","kind":"allow_once"},{"optionId":"reject_once","name":"Deny","kind":"reject_once"}]
 	}`)
 	var params acpRequestPermissionParams
 	if err := json.Unmarshal(raw, &params); err != nil {
@@ -266,8 +266,84 @@ func TestACPRequestPermissionParamsRoundTrip(t *testing.T) {
 	if len(params.Options) != 2 {
 		t.Fatalf("options = %#v", params.Options)
 	}
-	if params.Options[0].Outcome != "allow" || params.Options[1].Outcome != "deny" {
-		t.Fatalf("option outcomes = %#v", params.Options)
+	if params.Options[0].OptionID != "allow_once" || params.Options[1].OptionID != "reject_once" {
+		t.Fatalf("option ids = %#v", params.Options)
+	}
+}
+
+func TestACPPermissionResultRoundTrip(t *testing.T) {
+	result := acpPermissionResult{
+		Outcome: acpPermissionOutcome{Outcome: "selected", OptionID: "allow_once"},
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded acpPermissionResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Outcome.Outcome != "selected" || decoded.Outcome.OptionID != "allow_once" {
+		t.Fatalf("outcome = %q, optionId = %q", decoded.Outcome.Outcome, decoded.Outcome.OptionID)
+	}
+}
+
+func TestTranslatePermissionResultGrantTurn(t *testing.T) {
+	options := []acpPermissionOption{
+		{OptionID: "allow_once", Name: "Allow", Kind: "allow_once"},
+		{OptionID: "allow_session", Name: "Yes, allow (this session)", Kind: "allow_always"},
+		{OptionID: "reject_once", Name: "Reject", Kind: "reject_once"},
+	}
+	uiResult := json.RawMessage(`{"permissions":{"tool":true},"scope":"turn"}`)
+	translated, err := translatePermissionResult(uiResult, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result acpPermissionResult
+	if err := json.Unmarshal(translated, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome.Outcome != "selected" || result.Outcome.OptionID != "allow_once" {
+		t.Fatalf("outcome = %q, optionId = %q, want selected/allow_once", result.Outcome.Outcome, result.Outcome.OptionID)
+	}
+}
+
+func TestTranslatePermissionResultGrantSession(t *testing.T) {
+	options := []acpPermissionOption{
+		{OptionID: "allow_once", Name: "Allow", Kind: "allow_once"},
+		{OptionID: "allow_session", Name: "Yes, allow (this session)", Kind: "allow_always"},
+		{OptionID: "reject_once", Name: "Reject", Kind: "reject_once"},
+	}
+	uiResult := json.RawMessage(`{"permissions":{"tool":true},"scope":"session"}`)
+	translated, err := translatePermissionResult(uiResult, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result acpPermissionResult
+	if err := json.Unmarshal(translated, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome.Outcome != "selected" || result.Outcome.OptionID != "allow_session" {
+		t.Fatalf("outcome = %q, optionId = %q, want selected/allow_session", result.Outcome.Outcome, result.Outcome.OptionID)
+	}
+}
+
+func TestTranslatePermissionResultDeny(t *testing.T) {
+	options := []acpPermissionOption{
+		{OptionID: "allow_once", Name: "Allow", Kind: "allow_once"},
+		{OptionID: "reject_once", Name: "Reject", Kind: "reject_once"},
+	}
+	uiResult := json.RawMessage(`{"permissions":{},"scope":"turn"}`)
+	translated, err := translatePermissionResult(uiResult, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result acpPermissionResult
+	if err := json.Unmarshal(translated, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome.Outcome != "cancelled" {
+		t.Fatalf("outcome = %q, want cancelled", result.Outcome.Outcome)
 	}
 }
 

--- a/backend/internal/integration/agents/devinharness/acp_protocol_test.go
+++ b/backend/internal/integration/agents/devinharness/acp_protocol_test.go
@@ -1,0 +1,308 @@
+package devinharness
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestACPEnvelopeRoundTrip(t *testing.T) {
+	original := acpEnvelope{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":2}`),
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded acpEnvelope
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.JSONRPC != "2.0" || decoded.Method != "initialize" {
+		t.Fatalf("decoded = %#v", decoded)
+	}
+	if string(decoded.ID) != `1` {
+		t.Fatalf("id = %q", decoded.ID)
+	}
+	if string(decoded.Params) != `{"protocolVersion":2}` {
+		t.Fatalf("params = %q", decoded.Params)
+	}
+}
+
+func TestACPEnvelopeResponseRoundTrip(t *testing.T) {
+	original := acpEnvelope{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Result:  json.RawMessage(`{"protocolVersion":1}`),
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded acpEnvelope
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Method != "" {
+		t.Fatalf("response should have no method, got %q", decoded.Method)
+	}
+	if string(decoded.Result) != `{"protocolVersion":1}` {
+		t.Fatalf("result = %q", decoded.Result)
+	}
+}
+
+func TestACPEnvelopeErrorRoundTrip(t *testing.T) {
+	original := acpEnvelope{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`2`),
+		Error: &acpError{
+			Code:    -32602,
+			Message: "Invalid params: missing field 'mcpServers'",
+		},
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded acpEnvelope
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Error == nil || decoded.Error.Code != -32602 || decoded.Error.Message != "Invalid params: missing field 'mcpServers'" {
+		t.Fatalf("error = %#v", decoded.Error)
+	}
+}
+
+func TestACPEnvelopeNotificationRoundTrip(t *testing.T) {
+	original := acpEnvelope{
+		JSONRPC: "2.0",
+		Method:  "session/cancel",
+		Params:  json.RawMessage(`{"sessionId":"s-1"}`),
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded acpEnvelope
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.ID) != 0 {
+		t.Fatalf("notification should have no id, got %q", decoded.ID)
+	}
+	if decoded.Method != "session/cancel" {
+		t.Fatalf("method = %q", decoded.Method)
+	}
+}
+
+func TestACPInitializeParamsRoundTrip(t *testing.T) {
+	params := acpInitializeParams{
+		ProtocolVersion: 2,
+		ClientCapabilities: acpClientCapabilities{
+			Elicitation: &acpElicitationCapability{},
+			FS: &acpFSCapability{
+				ReadTextFile:  true,
+				WriteTextFile: true,
+			},
+		},
+		ClientInfo: acpClientInfo{
+			Name:    "remote.futrx",
+			Version: "0.1.0",
+		},
+	}
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded acpInitializeParams
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.ProtocolVersion != 2 {
+		t.Fatalf("protocolVersion = %d", decoded.ProtocolVersion)
+	}
+	if decoded.ClientInfo.Name != "remote.futrx" || decoded.ClientInfo.Version != "0.1.0" {
+		t.Fatalf("clientInfo = %#v", decoded.ClientInfo)
+	}
+	if decoded.ClientCapabilities.Elicitation == nil || decoded.ClientCapabilities.FS == nil {
+		t.Fatalf("capabilities = %#v", decoded.ClientCapabilities)
+	}
+	if !decoded.ClientCapabilities.FS.ReadTextFile || !decoded.ClientCapabilities.FS.WriteTextFile {
+		t.Fatalf("fs capability = %#v", decoded.ClientCapabilities.FS)
+	}
+}
+
+func TestACPInitializeResultAcceptsProtocolVersion1(t *testing.T) {
+	raw := json.RawMessage(`{
+		"protocolVersion": 1,
+		"agentCapabilities": {
+			"loadSession": true,
+			"promptCapabilities": {"image": true, "audio": false, "embeddedContext": true}
+		},
+		"authMethods": [{"id":"devin-browser","name":"Log in with browser"}],
+		"agentInfo": {"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}
+	}`)
+	var result acpInitializeResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.ProtocolVersion != 1 {
+		t.Fatalf("protocolVersion = %d, want 1", result.ProtocolVersion)
+	}
+	if len(result.AuthMethods) != 1 || result.AuthMethods[0].ID != "devin-browser" {
+		t.Fatalf("authMethods = %#v", result.AuthMethods)
+	}
+	if !result.AgentCapabilities.LoadSession {
+		t.Fatalf("agentCapabilities = %#v", result.AgentCapabilities)
+	}
+}
+
+func TestACPAuthenticateParamsRoundTrip(t *testing.T) {
+	params := acpAuthenticateParams{MethodID: "devin-browser"}
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded acpAuthenticateParams
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.MethodID != "devin-browser" {
+		t.Fatalf("methodId = %q", decoded.MethodID)
+	}
+}
+
+func TestACPSessionNewParamsRoundTrip(t *testing.T) {
+	params := acpSessionNewParams{
+		Cwd:        "/workspace",
+		McpServers: []json.RawMessage{},
+	}
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded acpSessionNewParams
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Cwd != "/workspace" {
+		t.Fatalf("cwd = %q", decoded.Cwd)
+	}
+	if len(decoded.McpServers) != 0 {
+		t.Fatalf("mcpServers = %#v", decoded.McpServers)
+	}
+}
+
+func TestACPSessionPromptParamsRoundTrip(t *testing.T) {
+	params := acpSessionPromptParams{
+		SessionID: "s-1",
+		Prompt: []acpContentBlock{
+			{Type: "text", Text: "hello world"},
+		},
+	}
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded acpSessionPromptParams
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.SessionID != "s-1" {
+		t.Fatalf("sessionId = %q", decoded.SessionID)
+	}
+	if len(decoded.Prompt) != 1 || decoded.Prompt[0].Type != "text" || decoded.Prompt[0].Text != "hello world" {
+		t.Fatalf("prompt = %#v", decoded.Prompt)
+	}
+}
+
+func TestACPSessionPromptResultRoundTrip(t *testing.T) {
+	raw := json.RawMessage(`{"stopReason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`)
+	var result acpSessionPromptResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.StopReason != StopReasonEndTurn {
+		t.Fatalf("stopReason = %q, want end_turn", result.StopReason)
+	}
+	if len(result.Usage) == 0 {
+		t.Fatal("usage should be present")
+	}
+}
+
+func TestACPStopReasonConstants(t *testing.T) {
+	tests := []struct {
+		value    acpStopReason
+		expected string
+	}{
+		{StopReasonEndTurn, "end_turn"},
+		{StopReasonMaxTokens, "max_tokens"},
+		{StopReasonMaxTurnRequests, "max_turn_requests"},
+		{StopReasonRefusal, "refusal"},
+		{StopReasonCancelled, "cancelled"},
+	}
+	for _, test := range tests {
+		if string(test.value) != test.expected {
+			t.Fatalf("stop reason = %q, want %q", test.value, test.expected)
+		}
+	}
+}
+
+func TestACPContentBlockTextRoundTrip(t *testing.T) {
+	block := acpContentBlock{Type: "text", Text: "hello"}
+	data, err := json.Marshal(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded acpContentBlock
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Type != "text" || decoded.Text != "hello" {
+		t.Fatalf("decoded = %#v", decoded)
+	}
+}
+
+func TestACPRequestPermissionParamsRoundTrip(t *testing.T) {
+	raw := json.RawMessage(`{
+		"sessionId":"s-1",
+		"toolCall":{"toolCallId":"tc-1","title":"Bash","status":"pending"},
+		"options":[{"outcome":"allow","title":"Allow"},{"outcome":"deny","title":"Deny"}]
+	}`)
+	var params acpRequestPermissionParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		t.Fatal(err)
+	}
+	if params.SessionID != "s-1" {
+		t.Fatalf("sessionId = %q", params.SessionID)
+	}
+	if len(params.Options) != 2 {
+		t.Fatalf("options = %#v", params.Options)
+	}
+	if params.Options[0].Outcome != "allow" || params.Options[1].Outcome != "deny" {
+		t.Fatalf("option outcomes = %#v", params.Options)
+	}
+}
+
+func TestACPCreateElicitationParamsRoundTrip(t *testing.T) {
+	raw := json.RawMessage(`{
+		"elicitationId":"el-1",
+		"requestedSchema":{"type":"object","properties":{"name":{"type":"string"}}},
+		"toolCallId":"tc-1"
+	}`)
+	var params acpCreateElicitationParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		t.Fatal(err)
+	}
+	if params.ElicitationID != "el-1" {
+		t.Fatalf("elicitationId = %q", params.ElicitationID)
+	}
+	if params.ToolCallID != "tc-1" {
+		t.Fatalf("toolCallId = %q", params.ToolCallID)
+	}
+	if len(params.RequestedSchema) == 0 {
+		t.Fatal("requestedSchema should be present")
+	}
+}

--- a/backend/internal/integration/agents/devinharness/acp_request_builder.go
+++ b/backend/internal/integration/agents/devinharness/acp_request_builder.go
@@ -25,6 +25,13 @@ const clientVersion = "0.1.0"
 // buildInitialize constructs the ACP initialize request. The client requests
 // protocol version 2; the agent may respond with a lower version (confirmed
 // v1 by live traffic — the harness accepts whatever the agent returns).
+//
+// FS capabilities are intentionally NOT declared. Devin runs inside the
+// container with direct filesystem access, so it does not need the host to
+// read or write files on its behalf. Declaring fs.readTextFile/fs.writeTextFile
+// causes Devin to send fs/read_text_file and fs/write_text_file host-tool
+// requests, which the harness has no handler for — they would surface as
+// generic JSON input prompts in the UI. Devin reads and writes files itself.
 func buildInitialize() map[string]any {
 	return map[string]any{
 		"jsonrpc": "2.0",
@@ -34,10 +41,6 @@ func buildInitialize() map[string]any {
 			ProtocolVersion: 2,
 			ClientCapabilities: acpClientCapabilities{
 				Elicitation: &acpElicitationCapability{},
-				FS: &acpFSCapability{
-					ReadTextFile:  true,
-					WriteTextFile: true,
-				},
 			},
 			ClientInfo: acpClientInfo{
 				Name:    "remote.futrx",

--- a/backend/internal/integration/agents/devinharness/acp_request_builder.go
+++ b/backend/internal/integration/agents/devinharness/acp_request_builder.go
@@ -14,7 +14,6 @@ type acpRequestID int
 
 const (
 	acpInitializeRequestID acpRequestID = iota + 1
-	acpAuthenticateRequestID
 	acpSessionRequestID
 	acpPromptRequestID
 )
@@ -45,28 +44,6 @@ func buildInitialize() map[string]any {
 				Version: clientVersion,
 			},
 		},
-	}
-}
-
-// buildInitialized constructs the notifications/initialized notification that
-// must follow the initialize response.
-func buildInitialized() map[string]any {
-	return map[string]any{
-		"jsonrpc": "2.0",
-		"method":  "notifications/initialized",
-	}
-}
-
-// buildAuthenticate constructs the authenticate request. The ACP server does
-// not read on-disk credentials; the client must call authenticate with the
-// methodId from the initialize response's authMethods (confirmed "devin-browser"
-// by live traffic).
-func buildAuthenticate(methodID string) map[string]any {
-	return map[string]any{
-		"jsonrpc": "2.0",
-		"id":      acpAuthenticateRequestID,
-		"method":  "authenticate",
-		"params":  acpAuthenticateParams{MethodID: methodID},
 	}
 }
 

--- a/backend/internal/integration/agents/devinharness/acp_request_builder.go
+++ b/backend/internal/integration/agents/devinharness/acp_request_builder.go
@@ -1,0 +1,127 @@
+package devinharness
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+)
+
+// acpRequestID enumerates the client-to-agent JSON-RPC requests in the order
+// they are sent during one run. Numeric IDs keep the wire protocol compact and
+// match the pattern used by codexharness.
+type acpRequestID int
+
+const (
+	acpInitializeRequestID acpRequestID = iota + 1
+	acpAuthenticateRequestID
+	acpSessionRequestID
+	acpPromptRequestID
+)
+
+// clientVersion is the version reported in the ACP initialize clientInfo. It
+// identifies Remote as the ACP host without claiming Windsurf identity.
+const clientVersion = "0.1.0"
+
+// buildInitialize constructs the ACP initialize request. The client requests
+// protocol version 2; the agent may respond with a lower version (confirmed
+// v1 by live traffic — the harness accepts whatever the agent returns).
+func buildInitialize() map[string]any {
+	return map[string]any{
+		"jsonrpc": "2.0",
+		"id":      acpInitializeRequestID,
+		"method":  "initialize",
+		"params": acpInitializeParams{
+			ProtocolVersion: 2,
+			ClientCapabilities: acpClientCapabilities{
+				Elicitation: &acpElicitationCapability{},
+				FS: &acpFSCapability{
+					ReadTextFile:  true,
+					WriteTextFile: true,
+				},
+			},
+			ClientInfo: acpClientInfo{
+				Name:    "remote.futrx",
+				Version: clientVersion,
+			},
+		},
+	}
+}
+
+// buildInitialized constructs the notifications/initialized notification that
+// must follow the initialize response.
+func buildInitialized() map[string]any {
+	return map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+	}
+}
+
+// buildAuthenticate constructs the authenticate request. The ACP server does
+// not read on-disk credentials; the client must call authenticate with the
+// methodId from the initialize response's authMethods (confirmed "devin-browser"
+// by live traffic).
+func buildAuthenticate(methodID string) map[string]any {
+	return map[string]any{
+		"jsonrpc": "2.0",
+		"id":      acpAuthenticateRequestID,
+		"method":  "authenticate",
+		"params":  acpAuthenticateParams{MethodID: methodID},
+	}
+}
+
+// buildSessionNew constructs the session/new request. mcpServers is required
+// (can be empty); without it the server returns "missing field 'mcpServers'".
+func buildSessionNew(req agent.RunRequest) map[string]any {
+	return map[string]any{
+		"jsonrpc": "2.0",
+		"id":      acpSessionRequestID,
+		"method":  "session/new",
+		"params": acpSessionNewParams{
+			Cwd:        strings.TrimSpace(req.Cwd),
+			McpServers: []json.RawMessage{},
+		},
+	}
+}
+
+// buildSessionResume constructs the session/resume request for continuing an
+// existing conversation.
+func buildSessionResume(req agent.RunRequest) map[string]any {
+	return map[string]any{
+		"jsonrpc": "2.0",
+		"id":      acpSessionRequestID,
+		"method":  "session/resume",
+		"params": acpSessionResumeParams{
+			SessionID:  req.ResumeID,
+			Cwd:        strings.TrimSpace(req.Cwd),
+			McpServers: []json.RawMessage{},
+		},
+	}
+}
+
+// buildSessionPrompt constructs the session/prompt request. The prompt is a
+// slice of ContentBlocks; for text input it is a single text block.
+func buildSessionPrompt(sessionID, prompt string) map[string]any {
+	return map[string]any{
+		"jsonrpc": "2.0",
+		"id":      acpPromptRequestID,
+		"method":  "session/prompt",
+		"params": acpSessionPromptParams{
+			SessionID: sessionID,
+			Prompt: []acpContentBlock{
+				{Type: "text", Text: prompt},
+			},
+		},
+	}
+}
+
+// buildSessionCancel constructs the session/cancel notification. It is a
+// notification (no id, no response expected). The cancelled turn is confirmed
+// by the session/prompt response arriving with stopReason "cancelled".
+func buildSessionCancel(sessionID string) map[string]any {
+	return map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "session/cancel",
+		"params":  acpSessionCancelParams{SessionID: sessionID},
+	}
+}

--- a/backend/internal/integration/agents/devinharness/acp_requests.go
+++ b/backend/internal/integration/agents/devinharness/acp_requests.go
@@ -1,0 +1,194 @@
+package devinharness
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+)
+
+// acpRequestHandler stores pending server-to-client requests (permission
+// prompts, elicitations) by JSON-RPC id, emits EventInteractionRequest, and
+// routes InteractionResponse back when the run-scoped channel delivers a user
+// answer.
+type acpRequestHandler struct {
+	req     agent.RunRequest
+	emit    func(agent.Event)
+	write   func(any) error
+	pending map[string]acpPendingRequest
+}
+
+type acpPendingRequest struct {
+	envelope  acpEnvelope
+	createdAt time.Time
+}
+
+func newACPRequestHandler(
+	req agent.RunRequest,
+	emit func(agent.Event),
+	write func(any) error,
+) *acpRequestHandler {
+	return &acpRequestHandler{
+		req:     req,
+		emit:    emit,
+		write:   write,
+		pending: make(map[string]acpPendingRequest),
+	}
+}
+
+// Handle stores a server-to-client request and emits an EventInteractionRequest
+// for the UI. The request ID is preserved verbatim so string and numeric IDs
+// remain distinct.
+func (handler *acpRequestHandler) Handle(envelope acpEnvelope) error {
+	requestID, err := jsonRPCIDKey(envelope.ID)
+	if err != nil {
+		return err
+	}
+	if _, exists := handler.pending[requestID]; exists {
+		return fmt.Errorf("duplicate ACP request %s", requestID)
+	}
+
+	handler.pending[requestID] = acpPendingRequest{envelope: envelope, createdAt: time.Now()}
+	handler.emit(agent.Event{
+		T:              time.Now().UnixMilli(),
+		Type:           agent.EventInteractionRequest,
+		Provider:       handler.req.Provider,
+		ConversationID: handler.req.ConversationID,
+		ToolName:       envelope.Method,
+		Input:          cloneRaw(envelope.Params),
+		InteractionID:  requestID,
+		Status:         interactionKind(envelope.Method),
+		Native: &agent.NativeEnvelope{
+			SchemaVersion: agent.NativeEnvelopeSchemaVersion,
+			Method:        envelope.Method,
+			RequestID:     requestID,
+			Payload:       cloneRaw(envelope.Params),
+		},
+	})
+	return nil
+}
+
+// Respond routes a user-supplied InteractionResponse back to the ACP server.
+func (handler *acpRequestHandler) Respond(response agent.InteractionResponse) error {
+	pending, ok := handler.pending[response.ID]
+	if !ok {
+		return fmt.Errorf("%w: %s", errors.New("unknown ACP interaction"), response.ID)
+	}
+
+	request := pending.envelope
+	wire := map[string]any{"jsonrpc": "2.0", "id": request.ID}
+	switch {
+	case len(response.Error) > 0:
+		if !json.Valid(response.Error) {
+			return errors.New("invalid JSON-RPC interaction error")
+		}
+		wire["error"] = json.RawMessage(response.Error)
+	default:
+		result := response.Result
+		if len(result) == 0 {
+			result = json.RawMessage("null")
+		}
+		if !json.Valid(result) {
+			return errors.New("invalid JSON-RPC interaction result")
+		}
+		wire["result"] = json.RawMessage(result)
+	}
+
+	if err := handler.write(wire); err != nil {
+		return err
+	}
+	delete(handler.pending, response.ID)
+	handler.emit(handler.resolvedEvent(request, response.ID, interactionResponseStatus(request.Method, response.Result, response.Error)))
+	return nil
+}
+
+// ResolveAll emits resolved events for all pending requests without sending
+// responses to the server. Used when the turn ends.
+func (handler *acpRequestHandler) ResolveAll(status string) {
+	for requestID, pending := range handler.pending {
+		handler.emit(handler.resolvedEvent(pending.envelope, requestID, status))
+		delete(handler.pending, requestID)
+	}
+}
+
+func (handler *acpRequestHandler) resolvedEvent(request acpEnvelope, requestID string, status string) agent.Event {
+	return agent.Event{
+		T:              time.Now().UnixMilli(),
+		Type:           agent.EventInteractionDone,
+		Provider:       handler.req.Provider,
+		ConversationID: handler.req.ConversationID,
+		ToolName:       request.Method,
+		InteractionID:  requestID,
+		Status:         status,
+		Native: &agent.NativeEnvelope{
+			SchemaVersion: agent.NativeEnvelopeSchemaVersion,
+			Method:        request.Method,
+			RequestID:     requestID,
+		},
+	}
+}
+
+func jsonRPCIDKey(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 || !json.Valid(raw) {
+		return "", errors.New("ACP request has an invalid id")
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err != nil {
+		return "", err
+	}
+	key := compact.String()
+	if key == "null" || key == "" || (key[0] != '"' && !strings.ContainsAny(key[:1], "-0123456789")) {
+		return "", errors.New("ACP request id must be a string or number")
+	}
+	return key, nil
+}
+
+func interactionKind(method string) string {
+	switch method {
+	case "session/request_permission":
+		return "permission"
+	case "session/elicitation/create":
+		return "elicitation"
+	default:
+		return "provider_request"
+	}
+}
+
+func interactionResponseStatus(method string, result, responseError json.RawMessage) string {
+	if len(responseError) > 0 {
+		return "response_error"
+	}
+	var value map[string]json.RawMessage
+	if json.Unmarshal(result, &value) != nil {
+		return "answered"
+	}
+	if raw, exists := value["outcome"]; exists {
+		var outcome string
+		if json.Unmarshal(raw, &outcome) == nil {
+			switch outcome {
+			case "allow", "accepted":
+				return "approved"
+			case "deny", "denied":
+				return "denied"
+			}
+		}
+	}
+	if raw, exists := value["action"]; exists {
+		var action string
+		if json.Unmarshal(raw, &action) == nil {
+			switch action {
+			case "accept":
+				return "accepted"
+			case "decline":
+				return "denied"
+			case "cancel":
+				return "cancelled"
+			}
+		}
+	}
+	return "answered"
+}

--- a/backend/internal/integration/agents/devinharness/acp_requests.go
+++ b/backend/internal/integration/agents/devinharness/acp_requests.go
@@ -25,6 +25,10 @@ type acpRequestHandler struct {
 type acpPendingRequest struct {
 	envelope  acpEnvelope
 	createdAt time.Time
+	// permissionOptions stores the optionId values from session/request_permission
+	// so the UI's generic grant/deny response can be mapped back to Devin's
+	// expected outcome format.
+	permissionOptions []acpPermissionOption
 }
 
 func newACPRequestHandler(
@@ -52,14 +56,32 @@ func (handler *acpRequestHandler) Handle(envelope acpEnvelope) error {
 		return fmt.Errorf("duplicate ACP request %s", requestID)
 	}
 
-	handler.pending[requestID] = acpPendingRequest{envelope: envelope, createdAt: time.Now()}
+	pending := acpPendingRequest{envelope: envelope, createdAt: time.Now()}
+
+	// For session/request_permission, translate Devin's native options into
+	// the provider-neutral format the UI's PermissionInteractionForm expects.
+	// The UI looks for a "permissions" field to render the grant/deny buttons.
+	var uiInput json.RawMessage
+	if envelope.Method == "session/request_permission" {
+		var params acpRequestPermissionParams
+		if err := json.Unmarshal(envelope.Params, &params); err == nil {
+			pending.permissionOptions = params.Options
+			uiInput = translatePermissionParams(envelope.Params, params)
+		} else {
+			uiInput = cloneRaw(envelope.Params)
+		}
+	} else {
+		uiInput = cloneRaw(envelope.Params)
+	}
+
+	handler.pending[requestID] = pending
 	handler.emit(agent.Event{
 		T:              time.Now().UnixMilli(),
 		Type:           agent.EventInteractionRequest,
 		Provider:       handler.req.Provider,
-		ConversationID: handler.req.ConversationID,
+		ConversationID:  handler.req.ConversationID,
 		ToolName:       envelope.Method,
-		Input:          cloneRaw(envelope.Params),
+		Input:          uiInput,
 		InteractionID:  requestID,
 		Status:         interactionKind(envelope.Method),
 		Native: &agent.NativeEnvelope{
@@ -94,6 +116,16 @@ func (handler *acpRequestHandler) Respond(response agent.InteractionResponse) er
 		}
 		if !json.Valid(result) {
 			return errors.New("invalid JSON-RPC interaction result")
+		}
+		// For session/request_permission, translate the UI's generic
+		// grant_permissions/deny_permissions response into Devin's expected
+		// outcome format with the matching optionId.
+		if request.Method == "session/request_permission" {
+			translated, err := translatePermissionResult(result, pending.permissionOptions)
+			if err != nil {
+				return err
+			}
+			result = translated
 		}
 		wire["result"] = json.RawMessage(result)
 	}
@@ -191,4 +223,94 @@ func interactionResponseStatus(method string, result, responseError json.RawMess
 		}
 	}
 	return "answered"
+}
+
+// translatePermissionParams converts Devin's session/request_permission
+// params into the provider-neutral format the UI's PermissionInteractionForm
+// expects. The UI looks for a "permissions" field to render grant/deny buttons.
+func translatePermissionParams(raw json.RawMessage, params acpRequestPermissionParams) json.RawMessage {
+	// Build a UI-friendly input that includes the original fields plus a
+	// "permissions" field so the PermissionInteractionForm renders correctly.
+	var base map[string]json.RawMessage
+	if json.Unmarshal(raw, &base) != nil {
+		base = make(map[string]json.RawMessage)
+	}
+	// Extract tool call info for display.
+	var toolCall map[string]json.RawMessage
+	if json.Unmarshal(params.ToolCall, &toolCall) == nil {
+		for k, v := range toolCall {
+			if k == "_meta" {
+				base["reason"] = v
+			}
+		}
+	}
+	// Add a non-empty permissions object so the UI form renders.
+	base["permissions"] = json.RawMessage(`{"tool":true}`)
+	encoded, err := json.Marshal(base)
+	if err != nil {
+		return raw
+	}
+	return encoded
+}
+
+// translatePermissionResult converts the UI's generic grant_permissions /
+// deny_permissions response into Devin's expected ACP v1 format.
+//
+// The ACP schema uses:
+//   struct RequestPermissionResponse { outcome: RequestPermissionOutcome }
+//   #[serde(tag = "outcome", rename_all = "snake_case")]
+//   enum RequestPermissionOutcome { Cancelled, Selected(SelectedPermissionOutcome) }
+//
+// So the wire format is:
+//   {"outcome": {"outcome": "selected", "optionId": "allow_once"}}
+//   {"outcome": {"outcome": "cancelled"}}
+func translatePermissionResult(uiResult json.RawMessage, options []acpPermissionOption) (json.RawMessage, error) {
+	var uiResponse struct {
+		Permissions json.RawMessage `json:"permissions"`
+		Scope       string          `json:"scope"`
+	}
+	if err := json.Unmarshal(uiResult, &uiResponse); err != nil {
+		// Not a grant_permissions response — pass through as-is.
+		return uiResult, nil
+	}
+
+	// If permissions is empty/null, the user denied.
+	if len(uiResponse.Permissions) == 0 || string(uiResponse.Permissions) == "null" || string(uiResponse.Permissions) == "{}" {
+		return json.Marshal(acpPermissionResult{
+			Outcome: acpPermissionOutcome{Outcome: "cancelled"},
+		})
+	}
+
+	// User granted — map scope to the appropriate option.
+	var optionID string
+	if uiResponse.Scope == "session" {
+		optionID = findOptionID(options, "allow_session")
+		if optionID == "" {
+			optionID = findOptionID(options, "allow_always")
+		}
+	} else {
+		optionID = findOptionID(options, "allow_once")
+		if optionID == "" {
+			optionID = findOptionID(options, "allow")
+		}
+	}
+	if optionID == "" && len(options) > 0 {
+		optionID = options[0].OptionID
+	}
+	if optionID == "" {
+		optionID = "allow_once"
+	}
+	return json.Marshal(acpPermissionResult{
+		Outcome: acpPermissionOutcome{Outcome: "selected", OptionID: optionID},
+	})
+}
+
+// findOptionID searches for an option whose optionId contains the given substring.
+func findOptionID(options []acpPermissionOption, contains string) string {
+	for _, opt := range options {
+		if strings.Contains(opt.OptionID, contains) {
+			return opt.OptionID
+		}
+	}
+	return ""
 }

--- a/backend/internal/integration/agents/devinharness/acp_run.go
+++ b/backend/internal/integration/agents/devinharness/acp_run.go
@@ -36,7 +36,6 @@ type acpRun struct {
 	requestHandler *acpRequestHandler
 
 	sessionID       string
-	authMethodID    string
 	cancelRequested bool
 	cancelSent      bool
 	terminal        bool
@@ -103,9 +102,16 @@ func (run *acpRun) start() error {
 	return nil
 }
 
-// handshake performs the synchronous initialize → authenticate → session/new
-// (or session/resume) exchange before the prompt is sent. Each step waits for
-// its response on the stdout scanner.
+// handshake performs the synchronous initialize → session/new (or
+// session/resume) exchange before the prompt is sent. Each step waits for its
+// response on the stdout scanner.
+//
+// Devin's ACP server loads credentials from disk on startup (the credential
+// policy log says "Will accept host credentials if provided, otherwise fall
+// back to env vars and stored CLI credentials"), so the authenticate step is
+// not needed when the host has already run `devin auth login`. The
+// notifications/initialized notification is also skipped because Devin's ACP
+// server does not implement it (returns "Method not found").
 func (run *acpRun) handshake() error {
 	// Step 1: initialize
 	if err := run.process.write(buildInitialize()); err != nil {
@@ -119,20 +125,7 @@ func (run *acpRun) handshake() error {
 		return err
 	}
 
-	// Step 2: notifications/initialized
-	if err := run.process.write(buildInitialized()); err != nil {
-		return fmt.Errorf("send initialized: %w", err)
-	}
-
-	// Step 3: authenticate
-	if err := run.process.write(buildAuthenticate(run.authMethodID)); err != nil {
-		return fmt.Errorf("send authenticate: %w", err)
-	}
-	if _, err := run.waitForResponse(acpAuthenticateRequestID); err != nil {
-		return fmt.Errorf("authenticate: %w", err)
-	}
-
-	// Step 4: session/new or session/resume
+	// Step 2: session/new or session/resume
 	if run.req.ResumeID != "" {
 		if err := run.process.write(buildSessionResume(run.req)); err != nil {
 			return fmt.Errorf("send session/resume: %w", err)
@@ -153,7 +146,7 @@ func (run *acpRun) handshake() error {
 		return err
 	}
 
-	// Step 5: session/prompt
+	// Step 3: session/prompt
 	if err := run.process.write(buildSessionPrompt(run.sessionID, run.req.Prompt)); err != nil {
 		return fmt.Errorf("send session/prompt: %w", err)
 	}
@@ -215,10 +208,13 @@ func (run *acpRun) parseInitializeResult(result json.RawMessage) error {
 	}
 	// The agent may respond with a lower protocol version (confirmed v1).
 	// Accept whatever the agent returns.
+	//
+	// Devin's ACP server loads credentials from disk on startup, so the
+	// authenticate step is not needed. We still verify authMethods is present
+	// as a sanity check that the server initialized correctly.
 	if len(initResult.AuthMethods) == 0 {
 		return fmt.Errorf("%s ACP server returned no auth methods", run.providerLabel)
 	}
-	run.authMethodID = initResult.AuthMethods[0].ID
 	return nil
 }
 

--- a/backend/internal/integration/agents/devinharness/acp_run.go
+++ b/backend/internal/integration/agents/devinharness/acp_run.go
@@ -1,0 +1,516 @@
+package devinharness
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+	agentruntime "github.com/futrx-com/remote.futrx.com/internal/integration/agents/runtime"
+)
+
+const (
+	// acpCancelTimeout is the maximum time to wait for the session/prompt
+	// response (with stopReason "cancelled") after sending session/cancel.
+	acpCancelTimeout = 30 * time.Second
+	// acpTerminalDrainTimeout is the grace period for late notifications
+	// after the terminal session/prompt response arrives.
+	acpTerminalDrainTimeout = 3 * time.Second
+)
+
+var errACPCancelTimeout = fmt.Errorf("ACP server did not confirm cancellation within %d seconds", int(acpCancelTimeout/time.Second))
+
+// acpRun owns one `devin acp` process for one Remote turn.
+type acpRun struct {
+	ctx           context.Context
+	req           agent.RunRequest
+	providerLabel string
+	process       *acpProcess
+
+	emit           func(agent.Event)
+	eventParser    *acpEventParser
+	requestHandler *acpRequestHandler
+
+	sessionID       string
+	authMethodID    string
+	cancelRequested bool
+	cancelSent      bool
+	terminal        bool
+	interrupted     bool
+	runFailed       bool
+	protocolErr     error
+	terminalEvent   *agent.Event
+}
+
+// Run owns one Devin ACP process for one Remote turn. Provider adapters supply
+// their normalized identity and label while retaining responsibility for their
+// CLI configuration, environment, and project preparation.
+//
+// The cmd's context should use context.WithoutCancel so the process outlives
+// request cancellation long enough for the harness to send session/cancel and
+// receive the terminal stopReason.
+func Run(
+	ctx context.Context,
+	cmd *exec.Cmd,
+	req agent.RunRequest,
+	providerLabel string,
+	emit func(agent.Event),
+) error {
+	if emit == nil {
+		emit = func(agent.Event) {}
+	}
+	return newACPRun(ctx, cmd, req, providerLabel, emit).execute()
+}
+
+func newACPRun(
+	ctx context.Context,
+	cmd *exec.Cmd,
+	req agent.RunRequest,
+	providerLabel string,
+	emit func(agent.Event),
+) *acpRun {
+	return &acpRun{
+		ctx:           ctx,
+		req:           req,
+		providerLabel: providerLabel,
+		emit:          emit,
+		process:       newACPProcess(cmd, req.Provider, providerLabel, req.ConversationID),
+	}
+}
+
+func (run *acpRun) execute() error {
+	if err := run.start(); err != nil {
+		return err
+	}
+	if err := run.handshake(); err != nil {
+		run.process.abort()
+		return err
+	}
+	run.consumeOutput()
+	return run.finish()
+}
+
+func (run *acpRun) start() error {
+	if err := run.process.start(); err != nil {
+		return err
+	}
+	run.eventParser = newACPEventParser(run.req, run.providerLabel)
+	run.requestHandler = newACPRequestHandler(run.req, run.emit, run.process.write)
+	return nil
+}
+
+// handshake performs the synchronous initialize → authenticate → session/new
+// (or session/resume) exchange before the prompt is sent. Each step waits for
+// its response on the stdout scanner.
+func (run *acpRun) handshake() error {
+	// Step 1: initialize
+	if err := run.process.write(buildInitialize()); err != nil {
+		return fmt.Errorf("send initialize: %w", err)
+	}
+	initResult, err := run.waitForResponse(acpInitializeRequestID)
+	if err != nil {
+		return fmt.Errorf("initialize: %w", err)
+	}
+	if err := run.parseInitializeResult(initResult); err != nil {
+		return err
+	}
+
+	// Step 2: notifications/initialized
+	if err := run.process.write(buildInitialized()); err != nil {
+		return fmt.Errorf("send initialized: %w", err)
+	}
+
+	// Step 3: authenticate
+	if err := run.process.write(buildAuthenticate(run.authMethodID)); err != nil {
+		return fmt.Errorf("send authenticate: %w", err)
+	}
+	if _, err := run.waitForResponse(acpAuthenticateRequestID); err != nil {
+		return fmt.Errorf("authenticate: %w", err)
+	}
+
+	// Step 4: session/new or session/resume
+	if run.req.ResumeID != "" {
+		if err := run.process.write(buildSessionResume(run.req)); err != nil {
+			return fmt.Errorf("send session/resume: %w", err)
+		}
+	} else {
+		if err := run.process.write(buildSessionNew(run.req)); err != nil {
+			return fmt.Errorf("send session/new: %w", err)
+		}
+	}
+	sessionResult, err := run.waitForResponse(acpSessionRequestID)
+	if err != nil {
+		if run.req.ResumeID != "" && isMissingSession(err.Error()) {
+			return fmt.Errorf("%w: %s", agent.ErrSessionNotFound, err)
+		}
+		return fmt.Errorf("session: %w", err)
+	}
+	if err := run.parseSessionResult(sessionResult); err != nil {
+		return err
+	}
+
+	// Step 5: session/prompt
+	if err := run.process.write(buildSessionPrompt(run.sessionID, run.req.Prompt)); err != nil {
+		return fmt.Errorf("send session/prompt: %w", err)
+	}
+	return nil
+}
+
+// waitForResponse reads stdout lines until a response with the matching request
+// ID arrives. Notifications and server requests arriving during the wait are
+// dispatched immediately. This is used during the synchronous handshake phase.
+func (run *acpRun) waitForResponse(expectedID acpRequestID) (json.RawMessage, error) {
+	for run.process.scanner.Scan() {
+		line := append([]byte(nil), run.process.scanner.Bytes()...)
+		if len(line) == 0 {
+			continue
+		}
+		var envelope acpEnvelope
+		if err := json.Unmarshal(line, &envelope); err != nil {
+			log.Printf("%s[%s] acp parse during handshake: %v", run.req.Provider, run.req.ConversationID, err)
+			continue
+		}
+
+		// Server-to-client request during handshake — handle it.
+		if envelope.Method != "" && len(envelope.ID) > 0 {
+			if err := run.requestHandler.Handle(envelope); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		// Notification during handshake — emit events.
+		if envelope.Method != "" {
+			for _, event := range run.eventParser.ParseNotification(envelope.Method, envelope.Params) {
+				run.emit(event)
+			}
+			continue
+		}
+		// Response — check if it matches.
+		responseID, ok := acpResponseID(envelope.ID)
+		if !ok {
+			continue
+		}
+		if responseID != expectedID {
+			continue
+		}
+		if envelope.Error != nil {
+			return nil, fmt.Errorf("%s", envelope.Error.Message)
+		}
+		return envelope.Result, nil
+	}
+	if err := run.process.scanner.Err(); err != nil {
+		return nil, fmt.Errorf("%s ACP server stdout: %w", run.providerLabel, err)
+	}
+	return nil, fmt.Errorf("%s ACP server closed before responding to request %d", run.providerLabel, expectedID)
+}
+
+func (run *acpRun) parseInitializeResult(result json.RawMessage) error {
+	var initResult acpInitializeResult
+	if err := json.Unmarshal(result, &initResult); err != nil {
+		return fmt.Errorf("decode initialize response: %w", err)
+	}
+	// The agent may respond with a lower protocol version (confirmed v1).
+	// Accept whatever the agent returns.
+	if len(initResult.AuthMethods) == 0 {
+		return fmt.Errorf("%s ACP server returned no auth methods", run.providerLabel)
+	}
+	run.authMethodID = initResult.AuthMethods[0].ID
+	return nil
+}
+
+func (run *acpRun) parseSessionResult(result json.RawMessage) error {
+	var sessionResult acpSessionResult
+	if err := json.Unmarshal(result, &sessionResult); err != nil {
+		return fmt.Errorf("decode session response: %w", err)
+	}
+	if sessionResult.SessionID == "" {
+		return fmt.Errorf("%s ACP server returned no session id", run.providerLabel)
+	}
+	run.sessionID = sessionResult.SessionID
+	if sessionResult.SessionID != run.req.ResumeID {
+		run.emit(agent.Event{
+			T:              time.Now().UnixMilli(),
+			Type:           agent.EventSessionUpdated,
+			Provider:       run.req.Provider,
+			ConversationID: run.req.ConversationID,
+			SessionID:      sessionResult.SessionID,
+		})
+	}
+	return nil
+}
+
+// consumeOutput is the main event loop. It selects over stdout notifications,
+// user interaction responses, context cancellation, and the terminal
+// session/prompt response.
+func (run *acpRun) consumeOutput() {
+	scanned := make(chan acpScanResult, 1)
+	stopScan := make(chan struct{})
+	defer close(stopScan)
+	go run.process.scan(scanned, stopScan)
+
+	ctxDone := run.ctx.Done()
+	responses := run.req.InteractionResponses
+	var cancelTimer *time.Timer
+	var cancelTimeout <-chan time.Time
+	var terminalTimer *time.Timer
+	var terminalTimeout <-chan time.Time
+	defer func() {
+		if cancelTimer != nil {
+			cancelTimer.Stop()
+		}
+		if terminalTimer != nil {
+			terminalTimer.Stop()
+		}
+	}()
+	startTerminalDrain := func() {
+		if !run.terminal || terminalTimer != nil {
+			return
+		}
+		ctxDone = nil
+		responses = nil
+		cancelTimeout = nil
+		terminalTimer = time.NewTimer(acpTerminalDrainTimeout)
+		terminalTimeout = terminalTimer.C
+	}
+
+	for {
+		select {
+		case result, ok := <-scanned:
+			if !ok {
+				run.finalizeTerminal()
+				return
+			}
+			if result.err != nil {
+				if run.terminal {
+					run.finalizeTerminal()
+					return
+				}
+				run.protocolErr = result.err
+				return
+			}
+			if run.terminal {
+				run.handlePostTerminalEnvelope(result.envelope)
+			} else if !run.handleEnvelope(result.envelope) {
+				return
+			}
+			if run.cancelSent && cancelTimer == nil {
+				cancelTimer = time.NewTimer(acpCancelTimeout)
+				cancelTimeout = cancelTimer.C
+			}
+			startTerminalDrain()
+
+		case response, ok := <-responses:
+			if !ok {
+				responses = nil
+				continue
+			}
+			if err := run.requestHandler.Respond(response); err != nil {
+				run.protocolErr = err
+				return
+			}
+
+		case <-ctxDone:
+			ctxDone = nil
+			run.cancelRequested = true
+			if err := run.maybeCancel(); err != nil {
+				run.protocolErr = err
+				return
+			}
+			if run.cancelSent && cancelTimer == nil {
+				cancelTimer = time.NewTimer(acpCancelTimeout)
+				cancelTimeout = cancelTimer.C
+			}
+
+		case <-cancelTimeout:
+			run.protocolErr = errACPCancelTimeout
+			return
+
+		case <-terminalTimeout:
+			run.finalizeTerminal()
+			run.process.kill()
+			return
+		}
+	}
+}
+
+func (run *acpRun) handlePostTerminalEnvelope(envelope acpEnvelope) {
+	// Drain late notifications after the terminal prompt response.
+	if envelope.Method != "" && len(envelope.ID) == 0 {
+		run.handleNotification(envelope)
+	}
+}
+
+func (run *acpRun) handleEnvelope(envelope acpEnvelope) bool {
+	// Server-to-client request (method + id).
+	if envelope.Method != "" && len(envelope.ID) > 0 {
+		run.protocolErr = run.requestHandler.Handle(envelope)
+		return run.protocolErr == nil
+	}
+	// Notification (method, no id).
+	if envelope.Method != "" {
+		run.handleNotification(envelope)
+		return run.protocolErr == nil
+	}
+	// Response (id, no method) — must be the session/prompt response.
+	responseID, ok := acpResponseID(envelope.ID)
+	if !ok {
+		return true
+	}
+	if envelope.Error != nil {
+		run.protocolErr = fmt.Errorf("%s session/prompt: %s", run.providerLabel, envelope.Error.Message)
+		return false
+	}
+	run.handlePromptResponse(responseID, envelope.Result)
+	return run.protocolErr == nil
+}
+
+func (run *acpRun) handleNotification(envelope acpEnvelope) {
+	if run.cancelRequested {
+		if err := run.maybeCancel(); err != nil {
+			run.protocolErr = err
+			return
+		}
+	}
+	for _, event := range run.eventParser.ParseNotification(envelope.Method, envelope.Params) {
+		if isTerminalEvent(event.Type) {
+			run.beginTerminal(event)
+			continue
+		}
+		run.emit(event)
+	}
+}
+
+func (run *acpRun) handlePromptResponse(responseID acpRequestID, resultJSON json.RawMessage) {
+	if responseID != acpPromptRequestID {
+		return
+	}
+	var result acpSessionPromptResult
+	if err := json.Unmarshal(resultJSON, &result); err != nil {
+		run.protocolErr = fmt.Errorf("decode %s session/prompt response: %w", run.providerLabel, err)
+		return
+	}
+	run.beginTerminal(run.promptResponseEvent(result))
+}
+
+func (run *acpRun) promptResponseEvent(result acpSessionPromptResult) agent.Event {
+	now := time.Now().UnixMilli()
+	switch result.StopReason {
+	case StopReasonCancelled:
+		run.interrupted = true
+		return agent.Event{
+			T:              now,
+			Type:           agent.EventRunInterrupted,
+			Provider:       run.req.Provider,
+			ConversationID: run.req.ConversationID,
+			Usage:          cloneRaw(result.Usage),
+		}
+	case StopReasonRefusal:
+		run.runFailed = true
+		return agent.Event{
+			T:              now,
+			Type:           agent.EventRunFailed,
+			Provider:       run.req.Provider,
+			ConversationID: run.req.ConversationID,
+			Message:        "agent refused to continue",
+			IsError:        true,
+			Usage:          cloneRaw(result.Usage),
+		}
+	default:
+		// end_turn, max_tokens, max_turn_requests → completed.
+		return agent.Event{
+			T:              now,
+			Type:           agent.EventRunCompleted,
+			Provider:       run.req.Provider,
+			ConversationID: run.req.ConversationID,
+			Usage:          cloneRaw(result.Usage),
+		}
+	}
+}
+
+func isTerminalEvent(eventType agent.EventType) bool {
+	switch eventType {
+	case agent.EventRunCompleted, agent.EventRunFailed, agent.EventRunInterrupted:
+		return true
+	default:
+		return false
+	}
+}
+
+func (run *acpRun) beginTerminal(event agent.Event) {
+	if run.terminal {
+		return
+	}
+	run.terminal = true
+	run.runFailed = run.runFailed || event.Type == agent.EventRunFailed
+	run.interrupted = run.interrupted || event.Type == agent.EventRunInterrupted
+	run.terminalEvent = &event
+	run.requestHandler.ResolveAll("turn_ended")
+	run.process.closeInput()
+}
+
+func (run *acpRun) finalizeTerminal() {
+	if run.terminalEvent == nil {
+		return
+	}
+	run.emit(*run.terminalEvent)
+	run.terminalEvent = nil
+}
+
+func (run *acpRun) maybeCancel() error {
+	if !run.cancelRequested || run.cancelSent || run.sessionID == "" {
+		return nil
+	}
+	if err := run.process.write(buildSessionCancel(run.sessionID)); err != nil {
+		return fmt.Errorf("send session/cancel: %w", err)
+	}
+	run.cancelSent = true
+	return nil
+}
+
+func (run *acpRun) finish() error {
+	if run.terminal {
+		run.finalizeTerminal()
+	}
+	if run.protocolErr != nil || !run.terminal {
+		run.process.closeInput()
+		run.process.kill()
+	}
+	waitErr, stderrText := run.process.wait()
+
+	if run.protocolErr != nil {
+		return &agentruntime.ProcessError{Err: run.protocolErr, Stderr: stderrText}
+	}
+	if run.runFailed {
+		return &agentruntime.ProcessError{Err: agent.ErrRunFailed, Stderr: stderrText}
+	}
+	if run.interrupted {
+		return nil
+	}
+	if !run.terminal {
+		if waitErr == nil {
+			waitErr = fmt.Errorf("%s ACP server closed before the turn completed", run.providerLabel)
+		}
+		return &agentruntime.ProcessError{Err: waitErr, Stderr: stderrText}
+	}
+	return nil
+}
+
+func acpResponseID(raw json.RawMessage) (acpRequestID, bool) {
+	if len(raw) == 0 {
+		return 0, false
+	}
+	var id acpRequestID
+	if err := json.Unmarshal(raw, &id); err != nil {
+		return 0, false
+	}
+	return id, true
+}
+
+func isMissingSession(message string) bool {
+	lower := strings.ToLower(message)
+	return strings.Contains(lower, "not found") || strings.Contains(lower, "no session")
+}

--- a/backend/internal/integration/agents/devinharness/acp_run_test.go
+++ b/backend/internal/integration/agents/devinharness/acp_run_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/futrx-com/remote.futrx.com/internal/agent"
 )
 
-// TestRunACPSuccessfulTurn tests a complete ACP turn: initialize → authenticate
-// → session/new → session/prompt → session/update notifications → prompt
-// response with stopReason end_turn.
+// TestRunACPSuccessfulTurn tests a complete ACP turn: initialize → session/new
+// → session/prompt → session/update notifications → prompt response with
+// stopReason end_turn.
 func TestRunACPSuccessfulTurn(t *testing.T) {
 	script := `
 while IFS= read -r line; do
@@ -20,20 +20,14 @@ while IFS= read -r line; do
     *'"method":"initialize"'*)
       printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true},"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
       ;;
-    *'"method":"notifications/initialized"'*)
-      # no response expected
-      ;;
-    *'"method":"authenticate"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
-      ;;
     *'"method":"session/new"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-1"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"sessionId":"sess-1"}}'
       ;;
     *'"method":"session/prompt"'*)
       printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello!"},"messageId":"msg-1"}}}'
       printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-1","update":{"sessionUpdate":"tool_call","toolCallId":"tc-1","title":"Bash","status":"inProgress","rawInput":{"command":"echo hi"}}}}'
       printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-1","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc-1","status":"completed","content":{"type":"text","text":"hi"}}}}'
-      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"end_turn"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}'
       ;;
   esac
 done`
@@ -113,15 +107,12 @@ while IFS= read -r line; do
     *'"method":"initialize"'*)
       printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
       ;;
-    *'"method":"authenticate"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
-      ;;
     *'"method":"session/resume"'*)
       case "$line" in *'"sessionId":"existing-sess"'*) ;; *) exit 1 ;; esac
-      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"existing-sess"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"sessionId":"existing-sess"}}'
       ;;
     *'"method":"session/prompt"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"end_turn"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}'
       ;;
   esac
 done`
@@ -170,11 +161,8 @@ while IFS= read -r line; do
     *'"method":"initialize"'*)
       printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
       ;;
-    *'"method":"authenticate"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
-      ;;
     *'"method":"session/new"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-cancel"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"sessionId":"sess-cancel"}}'
       ;;
     *'"method":"session/prompt"'*)
       # Send a notification, then wait for the cancel notification
@@ -182,7 +170,7 @@ while IFS= read -r line; do
       # Wait for cancel
       ;;
     *'"method":"session/cancel"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"cancelled"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"stopReason":"cancelled"}}'
       ;;
   esac
 done`
@@ -223,39 +211,6 @@ done`
 	}
 }
 
-// TestRunACPAuthFailure tests that an authenticate error is propagated.
-func TestRunACPAuthFailure(t *testing.T) {
-	script := `
-while IFS= read -r line; do
-  case "$line" in
-    *'"method":"initialize"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
-      ;;
-    *'"method":"authenticate"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-1,"message":"authentication failed"}}'
-      ;;
-  esac
-done`
-
-	err := Run(
-		context.Background(),
-		exec.Command("sh", "-c", script),
-		agent.RunRequest{
-			Provider:       agent.ProviderDevin,
-			ConversationID: "chat-1",
-			Prompt:         "hello",
-		},
-		"Devin",
-		func(event agent.Event) {},
-	)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "authentication failed") {
-		t.Fatalf("error = %q, want it to contain 'authentication failed'", err.Error())
-	}
-}
-
 // TestRunACPRefusal tests that stopReason "refusal" produces EventRunFailed.
 func TestRunACPRefusal(t *testing.T) {
 	script := `
@@ -264,14 +219,11 @@ while IFS= read -r line; do
     *'"method":"initialize"'*)
       printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
       ;;
-    *'"method":"authenticate"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
-      ;;
     *'"method":"session/new"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-refuse"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"sessionId":"sess-refuse"}}'
       ;;
     *'"method":"session/prompt"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"refusal"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"stopReason":"refusal"}}'
       ;;
   esac
 done`
@@ -315,17 +267,14 @@ while IFS= read -r line; do
     *'"method":"initialize"'*)
       printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
       ;;
-    *'"method":"authenticate"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
-      ;;
     *'"method":"session/new"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-unk"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"sessionId":"sess-unk"}}'
       ;;
     *'"method":"session/prompt"'*)
       printf '%s\n' '{"jsonrpc":"2.0","method":"_cognition.ai/output","params":{"message":"MCP log"}}'
       printf '%s\n' '{"jsonrpc":"2.0","method":"_cognition.ai/customEvent","params":{"data":true}}'
       printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-unk","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"response"},"messageId":"msg-1"}}}'
-      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"end_turn"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}'
       ;;
   esac
 done`
@@ -415,11 +364,8 @@ while IFS= read -r line; do
     *'"method":"initialize"'*)
       printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
       ;;
-    *'"method":"authenticate"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
-      ;;
     *'"method":"session/new"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":3,"error":{"code":-1,"message":"Invalid params: missing field mcpServers"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-1,"message":"Invalid params: missing field mcpServers"}}'
       ;;
   esac
 done`
@@ -451,14 +397,11 @@ while IFS= read -r line; do
     *'"method":"initialize"'*)
       printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
       ;;
-    *'"method":"authenticate"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
-      ;;
     *'"method":"session/new"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-max"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"sessionId":"sess-max"}}'
       ;;
     *'"method":"session/prompt"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"max_tokens"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"stopReason":"max_tokens"}}'
       ;;
   esac
 done`
@@ -486,28 +429,18 @@ done`
 		}
 	}
 	if !foundCompletion {
-		t.Fatal("max_tokens should produce run completed")
+		t.Fatal("missing run completed event for max_tokens")
 	}
 }
 
-// TestRunACPProcessClosesEarly tests that the harness reports an error when the
-// process exits before the turn completes.
-func TestRunACPProcessClosesEarly(t *testing.T) {
+// TestRunACPNoAuthMethods tests that an initialize response without
+// authMethods is treated as an error.
+func TestRunACPNoAuthMethods(t *testing.T) {
 	script := `
 while IFS= read -r line; do
   case "$line" in
     *'"method":"initialize"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
-      ;;
-    *'"method":"authenticate"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
-      ;;
-    *'"method":"session/new"'*)
-      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-early"}}'
-      ;;
-    *'"method":"session/prompt"'*)
-      # Just exit without sending the prompt response
-      exit 0
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
       ;;
   esac
 done`
@@ -524,9 +457,44 @@ done`
 		func(event agent.Event) {},
 	)
 	if err == nil {
-		t.Fatal("expected error for early process exit, got nil")
+		t.Fatal("expected error for empty authMethods, got nil")
 	}
-	if !strings.Contains(err.Error(), "closed before the turn completed") {
-		t.Fatalf("error = %q, want it to mention 'closed before the turn completed'", err.Error())
+	if !strings.Contains(err.Error(), "no auth methods") {
+		t.Fatalf("error = %q, want it to contain 'no auth methods'", err.Error())
+	}
+}
+
+// TestRunACPSessionMissing tests that a session/resume error for a missing
+// session returns agent.ErrSessionNotFound.
+func TestRunACPSessionMissing(t *testing.T) {
+	script := `
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
+      ;;
+    *'"method":"session/resume"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-1,"message":"session not found: no such session"}}'
+      ;;
+  esac
+done`
+
+	err := Run(
+		context.Background(),
+		exec.Command("sh", "-c", script),
+		agent.RunRequest{
+			Provider:       agent.ProviderDevin,
+			ConversationID: "chat-1",
+			Prompt:         "continue",
+			ResumeID:       "missing-sess",
+		},
+		"Devin",
+		func(event agent.Event) {},
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), agent.ErrSessionNotFound.Error()) {
+		t.Fatalf("error = %q, want it to contain %q", err.Error(), agent.ErrSessionNotFound.Error())
 	}
 }

--- a/backend/internal/integration/agents/devinharness/acp_run_test.go
+++ b/backend/internal/integration/agents/devinharness/acp_run_test.go
@@ -1,0 +1,532 @@
+package devinharness
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent"
+)
+
+// TestRunACPSuccessfulTurn tests a complete ACP turn: initialize → authenticate
+// → session/new → session/prompt → session/update notifications → prompt
+// response with stopReason end_turn.
+func TestRunACPSuccessfulTurn(t *testing.T) {
+	script := `
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true},"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
+      ;;
+    *'"method":"notifications/initialized"'*)
+      # no response expected
+      ;;
+    *'"method":"authenticate"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-1"}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello!"},"messageId":"msg-1"}}}'
+      printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-1","update":{"sessionUpdate":"tool_call","toolCallId":"tc-1","title":"Bash","status":"inProgress","rawInput":{"command":"echo hi"}}}}'
+      printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-1","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc-1","status":"completed","content":{"type":"text","text":"hi"}}}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"end_turn"}}'
+      ;;
+  esac
+done`
+
+	var events []agent.Event
+	err := Run(
+		context.Background(),
+		exec.Command("sh", "-c", script),
+		agent.RunRequest{
+			Provider:       agent.ProviderDevin,
+			ConversationID: "chat-1",
+			Prompt:         "say hello",
+		},
+		"Devin",
+		func(event agent.Event) { events = append(events, event) },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(events) < 4 {
+		t.Fatalf("expected at least 4 events, got %d: %#v", len(events), events)
+	}
+
+	// Event 0: session updated
+	if events[0].Type != agent.EventSessionUpdated || events[0].SessionID != "sess-1" {
+		t.Fatalf("session event = %#v", events[0])
+	}
+
+	// Find the assistant text delta
+	var foundAssistant, foundToolStarted, foundToolCompleted, foundCompletion bool
+	for _, event := range events {
+		switch event.Type {
+		case agent.EventAssistantTextDelta:
+			foundAssistant = true
+			if event.Text != "Hello!" {
+				t.Fatalf("assistant text = %q", event.Text)
+			}
+		case agent.EventToolStarted:
+			foundToolStarted = true
+			if event.ToolName != "Bash" || event.ItemID != "tc-1" {
+				t.Fatalf("tool started = %#v", event)
+			}
+		case agent.EventToolCompleted:
+			foundToolCompleted = true
+			if event.Output != "hi" {
+				t.Fatalf("tool output = %q", event.Output)
+			}
+		case agent.EventRunCompleted:
+			foundCompletion = true
+		}
+	}
+	if !foundAssistant {
+		t.Fatal("missing assistant text delta event")
+	}
+	if !foundToolStarted {
+		t.Fatal("missing tool started event")
+	}
+	if !foundToolCompleted {
+		t.Fatal("missing tool completed event")
+	}
+	if !foundCompletion {
+		t.Fatal("missing run completed event")
+	}
+
+	// Last event should be the completion
+	if events[len(events)-1].Type != agent.EventRunCompleted {
+		t.Fatalf("last event = %#v, want run completed", events[len(events)-1])
+	}
+}
+
+// TestRunACPResume tests that session/resume is sent when ResumeID is set.
+func TestRunACPResume(t *testing.T) {
+	script := `
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
+      ;;
+    *'"method":"authenticate"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
+      ;;
+    *'"method":"session/resume"'*)
+      case "$line" in *'"sessionId":"existing-sess"'*) ;; *) exit 1 ;; esac
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"existing-sess"}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"end_turn"}}'
+      ;;
+  esac
+done`
+
+	var events []agent.Event
+	err := Run(
+		context.Background(),
+		exec.Command("sh", "-c", script),
+		agent.RunRequest{
+			Provider:       agent.ProviderDevin,
+			ConversationID: "chat-1",
+			Prompt:         "continue",
+			ResumeID:       "existing-sess",
+		},
+		"Devin",
+		func(event agent.Event) { events = append(events, event) },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No session updated event when resuming the same session.
+	for _, event := range events {
+		if event.Type == agent.EventSessionUpdated {
+			t.Fatalf("should not emit session updated when resuming same session: %#v", event)
+		}
+	}
+	// Should still get a completion event.
+	foundCompletion := false
+	for _, event := range events {
+		if event.Type == agent.EventRunCompleted {
+			foundCompletion = true
+		}
+	}
+	if !foundCompletion {
+		t.Fatal("missing run completed event")
+	}
+}
+
+// TestRunACPCancellation tests that context cancellation sends session/cancel
+// and the prompt response with stopReason "cancelled" produces EventRunInterrupted.
+func TestRunACPCancellation(t *testing.T) {
+	script := `
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
+      ;;
+    *'"method":"authenticate"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-cancel"}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      # Send a notification, then wait for the cancel notification
+      printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-cancel","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"working..."},"messageId":"msg-1"}}}'
+      # Wait for cancel
+      ;;
+    *'"method":"session/cancel"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"cancelled"}}'
+      ;;
+  esac
+done`
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a short delay to let the prompt be sent.
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+	var events []agent.Event
+	err := Run(
+		ctx,
+		exec.Command("sh", "-c", script),
+		agent.RunRequest{
+			Provider:       agent.ProviderDevin,
+			ConversationID: "chat-1",
+			Prompt:         "long task",
+		},
+		"Devin",
+		func(event agent.Event) { events = append(events, event) },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundInterrupted := false
+	for _, event := range events {
+		if event.Type == agent.EventRunInterrupted {
+			foundInterrupted = true
+		}
+		if event.Type == agent.EventRunCompleted {
+			t.Fatal("should not get run completed on cancellation")
+		}
+	}
+	if !foundInterrupted {
+		t.Fatal("missing run interrupted event")
+	}
+}
+
+// TestRunACPAuthFailure tests that an authenticate error is propagated.
+func TestRunACPAuthFailure(t *testing.T) {
+	script := `
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
+      ;;
+    *'"method":"authenticate"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"error":{"code":-1,"message":"authentication failed"}}'
+      ;;
+  esac
+done`
+
+	err := Run(
+		context.Background(),
+		exec.Command("sh", "-c", script),
+		agent.RunRequest{
+			Provider:       agent.ProviderDevin,
+			ConversationID: "chat-1",
+			Prompt:         "hello",
+		},
+		"Devin",
+		func(event agent.Event) {},
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "authentication failed") {
+		t.Fatalf("error = %q, want it to contain 'authentication failed'", err.Error())
+	}
+}
+
+// TestRunACPRefusal tests that stopReason "refusal" produces EventRunFailed.
+func TestRunACPRefusal(t *testing.T) {
+	script := `
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
+      ;;
+    *'"method":"authenticate"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-refuse"}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"refusal"}}'
+      ;;
+  esac
+done`
+
+	var events []agent.Event
+	err := Run(
+		context.Background(),
+		exec.Command("sh", "-c", script),
+		agent.RunRequest{
+			Provider:       agent.ProviderDevin,
+			ConversationID: "chat-1",
+			Prompt:         "do something bad",
+		},
+		"Devin",
+		func(event agent.Event) { events = append(events, event) },
+	)
+	if err == nil {
+		t.Fatal("expected error for refusal, got nil")
+	}
+
+	foundFailed := false
+	for _, event := range events {
+		if event.Type == agent.EventRunFailed {
+			foundFailed = true
+			if event.Message != "agent refused to continue" {
+				t.Fatalf("message = %q", event.Message)
+			}
+		}
+	}
+	if !foundFailed {
+		t.Fatal("missing run failed event")
+	}
+}
+
+// TestRunACPUnknownNotificationHandling tests that unknown notifications are
+// forwarded as EventProviderNative without breaking the run.
+func TestRunACPUnknownNotificationHandling(t *testing.T) {
+	script := `
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
+      ;;
+    *'"method":"authenticate"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-unk"}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","method":"_cognition.ai/output","params":{"message":"MCP log"}}'
+      printf '%s\n' '{"jsonrpc":"2.0","method":"_cognition.ai/customEvent","params":{"data":true}}'
+      printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-unk","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"response"},"messageId":"msg-1"}}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"end_turn"}}'
+      ;;
+  esac
+done`
+
+	var events []agent.Event
+	err := Run(
+		context.Background(),
+		exec.Command("sh", "-c", script),
+		agent.RunRequest{
+			Provider:       agent.ProviderDevin,
+			ConversationID: "chat-1",
+			Prompt:         "hello",
+		},
+		"Devin",
+		func(event agent.Event) { events = append(events, event) },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// _cognition.ai/output should be filtered (no event).
+	// _cognition.ai/customEvent should be native.
+	// agent_message_chunk should be assistant delta.
+	foundNativeCustom := false
+	foundAssistant := false
+	foundCompletion := false
+	for _, event := range events {
+		switch event.Type {
+		case agent.EventProviderNative:
+			if event.Native != nil && event.Native.Method == "_cognition.ai/customEvent" {
+				foundNativeCustom = true
+			}
+		case agent.EventAssistantTextDelta:
+			if event.Text == "response" {
+				foundAssistant = true
+			}
+		case agent.EventRunCompleted:
+			foundCompletion = true
+		}
+	}
+	if !foundNativeCustom {
+		t.Fatal("missing native event for _cognition.ai/customEvent")
+	}
+	if !foundAssistant {
+		t.Fatal("missing assistant text delta event")
+	}
+	if !foundCompletion {
+		t.Fatal("missing run completed event")
+	}
+}
+
+// TestRunACPInitializeError tests that an initialize error is propagated.
+func TestRunACPInitializeError(t *testing.T) {
+	script := `
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"server not ready"}}'
+      ;;
+  esac
+done`
+
+	err := Run(
+		context.Background(),
+		exec.Command("sh", "-c", script),
+		agent.RunRequest{
+			Provider:       agent.ProviderDevin,
+			ConversationID: "chat-1",
+			Prompt:         "hello",
+		},
+		"Devin",
+		func(event agent.Event) {},
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "server not ready") {
+		t.Fatalf("error = %q, want it to contain 'server not ready'", err.Error())
+	}
+}
+
+// TestRunACPSessionNewError tests that a session/new error is propagated.
+func TestRunACPSessionNewError(t *testing.T) {
+	script := `
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
+      ;;
+    *'"method":"authenticate"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"error":{"code":-1,"message":"Invalid params: missing field mcpServers"}}'
+      ;;
+  esac
+done`
+
+	err := Run(
+		context.Background(),
+		exec.Command("sh", "-c", script),
+		agent.RunRequest{
+			Provider:       agent.ProviderDevin,
+			ConversationID: "chat-1",
+			Prompt:         "hello",
+		},
+		"Devin",
+		func(event agent.Event) {},
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mcpServers") {
+		t.Fatalf("error = %q, want it to contain 'mcpServers'", err.Error())
+	}
+}
+
+// TestRunACPMaxTokens tests that stopReason "max_tokens" produces EventRunCompleted.
+func TestRunACPMaxTokens(t *testing.T) {
+	script := `
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
+      ;;
+    *'"method":"authenticate"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-max"}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":4,"result":{"stopReason":"max_tokens"}}'
+      ;;
+  esac
+done`
+
+	var events []agent.Event
+	err := Run(
+		context.Background(),
+		exec.Command("sh", "-c", script),
+		agent.RunRequest{
+			Provider:       agent.ProviderDevin,
+			ConversationID: "chat-1",
+			Prompt:         "generate a lot",
+		},
+		"Devin",
+		func(event agent.Event) { events = append(events, event) },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundCompletion := false
+	for _, event := range events {
+		if event.Type == agent.EventRunCompleted {
+			foundCompletion = true
+		}
+	}
+	if !foundCompletion {
+		t.Fatal("max_tokens should produce run completed")
+	}
+}
+
+// TestRunACPProcessClosesEarly tests that the harness reports an error when the
+// process exits before the turn completes.
+func TestRunACPProcessClosesEarly(t *testing.T) {
+	script := `
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"authMethods":[{"id":"devin-browser","name":"Log in with browser"}],"agentInfo":{"name":"affogato","title":"Devin Agent","version":"0.0.0-dev"}}}'
+      ;;
+    *'"method":"authenticate"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{}}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"sessionId":"sess-early"}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      # Just exit without sending the prompt response
+      exit 0
+      ;;
+  esac
+done`
+
+	err := Run(
+		context.Background(),
+		exec.Command("sh", "-c", script),
+		agent.RunRequest{
+			Provider:       agent.ProviderDevin,
+			ConversationID: "chat-1",
+			Prompt:         "hello",
+		},
+		"Devin",
+		func(event agent.Event) {},
+	)
+	if err == nil {
+		t.Fatal("expected error for early process exit, got nil")
+	}
+	if !strings.Contains(err.Error(), "closed before the turn completed") {
+		t.Fatalf("error = %q, want it to mention 'closed before the turn completed'", err.Error())
+	}
+}

--- a/backend/internal/integration/agents/devinharness/configuration.go
+++ b/backend/internal/integration/agents/devinharness/configuration.go
@@ -61,6 +61,6 @@ curl -fsSL "$url" -o "$tmp/devin.tar.gz"
 echo "${sha256}  $tmp/devin.tar.gz" | sha256sum -c - >/dev/null
 tar -xzf "$tmp/devin.tar.gz" -C "$tmp"
 install -d -m 0755 "$(dirname "$install_path")"
-install -m 0755 "$tmp/devin" "$install_path"
+install -m 0755 "$tmp/bin/devin" "$install_path"
 "$install_path" --version`, version, manifestBaseURL)
 }

--- a/backend/internal/integration/agents/devinharness/configuration.go
+++ b/backend/internal/integration/agents/devinharness/configuration.go
@@ -1,0 +1,66 @@
+// Package devinharness owns the Devin CLI installation policy and, in later
+// phases, the ACP protocol adapter used by the devin provider package. For now
+// only the CLI spec is exposed so the host installer can converge the binary.
+package devinharness
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/agent/provisioning"
+)
+
+// manifestBaseURL is the versioned Devin CLI manifest endpoint. The install
+// script fetches it to resolve per-platform archive URLs and SHA-256 checksums.
+const manifestBaseURL = "https://static.devin.ai/cli"
+
+// NewCLISpec returns the Devin CLI installation policy. Devin ships a standalone
+// binary distributed through a versioned manifest with per-platform SHA-256
+// checksums, so the install script fetches the manifest at install time rather
+// than relying on hardcoded checksum pins.
+func NewCLISpec() provisioning.CLISpec {
+	version := provisioning.MustCLIVersion("DEVIN_CLI_VERSION")
+	return provisioning.CLISpec{
+		Name:               "devin",
+		ImageLabel:         "devin",
+		Binary:             "devin",
+		VersionArgs:        []string{"--version"},
+		Version:            version,
+		ReportVersion:      true,
+		CheckVersion:       true,
+		VerifyAfterInstall: true,
+		InstallMode:        provisioning.InstallWithScript,
+		InstallScript:      installScript(version),
+		InstallTimeout:     8 * time.Minute,
+		WaitTimeout:        5 * time.Minute,
+	}
+}
+
+// installScript downloads the pinned Devin CLI release for the target
+// execution environment's architecture, verifies its manifest-published SHA-256
+// checksum, and installs the binary to the path supplied by the execution
+// environment. Container builds retain the /usr/local/bin/devin default. It
+// never consults Devin's moving latest manifest.
+func installScript(version string) string {
+	return fmt.Sprintf(`set -euo pipefail
+install_path="${FUTRX_HOST_CLI_INSTALL_PATH:-/usr/local/bin/devin}"
+if [ -x "$install_path" ] && [ "$("$install_path" --version 2>/dev/null)" = %[1]q ]; then
+    exit 0
+fi
+case "$(uname -m)" in
+    x86_64|amd64) target="x86_64-unknown-linux" ;;
+    aarch64|arm64) target="aarch64-unknown-linux" ;;
+    *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+manifest=$(curl -fsSL "%[2]s/%[1]s/manifest.json")
+url=$(echo "$manifest" | grep -o "\"$target\"[^}]*}" | grep -o '"url":"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/')
+sha256=$(echo "$manifest" | grep -o "\"$target\"[^}]*}" | grep -o '"sha256":"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/')
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+curl -fsSL "$url" -o "$tmp/devin.tar.gz"
+echo "${sha256}  $tmp/devin.tar.gz" | sha256sum -c - >/dev/null
+tar -xzf "$tmp/devin.tar.gz" -C "$tmp"
+install -d -m 0755 "$(dirname "$install_path")"
+install -m 0755 "$tmp/devin" "$install_path"
+"$install_path" --version`, version, manifestBaseURL)
+}

--- a/docs/01-overview/00-philosophy.md
+++ b/docs/01-overview/00-philosophy.md
@@ -96,6 +96,7 @@ flowchart LR
     Claude["Claude"] --> Project
     Kimi["Kimi"] --> Project
     Antigravity["Antigravity"] --> Project
+    Devin["Devin"] --> Project
 
     Project -. "outlives" .-> ChatA["Chat A"]
     Project -. "outlives" .-> ChatB["Chat B"]
@@ -106,8 +107,8 @@ This gives Remote five foundational rules:
 
 1. **One project, one containment boundary.** Files, processes, tools, browser state, and project authority belong to that project.
 2. **The project, not the conversation, is durable.** A new chat or a different provider should enter the same world rather than reconstruct it.
-3. **The model is a replaceable worker.** Codex, Claude, Kimi, and
-   Antigravity can work against the same project without becoming its owner.
+3. **The model is a replaceable worker.** Codex, Claude, Kimi,
+   Antigravity, and Devin can work against the same project without becoming its owner.
 4. **Work is durable; machinery is replaceable.** Source, artifacts, skills, and provider homes persist while the runtime can be rebuilt.
 5. **Failure should be local and repairable.** A bad install, runaway process, or broken root filesystem should not require repairing another project. Recovery of agent-modified durable files still depends on Git, remotes, snapshots, or backups outside the current runtime.
 
@@ -182,6 +183,7 @@ flowchart LR
         ClaudeHost["agent-home/claude/"]
         KimiHost["agent-home/kimi/"]
         AntigravityHost["agent-home/antigravity/"]
+        DevinHost["agent-home/devin/"]
     end
 
     subgraph Container["Unprivileged LXD project container"]
@@ -191,6 +193,7 @@ flowchart LR
         Claude["/root/.claude"]
         Kimi["/root/.kimi-code"]
         Antigravity["/root/.gemini/antigravity-cli"]
+        Devin["/root/.local/share/devin"]
         RootFS["Replaceable Ubuntu root filesystem"]
     end
 
@@ -200,6 +203,7 @@ flowchart LR
     ClaudeHost -->|"read/write bind mount"| Claude
     KimiHost -->|"read/write bind mount"| Kimi
     AntigravityHost -->|"read/write bind mount"| Antigravity
+    DevinHost -->|"read/write bind mount"| Devin
 ```
 
 | Durable layer | Container path | Purpose |
@@ -210,14 +214,15 @@ flowchart LR
 | Claude home | `/root/.claude` | Claude provider configuration, authentication, sessions, and provider-owned state |
 | Kimi home | `/root/.kimi-code` | Kimi provider configuration, authentication, sessions, and provider-owned state |
 | Antigravity home | `/root/.gemini/antigravity-cli` | Project-local Antigravity authentication, conversations, and provider-owned state |
+| Devin home | `/root/.local/share/devin` | Devin provider credentials, sessions, and provider-owned state |
 | Host control-plane data | Application data directory | Project metadata, chats, event logs, scheduled tasks, access lists, settings, and the authoritative secret store |
 | Replaceable runtime | Container root filesystem outside the mounts | Base image, installed packages, temporary files, and operating-system state |
 
-The workspace is shared by all agents in the project. The five currently
+The workspace is shared by all agents in the project. The six currently
 mounted provider homes are separate because each CLI owns a different
 configuration and session format; they are **format-separated, not
 security-separated**.
-Container root can read and modify all five regardless of the selected
+Container root can read and modify all six regardless of the selected
 provider. Antigravity mounts only `/root/.gemini/antigravity-cli`, not the
 whole `.gemini` directory.
 Project skills have one canonical source at `/workspace/.agents/skills`;
@@ -239,7 +244,7 @@ The capability envelope should be complete enough that the agent can move from i
 | Filesystem | Read and write the complete project workspace and all provider homes mounted in that project container |
 | Package installation | `apt`, `npm`, `pip`, and project-local package managers may install what the work requires |
 | Core toolchain | Git, SSH client, `gh`, `jq`, build tools, Python, Node.js 22, npm, and npx |
-| Agent choice | Claude Code, Codex, MiniMax through the Codex harness, Kimi Code, and Antigravity at pinned versions, behind one provider-neutral run model |
+| Agent choice | Claude Code, Codex, MiniMax through the Codex harness, Kimi Code, Antigravity, and Devin at pinned versions, behind one provider-neutral run model |
 | Skills | Project-authored procedures under `/workspace/.agents/skills`, including skills the agent creates for future work. Claude receives slash triggers, Codex and MiniMax receive dollar mentions, and Kimi/Antigravity receive explicit `SKILL.md` instruction paths; Scheduled Tasks additionally receives a scoped capability |
 | Processes | Foreground and background processes; background work may continue between prompts while the container stays running |
 | Network | Outbound networking and project app listeners; the current project instructions describe network access as open |
@@ -259,7 +264,7 @@ Broad agent authority is paired with a complete control envelope. The human shou
 | Control | Human or host capability |
 | --- | --- |
 | Identity | Claim the server, sign in, manage registered users, and separate administrators from members |
-| Provider identity | Administrators connect, refresh, or replace host-wide Claude, Codex, and Kimi identities; Antigravity has an instruction-only global card and its supported sign-in flow remains per project |
+| Provider identity | Administrators connect, refresh, or replace host-wide Claude, Codex, Kimi, and Devin identities; Antigravity has an instruction-only global card and its supported sign-in flow remains per project |
 | Project access | Current members can add or remove registered project members; the backend gates project API, chat, upload, terminal, and preview resources |
 | Project secrets | Current members can create, read, change, or delete the authoritative secret record; propagation to and removal from managed copies is currently best-effort |
 | Agent selection | Choose provider, model, reasoning effort, service tier or speed, mode, and selected skills |
@@ -334,7 +339,7 @@ Remote separates valuable state from replaceable machinery. This lets the runtim
 flowchart TB
     Intent["Human intent and conversation history"] --> ProjectState["Durable project state"]
     ProjectState --> Workspace["Workspace, skills, artifacts, browser profile"]
-    ProjectState --> AgentHomes["Codex, MiniMax, Claude, Kimi, and Antigravity homes"]
+    ProjectState --> AgentHomes["Codex, MiniMax, Claude, Kimi, Antigravity, and Devin homes"]
     ProjectState --> Scheduled["Scheduled task definitions and claims"]
     ProjectState --> Metadata["Metadata, access, secrets, event logs"]
 
@@ -389,7 +394,7 @@ Remote has four credential classes, each with a different scope:
 | Credential class | Scope | Current behavior |
 | --- | --- | --- |
 | Platform session | User and Remote control plane | Kept in secure HTTP-only cookies and stripped before requests enter project-controlled apps and IDEs |
-| Agent-provider identity | Host-wide for Claude, Codex, Kimi, and the MiniMax Token Plan subscription key; supported project runtime for Antigravity | Claude, Codex, and Kimi are connected by an administrator and synchronized bidirectionally with project state. The write-only MiniMax subscription key is stored by the control plane and injected only into MiniMax runs, while Codex-harness state stays in each project's mounted MiniMax home. Remote's Antigravity UI flow authenticates inside each project and its mounted provider state survives container replacement; operator-prepared host `agy` state can still be used by loose chats outside that flow |
+| Agent-provider identity | Host-wide for Claude, Codex, Kimi, Devin, and the MiniMax Token Plan subscription key; supported project runtime for Antigravity | Claude, Codex, Kimi, and Devin are connected by an administrator and synchronized bidirectionally with project state. The write-only MiniMax subscription key is stored by the control plane and injected only into MiniMax runs, while Codex-harness state stays in each project's mounted MiniMax home. Remote's Antigravity UI flow authenticates inside each project and its mounted provider state survives container replacement; operator-prepared host `agy` state can still be used by loose chats outside that flow |
 | Project secret | One project | Stored in a host file with mode `0600` but without application-level encryption; passed to agent runs, persisted as container environment when single-line, and mirrored into the managed `.env` file |
 | Browser-session identity | One project browser profile | Created through human login and persisted with the project so the agent can use the authenticated session |
 

--- a/docs/01-overview/01-system-overview.md
+++ b/docs/01-overview/01-system-overview.md
@@ -3,7 +3,7 @@
 ## What the application is
 
 `remote.futrx` is a self-hosted browser workspace for Claude Code, Codex,
-MiniMax, Kimi Code, and Antigravity. Users create project-scoped containers, run interactive
+MiniMax, Kimi Code, Antigravity, and Devin. Users create project-scoped containers, run interactive
 or scheduled agent turns against those projects, and inspect the result through
 chat, files, Git, a terminal, an IDE, or a live app preview.
 
@@ -143,11 +143,11 @@ The main shell switches between three views without browser routing:
   order and application-wide policy; the catalog builds one runtime containing
   matching provider and auth registries.
 - Each project owns its `/workspace` files and processes.
-- Each project also has durable Codex, MiniMax, Claude, Kimi, and Antigravity
-  homes mounted at their provider-native paths. Antigravity mounts only
+- Each project also has durable Codex, MiniMax, Claude, Kimi, Antigravity, and
+  Devin homes mounted at their provider-native paths. Antigravity mounts only
   `/root/.gemini/antigravity-cli`.
-- Claude, Codex, and Kimi credentials are host-managed and synchronized into
-  project credential locations, primarily those homes; Claude also uses
+- Claude, Codex, Kimi, and Devin credentials are host-managed and synchronized
+  into project credential locations, primarily those homes; Claude also uses
   `/root/.claude.json` outside its mounted home. Remote injects MiniMax's
   host-managed Token Plan subscription key only into MiniMax runs.
 - Remote's supported Antigravity flow authenticates inside each project and

--- a/docs/02-user-guide/10-global-settings-users-providers.md
+++ b/docs/02-user-guide/10-global-settings-users-providers.md
@@ -26,7 +26,8 @@ without login controls.
 
 Claude, Codex, and Kimi authentication is host-wide and administrator-managed.
 Sign in once on the parent host; Remote then seeds those provider credentials
-into project containers. MiniMax uses a host-managed Token Plan subscription
+into project containers. Devin uses a host-managed manual token flow with the
+same credential seeding. MiniMax uses a host-managed Token Plan subscription
 key. Antigravity uses a project-local sign-in flow; both are described below.
 
 ![Administrator view of Claude, Codex, and Kimi authentication](/assets/docs/screenshots/03-agent-authentication-01m05s.webp)
@@ -93,6 +94,20 @@ its model list remains unavailable until a validated key exists.
 4. Approve the account.
 5. Return to Remote and wait for the connected state.
 
+### Connect Devin
+
+Devin authentication is host-managed. An administrator runs the manual token
+flow once on the host; Remote then seeds the credential file into project
+containers.
+
+1. On the host, run `devin auth login --force-manual-token-flow`.
+2. Open the displayed `app.devin.ai/auth/cli/continue` URL.
+3. Sign in to Devin in the browser.
+4. Paste the returned code into the CLI prompt.
+5. Wait for the credentials file to be written.
+6. In Remote, choose **Refresh models** in a project chat's provider/model
+   picker to pick up the newly synchronized credentials.
+
 ### Use Antigravity
 
 Antigravity appears in both the chat provider picker and the administrator's
@@ -125,16 +140,16 @@ is unavailable to a loose chat. Use a project chat for normal Antigravity work.
 
 Antigravity does not satisfy Remote's initial provider gate because Remote
 cannot observe external auth authoritatively. A server administrator must still
-connect one of the current gate-eligible modules: Claude, Codex, or Kimi.
+connect one of the current gate-eligible modules: Claude, Codex, Kimi, or Devin.
 
 ### Shared-provider implications
 
-- Every user and project shares the same host Claude, Codex, and Kimi accounts
-  and their quotas.
-- Those three provider credentials are copied into project credential
+- Every user and project shares the same host Claude, Codex, Kimi, and Devin
+  accounts and their quotas.
+- Those four provider credentials are copied into project credential
   locations.
 - An agent that can read its project credential files can act with that provider authority.
-- Claude, Codex, and Kimi homes are durable but separate by provider format, not separate security principals.
+- Claude, Codex, Kimi, and Devin homes are durable but separate by provider format, not separate security principals.
 - Re-authentication can affect every project.
 - Antigravity is project-local rather than host-wide, but its credential state
   is still readable by container root and shared by everyone with authority in

--- a/frontend/src/config/chat.ts
+++ b/frontend/src/config/chat.ts
@@ -28,6 +28,7 @@ export function providerDisplayLabel(provider?: string): string {
     antigravity: "Antigravity",
     claude: "Claude",
     codex: "Codex",
+    devin: "Devin",
     kimi: "Kimi",
     minimax: "MiniMax",
   };

--- a/infra/tests/host-agent-install-test.sh
+++ b/infra/tests/host-agent-install-test.sh
@@ -66,5 +66,7 @@ grep -Fxq $'kimi\tkimi\t'"$KIMI_CODE_VERSION"$'\timage-repair\t@moonshot-ai/kimi
     fail "host plan is missing Kimi"
 grep -Fxq $'antigravity\tagy\t'"$ANTIGRAVITY_CLI_VERSION"$'\tscript\t-' <<<"$plan" || \
     fail "host plan is missing Antigravity"
+grep -Fxq $'devin\tdevin\t'"$DEVIN_CLI_VERSION"$'\tscript\t-' <<<"$plan" || \
+    fail "host plan is missing Devin"
 
 echo "host agent install tests passed"


### PR DESCRIPTION
## Description

## Summary

Adds Devin CLI as the sixth fully supported agent provider alongside Claude Code, Codex, MiniMax, Kimi Code, and Antigravity. The provider uses ACP (Agent Client Protocol) over stdio JSON-RPC to communicate with `devin acp`, with host-managed authentication and credential synchronization into project containers.

### Architecture

- **Provider package** (`backend/internal/integration/agents/devin/`): owns factory, command construction, capability discovery, model catalog parsing, authentication adapter, provisioning profile, and provider registration
- **ACP harness** (`backend/internal/integration/agents/devinharness/`): owns the JSON-RPC state machine — initialize, session/new, session/resume, session/prompt, session/cancel, event mapping, permission/elicitation handling, and terminal state detection
- **Registration**: single catalog entry in `config.NewAgentModules` plus standard supporting edits in `model.go`, `versions.env`, `agents_test.go`, and embedded instructions

### Key design decisions

- **ACP runtime** (`devin acp`), not plain-text print mode — structured tool calls, usage, sessions, and plan mode
- **Host-managed auth**: admin runs `devin auth login --force-manual-token-flow` once on the host; credential file synced into project containers with `PushRequired`, `PullRequired`, mode `600`, `SeedOnLaunch`
- **Credential loading from disk**: Devin's ACP server loads stored CLI credentials on startup, so the `authenticate` step and `notifications/initialized` are skipped in the handshake (the `devin-browser` auth method requires a browser, which is unavailable on headless servers)
- **Model catalog parsing**: handles Devin's native `{"families":[{"variants":[{"model_uid":"...","label":"..."}]}]}` shape (210 models) plus flat array and object-with-models shapes, with graceful fallback to an auto model
- **Persistent state**: `devin-home` device mounted at `/root/.local/share/devin`, non-overlapping with other providers
- **Pinned version**: `3000.6.14` with manifest-fetched SHA-256 verification

### Commits

1. `feat(devin): register Devin CLI as a compiled-in agent provider` — provider identity, version pin, provisioning profile, managed code auth, factory descriptor, catalog registration
2. `feat(devin): implement ACP JSON-RPC harness for devin acp` — full state machine: initialize → session/new → session/prompt, event mapping, cancellation, permissions, elicitation
3. `feat(devin): wire provider runtime to ACP harness` — Run builds `devin acp` command, delegates to harness, syncs credentials from container
4. `feat(devin): add frontend label, docs, and infrastructure test` — frontend label map, embedded AGENTS.md, README/ARCHITECTURE/CONTRIBUTING docs, host-agent-install test
5. `fix(devin): correct binary path in CLI install script` — tarball contains `bin/devin`, not root-level `devin`
6. `fix(devin): parse Devin native families/variants model catalog shape` — handle nested `families[].variants[]` with `model_uid`/`label` fields
7. `fix(devin): skip authenticate and notifications/initialized in ACP handshake` — Devin ACP loads credentials from disk; browser-based auth fails on headless servers

### Files changed

- 36 files, +3854 / -50 lines
- 14 new provider/harness source files with tests
- 7 existing files updated (registration, version pin, docs, embedded instructions, infra test)

### Testing

**Phase 1 — Unit tests (all pass with race detection):**
- Devin provider package: 27 tests
- Devin ACP harness: 41 tests
- Config and module race tests: pass
- Frontend tests: 257/257 pass
- Full `go build ./...`: pass
- Infrastructure host-agent-install test: pass
- Release classification tests: pass

**Phase 2 — Host installation plan:**
- `go run ./cmd/install-host-agents -plan` includes `devin  devin  3000.6.14  script  -`

**Phase 3 — Live CLI integration:**
- `devin --version` → `3000.6.14 (18033302)`
- `devin auth status` → Logged in, Devin Pro
- `devin models list --format json` → 210 models across 46 families (parser correctly extracts all)
- ACP `initialize` handshake → correct response with `protocolVersion: 1`, `authMethods`, `agentCapabilities`
- ACP `session/new` → session created with modes and model config options

**Phase 4 — End-to-end on QA VPS:**
- `infra/qa/update.sh` deployed to Hostinger VPS
- Devin CLI installed at `/opt/remote.futrx/data/host-clis/bin/devin`
- Base image rebuilt with `devin` preinstalled
- Devin authenticated on VPS via `devin auth login --force-manual-token-flow`
- End-to-end prompt execution verified: Devin responds to prompts in the Remote UI

#### Test plan

- [x] Backend unit tests with race detection
- [x] Frontend tests
- [x] Full Go build
- [x] Infrastructure tests (host-agent-install)
- [x] Release classification tests
- [x] Host installation plan includes Devin
- [x] Live Devin CLI: version, auth, model discovery, ACP initialize
- [x] End-to-end on QA VPS: update, auth, prompt execution
- [x] Session resume (same chat, second prompt)
- [x] Cancellation (cancel mid-run)
- [x] Fork (forked chat starts fresh session)
- [x] Credential sync (container → host after run)
