### PR TITLE
refactor(infra): centralize defaults + explicit main() entry points

### DIFF
--- a/infra/config/defaults.sh
+++ b/infra/config/defaults.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Central shared defaults for the infra entry points
+# (install.sh, update.sh, deploy-app.sh, upgrade-workspaces.sh).
+#
+# Source this file — it defines readonly constants only and executes
+# nothing. Environment overrides keep working: every entry point applies
+# its own ${VAR:-$FUTRX_DEFAULT_*} wiring, so an exported FUTRX_INSTALL_DIR
+# (QA/tests) still wins over the default below.
+#
+# The curl|bash bootstrap block at the top of install.sh intentionally
+# inlines its own copy of the install dir / repo URL instead of sourcing
+# this file: no checkout exists on disk yet at that point.
+
+# Re-source guard: readonly assignments fail on a second source.
+if [ -n "${__FUTRX_DEFAULTS_SOURCED:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+__FUTRX_DEFAULTS_SOURCED=1
+
+readonly FUTRX_DEFAULT_INSTALL_DIR="/opt/remote.futrx"
+readonly FUTRX_DEFAULT_LEGACY_INSTALL_DIR="/opt/remote.futrx.dev"
+readonly FUTRX_DEFAULT_SERVICE_NAME="remote.futrx.service"
+readonly FUTRX_DEFAULT_SERVICE_PORT="7682"
+readonly FUTRX_DEFAULT_BASE_IMAGE="futrx-remote-dev-base"
+readonly FUTRX_REPOSITORY_URL="https://github.com/futrx-com/remote.futrx.git"

--- a/infra/deploy-app.sh
+++ b/infra/deploy-app.sh
@@ -26,13 +26,31 @@
 # Test-only overrides: FUTRX_INSTALL_DIR, FUTRX_SERVICE_NAME, FUTRX_SERVICE_PORT.
 set -euo pipefail
 
-SCRIPT_INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-# shellcheck source=lib/common.sh
-. "$SCRIPT_INFRA_DIR/lib/common.sh"
-
 usage() {
     sed -n '2,/^set -euo pipefail$/ { /^set -euo pipefail$/d; s/^# \{0,1\}//p; }' "$0"
 }
+finish() {
+    local status="$1"
+    trap - EXIT
+    if [ "$DEPLOYMENT_SUCCEEDED" -ne 1 ]; then
+        echo "Application deployment failed; restoring the previous release" >&2
+        git reset --hard "$PREVIOUS_SHA" >/dev/null 2>&1 || true
+        if [ "$BINARY_REPLACED" -eq 1 ]; then
+            install -m 0755 "$PREVIOUS_BINARY" "$BINARY" || true
+            systemctl restart "$SERVICE_NAME" || true
+        fi
+    fi
+    rm -f "$PREVIOUS_BINARY" "$STAGED_BINARY"
+    rmdir "$STAGE_DIR" 2>/dev/null || true
+    exit "$status"
+}
+main() {
+SCRIPT_INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=lib/common.sh
+. "$SCRIPT_INFRA_DIR/lib/common.sh"
+# shellcheck source=lib/../config/defaults.sh
+. "$SCRIPT_INFRA_DIR/config/defaults.sh"
+
 
 TARGET_REF=""
 for argument in "$@"; do
@@ -49,10 +67,10 @@ if [ -z "$TARGET_REF" ]; then
     exit 2
 fi
 
-DEFAULT_INSTALL_DIR="${INSTALL_DIR:-/opt/remote.futrx}"
+DEFAULT_INSTALL_DIR="${INSTALL_DIR:-$FUTRX_DEFAULT_INSTALL_DIR}"
 INSTALL_DIR="${FUTRX_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
-SERVICE_NAME="${FUTRX_SERVICE_NAME:-remote.futrx.service}"
-DEFAULT_SERVICE_PORT="${PORT:-7682}"
+SERVICE_NAME="${FUTRX_SERVICE_NAME:-$FUTRX_DEFAULT_SERVICE_NAME}"
+DEFAULT_SERVICE_PORT="${PORT:-$FUTRX_DEFAULT_SERVICE_PORT}"
 SERVICE_PORT="${FUTRX_SERVICE_PORT:-$DEFAULT_SERVICE_PORT}"
 BINARY="$INSTALL_DIR/backend/remote"
 
@@ -113,21 +131,6 @@ cp -p "$BINARY" "$PREVIOUS_BINARY"
 BINARY_REPLACED=0
 DEPLOYMENT_SUCCEEDED=0
 
-finish() {
-    local status="$1"
-    trap - EXIT
-    if [ "$DEPLOYMENT_SUCCEEDED" -ne 1 ]; then
-        echo "Application deployment failed; restoring the previous release" >&2
-        git reset --hard "$PREVIOUS_SHA" >/dev/null 2>&1 || true
-        if [ "$BINARY_REPLACED" -eq 1 ]; then
-            install -m 0755 "$PREVIOUS_BINARY" "$BINARY" || true
-            systemctl restart "$SERVICE_NAME" || true
-        fi
-    fi
-    rm -f "$PREVIOUS_BINARY" "$STAGED_BINARY"
-    rmdir "$STAGE_DIR" 2>/dev/null || true
-    exit "$status"
-}
 trap 'finish $?' EXIT
 
 write_update_progress "application-build" "Building the application update"
@@ -171,3 +174,12 @@ fi
 DEPLOYMENT_SUCCEEDED=1
 echo
 echo "✓ application release $TARGET_REF deployed"
+}
+
+# Sourced (e.g. by tests) - definitions only. Note the guard
+# defaults to *executing*: BASH_SOURCE is unset when bash reads
+# from stdin (`bash -s`), which must still run (curl|bash mode).
+if [[ -n "${BASH_SOURCE[0]:-}" ]] && [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+main "$@"

--- a/infra/deploy-app.sh
+++ b/infra/deploy-app.sh
@@ -44,14 +44,22 @@ finish() {
     rmdir "$STAGE_DIR" 2>/dev/null || true
     exit "$status"
 }
-main() {
+remote_load_configuration() {
 SCRIPT_INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=lib/common.sh
 . "$SCRIPT_INFRA_DIR/lib/common.sh"
 # shellcheck source=lib/../config/defaults.sh
 . "$SCRIPT_INFRA_DIR/config/defaults.sh"
 
+DEFAULT_INSTALL_DIR="${INSTALL_DIR:-$FUTRX_DEFAULT_INSTALL_DIR}"
+INSTALL_DIR="${FUTRX_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+SERVICE_NAME="${FUTRX_SERVICE_NAME:-$FUTRX_DEFAULT_SERVICE_NAME}"
+DEFAULT_SERVICE_PORT="${PORT:-$FUTRX_DEFAULT_SERVICE_PORT}"
+SERVICE_PORT="${FUTRX_SERVICE_PORT:-$DEFAULT_SERVICE_PORT}"
+BINARY="$INSTALL_DIR/backend/remote"
+}
 
+remote_parse_deploy_arguments() {
 TARGET_REF=""
 for argument in "$@"; do
     case "$argument" in
@@ -66,14 +74,9 @@ if [ -z "$TARGET_REF" ]; then
     echo "--ref=<release-tag> is required" >&2
     exit 2
 fi
+}
 
-DEFAULT_INSTALL_DIR="${INSTALL_DIR:-$FUTRX_DEFAULT_INSTALL_DIR}"
-INSTALL_DIR="${FUTRX_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
-SERVICE_NAME="${FUTRX_SERVICE_NAME:-$FUTRX_DEFAULT_SERVICE_NAME}"
-DEFAULT_SERVICE_PORT="${PORT:-$FUTRX_DEFAULT_SERVICE_PORT}"
-SERVICE_PORT="${FUTRX_SERVICE_PORT:-$DEFAULT_SERVICE_PORT}"
-BINARY="$INSTALL_DIR/backend/remote"
-
+remote_validate_deploy() {
 if [ ! -d "$INSTALL_DIR/.git" ]; then
     echo "$INSTALL_DIR is not an installed git checkout; run infra/install.sh first" >&2
     exit 1
@@ -101,7 +104,9 @@ for command_name in git npm go systemctl; do
         exit 1
     }
 done
+}
 
+remote_build_application() {
 # shellcheck source=lib/release-version.sh
 . "$SCRIPT_INFRA_DIR/lib/release-version.sh"
 # shellcheck source=lib/update-progress.sh
@@ -156,6 +161,9 @@ APP_VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"
 
 install -m 0755 "$STAGED_BINARY" "$BINARY"
 BINARY_REPLACED=1
+}
+
+remote_verify_deployment() {
 write_update_progress "application-restart" "Restarting the application"
 systemctl restart "$SERVICE_NAME"
 
@@ -174,6 +182,14 @@ fi
 DEPLOYMENT_SUCCEEDED=1
 echo
 echo "✓ application release $TARGET_REF deployed"
+}
+
+main() {
+    remote_load_configuration
+    remote_parse_deploy_arguments "$@"
+    remote_validate_deploy
+    remote_build_application
+    remote_verify_deployment
 }
 
 # Sourced (e.g. by tests) - definitions only. Note the guard

--- a/infra/install.sh
+++ b/infra/install.sh
@@ -40,6 +40,7 @@
 
 set -euo pipefail
 
+main() {
 # ───────────────── self-bootstrap (curl|bash mode) ─────────────────
 # When piped from curl, BASH_SOURCE points at /dev/stdin and there are no
 # sibling steps/ or templates/. Install git, clone the repo to the canonical
@@ -158,6 +159,8 @@ fi
 INFRA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=lib/common.sh
 . "$INFRA_DIR/lib/common.sh"
+# shellcheck source=lib/../config/defaults.sh
+. "$INFRA_DIR/config/defaults.sh"
 HOSTNAME=""
 SKIP_DNS_CHECK=0
 GOOGLE_CLIENT_ID=""
@@ -205,10 +208,10 @@ fi
 # ───────────────── globals ─────────────────
 # INFRA_DIR was resolved before argument parsing (see above) so the shared
 # helpers are available to every validation gate.
-INSTALL_DIR="${FUTRX_INSTALL_DIR:-/opt/remote.futrx}"
-LEGACY_INSTALL_DIR="${FUTRX_LEGACY_INSTALL_DIR:-/opt/remote.futrx.dev}"
-REPO_URL="https://github.com/futrx-com/remote.futrx.git"
-SERVICE_PORT="${SERVICE_PORT:-7682}"
+INSTALL_DIR="${FUTRX_INSTALL_DIR:-$FUTRX_DEFAULT_INSTALL_DIR}"
+LEGACY_INSTALL_DIR="${FUTRX_LEGACY_INSTALL_DIR:-$FUTRX_DEFAULT_LEGACY_INSTALL_DIR}"
+REPO_URL="$FUTRX_REPOSITORY_URL"
+SERVICE_PORT="${SERVICE_PORT:-$FUTRX_DEFAULT_SERVICE_PORT}"
 HOST_CLI_PREFIX="$INSTALL_DIR/data/host-clis"
 HOST_CLI_BIN_DIR="$HOST_CLI_PREFIX/bin"
 
@@ -254,6 +257,7 @@ fi
 # as commit-consistent as update.sh.
 # shellcheck source=steps/00-checkout.sh
 . "$INFRA_DIR/steps/00-checkout.sh"
+step_00_checkout
 
 # ───────────────── optional Google user authentication ─────────────────
 # The administrator always claims the server with a local email/password.
@@ -316,18 +320,25 @@ fi
 # ───────────────── run the convergence steps ─────────────────
 # shellcheck source=steps/01-host-deps.sh
 . "$INFRA_DIR/steps/01-host-deps.sh"
+step_01_host_deps
 # shellcheck source=steps/02-app.sh
 . "$INFRA_DIR/steps/02-app.sh"
+step_02_app
 # shellcheck source=steps/03-caddy.sh
 . "$INFRA_DIR/steps/03-caddy.sh"
+step_03_caddy
 # shellcheck source=steps/04-backend-svc.sh
 . "$INFRA_DIR/steps/04-backend-svc.sh"
+step_04_backend_svc
 # shellcheck source=steps/05-base-image.sh
 . "$INFRA_DIR/steps/05-base-image.sh"
+step_05_base_image
 # shellcheck source=steps/06-ssh-hardening.sh
 . "$INFRA_DIR/steps/06-ssh-hardening.sh"
+step_06_ssh_hardening
 # shellcheck source=steps/07-lxc-ipv4-heal.sh
 . "$INFRA_DIR/steps/07-lxc-ipv4-heal.sh"
+step_07_lxc_ipv4_heal
 
 # ───────────────── summary ─────────────────
 cat <<EOF
@@ -362,3 +373,12 @@ cat <<EOF
 ═══════════════════════════════════════════════════════════════
 
 EOF
+}
+
+# Sourced (e.g. by tests) - definitions only. Note the guard
+# defaults to *executing*: BASH_SOURCE is unset when bash reads
+# from stdin (`bash -s`), which must still run (curl|bash mode).
+if [[ -n "${BASH_SOURCE[0]:-}" ]] && [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+main "$@"

--- a/infra/install.sh
+++ b/infra/install.sh
@@ -40,7 +40,7 @@
 
 set -euo pipefail
 
-main() {
+remote_self_bootstrap() {
 # ───────────────── self-bootstrap (curl|bash mode) ─────────────────
 # When piped from curl, BASH_SOURCE points at /dev/stdin and there are no
 # sibling steps/ or templates/. Install git, clone the repo to the canonical
@@ -151,22 +151,10 @@ if [ -z "$INFRA_DIR_PROBE" ] || [ ! -d "${INFRA_DIR_PROBE}/steps" ]; then
     export FUTRX_INSTALL_CHECKOUT_SELECTED=1
     exec bash "$TARGET/infra/install.sh" "$@"
 fi
+}
 
+remote_parse_install_arguments() {
 # ───────────────── args ─────────────────
-# INFRA_DIR resolves before argument parsing so the shared helpers below
-# (and every validation gate) come from lib/common.sh. The curl|bash
-# bootstrap block above intentionally stays self-contained instead.
-INFRA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-# shellcheck source=lib/common.sh
-. "$INFRA_DIR/lib/common.sh"
-# shellcheck source=lib/../config/defaults.sh
-. "$INFRA_DIR/config/defaults.sh"
-HOSTNAME=""
-SKIP_DNS_CHECK=0
-GOOGLE_CLIENT_ID=""
-GOOGLE_CLIENT_SECRET=""
-GITHUB_TOKEN="${GITHUB_TOKEN:-}"
-TARGET_REF=""
 for a in "$@"; do
     case "$a" in
         --skip-dns-check)         SKIP_DNS_CHECK=1 ;;
@@ -198,9 +186,24 @@ if printf '%s' "$HOSTNAME" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$|^\[.*\]$'; 
     echo "  Let's Encrypt cannot issue certs for IPs and your site will lose TLS." >&2
     exit 1
 fi
-require_root "this installer"
+}
 
-export HOSTNAME GITHUB_TOKEN GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET
+remote_load_configuration() {
+HOSTNAME=""
+SKIP_DNS_CHECK=0
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+TARGET_REF=""
+# INFRA_DIR resolves before argument parsing so the shared helpers below
+# (and every validation gate) come from lib/common.sh. The curl|bash
+# bootstrap block above intentionally stays self-contained instead.
+INFRA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck source=lib/common.sh
+. "$INFRA_DIR/lib/common.sh"
+# shellcheck source=lib/../config/defaults.sh
+. "$INFRA_DIR/config/defaults.sh"
+
 if [ -n "$TARGET_REF" ]; then
     export FUTRX_CHECKOUT_REF="$TARGET_REF"
 fi
@@ -242,7 +245,9 @@ render_template() {
         < "$tmpl" > "$dest"
 }
 export -f render_template
+}
 
+remote_migrate_legacy_install() {
 # ───────────────── pre-rename installation migration ─────────────────
 # shellcheck source=lib/install-migration.sh
 . "$INFRA_DIR/lib/install-migration.sh"
@@ -251,14 +256,18 @@ if [ "$FUTRX_INSTALL_PATH_MIGRATED" -eq 1 ]; then
     INFRA_DIR="$INSTALL_DIR/infra"
     export INFRA_DIR
 fi
+}
 
+remote_select_checkout() {
 # ───────────────── select checkout and re-exec ─────────────────
 # This precedes every version/catalog consumer so direct installer reruns are
 # as commit-consistent as update.sh.
 # shellcheck source=steps/00-checkout.sh
 . "$INFRA_DIR/steps/00-checkout.sh"
 step_00_checkout
+}
 
+remote_validate_host() {
 # ───────────────── optional Google user authentication ─────────────────
 # The administrator always claims the server with a local email/password.
 # Google OAuth is only for invited users and may be configured later in the UI.
@@ -316,7 +325,9 @@ if [ "$SKIP_DNS_CHECK" -eq 0 ]; then
         ok "$HOSTNAME → $SERVER_IP (matches this server)"
     fi
 fi
+}
 
+remote_converge_host() {
 # ───────────────── run the convergence steps ─────────────────
 # shellcheck source=steps/01-host-deps.sh
 . "$INFRA_DIR/steps/01-host-deps.sh"
@@ -339,7 +350,9 @@ step_06_ssh_hardening
 # shellcheck source=steps/07-lxc-ipv4-heal.sh
 . "$INFRA_DIR/steps/07-lxc-ipv4-heal.sh"
 step_07_lxc_ipv4_heal
+}
 
+remote_print_install_summary() {
 # ───────────────── summary ─────────────────
 cat <<EOF
 
@@ -374,6 +387,19 @@ cat <<EOF
 
 EOF
 }
+
+main() {
+    remote_self_bootstrap "$@"
+    remote_load_configuration
+    remote_parse_install_arguments "$@"
+    require_root "this installer"
+    remote_migrate_legacy_install
+    remote_select_checkout
+    remote_validate_host
+    remote_converge_host
+    remote_print_install_summary
+}
+
 
 # Sourced (e.g. by tests) - definitions only. Note the guard
 # defaults to *executing*: BASH_SOURCE is unset when bash reads

--- a/infra/steps/00-checkout.sh
+++ b/infra/steps/00-checkout.sh
@@ -9,6 +9,7 @@
 #   - $FUTRX_CHECKOUT_REF (optional; defaults to origin/main)
 set -euo pipefail
 
+step_00_checkout() {
 if [ "${FUTRX_INSTALL_CHECKOUT_SELECTED:-0}" = "1" ]; then
     return 0
 fi
@@ -58,3 +59,4 @@ fi
 
 export FUTRX_INSTALL_CHECKOUT_SELECTED=1
 exec bash "$INSTALL_DIR/infra/install.sh" "$@"
+}

--- a/infra/steps/01-host-deps.sh
+++ b/infra/steps/01-host-deps.sh
@@ -12,6 +12,7 @@
 #   - $LXD_BRIDGE_IP (for the resolved drop-in)
 set -euo pipefail
 
+step_01_host_deps() {
 export DEBIAN_FRONTEND=noninteractive
 
 # ───────────────── base apt deps ─────────────────
@@ -243,3 +244,4 @@ if [ -n "${LXD_BRIDGE_IP:-}" ] && systemctl is-active --quiet systemd-resolved; 
                     /etc/systemd/resolved.conf.d/lxd.conf
     systemctl restart systemd-resolved
 fi
+}

--- a/infra/steps/02-app.sh
+++ b/infra/steps/02-app.sh
@@ -14,6 +14,7 @@
 #   - $AUTH_NOTE — string for the install summary
 set -euo pipefail
 
+step_02_app() {
 cd "$INSTALL_DIR"
 
 # ───────────────── agent CLIs (host-side execution/auth) ─────────────────
@@ -68,3 +69,4 @@ else
     AUTH_NOTE="Local admin authentication enabled. Create the admin password on first visit."
 fi
 export AUTH_NOTE
+}

--- a/infra/steps/03-caddy.sh
+++ b/infra/steps/03-caddy.sh
@@ -7,6 +7,7 @@
 #   - $INFRA_DIR, $HOSTNAME, $HOSTNAME_RE, $SERVICE_PORT
 set -euo pipefail
 
+step_03_caddy() {
 log "Rendering /etc/caddy/Caddyfile for $HOSTNAME"
 # Render to a temp file first, validate, then atomically replace. This way a
 # bad template doesn't blow away a working live config.
@@ -42,3 +43,4 @@ elif [ "${CADDYFILE_CHANGED:-0}" = "1" ]; then
 else
     ok "Caddy already running with current config"
 fi
+}

--- a/infra/steps/04-backend-svc.sh
+++ b/infra/steps/04-backend-svc.sh
@@ -10,6 +10,7 @@
 #   - $INFRA_DIR, $INSTALL_DIR, $HOSTNAME, $SERVICE_PORT
 set -euo pipefail
 
+step_04_backend_svc() {
 SERVICE_NAME="remote.futrx.service"
 SERVICE_UNIT_PATH="/etc/systemd/system/$SERVICE_NAME"
 LEGACY_SERVICE_NAME="remote.futrx.dev.service"
@@ -98,3 +99,4 @@ if command -v ufw >/dev/null && ufw status 2>/dev/null | grep -q "Status: active
     ufw allow 80/tcp  >/dev/null || true
     ufw allow 443/tcp >/dev/null || true
 fi
+}

--- a/infra/steps/05-base-image.sh
+++ b/infra/steps/05-base-image.sh
@@ -11,7 +11,8 @@
 #   - $INSTALL_DIR  (where the repo lives)
 set -euo pipefail
 
-BASE_IMAGE_ALIAS="futrx-remote-dev-base"
+step_05_base_image() {
+BASE_IMAGE_ALIAS="${FUTRX_DEFAULT_BASE_IMAGE:-futrx-remote-dev-base}"
 
 log "Base image: $BASE_IMAGE_ALIAS"
 
@@ -48,3 +49,4 @@ log "Running cmd/build-base-image (the first build can take up to 10 minutes)"
     go run ./cmd/build-base-image "${CLI_ARGS[@]}"
 )
 ok "$BASE_IMAGE_ALIAS published"
+}

--- a/infra/steps/06-ssh-hardening.sh
+++ b/infra/steps/06-ssh-hardening.sh
@@ -15,6 +15,7 @@
 # Expects from caller: log / ok / warn / err helpers.
 set -euo pipefail
 
+step_06_ssh_hardening() {
 DROPIN=/etc/ssh/sshd_config.d/10-futrx-hardening.conf
 
 log "Hardening sshd (key-only auth)"
@@ -57,3 +58,4 @@ else
 fi
 
 ok "sshd: password auth disabled (public-key only)"
+}

--- a/infra/steps/07-lxc-ipv4-heal.sh
+++ b/infra/steps/07-lxc-ipv4-heal.sh
@@ -17,6 +17,7 @@
 # Expects from caller: log / ok helpers.
 set -euo pipefail
 
+step_07_lxc_ipv4_heal() {
 log "Installing lxc-ipv4-heal (container IPv4 self-heal)"
 
 cat > /usr/local/sbin/lxc-ipv4-heal << "SCRIPT"
@@ -65,3 +66,4 @@ systemctl daemon-reload
 systemctl enable --now lxc-ipv4-heal.timer
 
 ok "lxc-ipv4-heal timer active"
+}

--- a/infra/tests/remote-cli-test.sh
+++ b/infra/tests/remote-cli-test.sh
@@ -25,6 +25,7 @@ install_cli() (
         command install "${options[@]}" "$1" "$CLI_PATH"
     }
     . "$INFRA_DIR/steps/04-backend-svc.sh"
+    step_04_backend_svc
 )
 
 # Exercise first installation and reinstallation with different settings.

--- a/infra/update.sh
+++ b/infra/update.sh
@@ -44,13 +44,20 @@ set -euo pipefail
 usage() {
     sed -n '2,/^set -euo pipefail$/ { /^set -euo pipefail$/d; s/^# \{0,1\}//p; }' "$0"
 }
-main() {
+remote_load_configuration() {
 INSTALL_DIR="${FUTRX_INSTALL_DIR:-$FUTRX_DEFAULT_INSTALL_DIR}"
 LEGACY_INSTALL_DIR="${FUTRX_LEGACY_INSTALL_DIR:-$FUTRX_DEFAULT_LEGACY_INSTALL_DIR}"
 UNIT="${FUTRX_SERVICE_UNIT_PATH:-/etc/systemd/system/remote.futrx.service}"
 LEGACY_UNIT="${FUTRX_LEGACY_SERVICE_UNIT_PATH:-/etc/systemd/system/remote.futrx.dev.service}"
 
+SCRIPT_INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=lib/common.sh
+. "$SCRIPT_INFRA_DIR/lib/common.sh"
+# shellcheck source=lib/../config/defaults.sh
+. "$SCRIPT_INFRA_DIR/config/defaults.sh"
+}
 
+remote_parse_update_arguments() {
 HOSTNAME=""
 INCLUDE_BUSY=0
 UPDATE_WORKSPACES=1
@@ -71,20 +78,15 @@ for a in "$@"; do
             ;;
     esac
 done
+}
 
-SCRIPT_INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-# shellcheck source=lib/common.sh
-. "$SCRIPT_INFRA_DIR/lib/common.sh"
-# shellcheck source=lib/../config/defaults.sh
-. "$SCRIPT_INFRA_DIR/config/defaults.sh"
-
-require_root "this updater"
+remote_migrate_legacy_install() {
 # shellcheck source=lib/install-migration.sh
 . "$SCRIPT_INFRA_DIR/lib/install-migration.sh"
-# shellcheck source=lib/update-progress.sh
-. "$SCRIPT_INFRA_DIR/lib/update-progress.sh"
 migrate_legacy_install_dir "$INSTALL_DIR" "$LEGACY_INSTALL_DIR"
+}
 
+remote_refresh_checkout() {
 if [ ! -d "$INSTALL_DIR/.git" ]; then
     echo "$INSTALL_DIR is not an installed git checkout; run infra/install.sh first" >&2
     exit 1
@@ -103,7 +105,9 @@ if [ "${FUTRX_UPDATE_REEXECED:-0}" != "1" ]; then
     export FUTRX_UPDATE_REEXECED=1
     exec bash "$INSTALL_DIR/infra/update.sh" "$@"
 fi
+}
 
+remote_detect_hostname() {
 INFRA_DIR="$INSTALL_DIR/infra"
 if [ -z "$HOSTNAME" ]; then
     # The installer renders BASE_URL=https://<hostname> into the unit. During
@@ -119,7 +123,11 @@ fi
 # Keep install.sh's checkout step (steps/00-checkout.sh) on the same ref this
 # updater just checked out, instead of resetting back to origin/main.
 export FUTRX_CHECKOUT_REF="${TARGET_REF:-origin/main}"
+}
 
+remote_converge_update() {
+# shellcheck source=lib/update-progress.sh
+. "$SCRIPT_INFRA_DIR/lib/update-progress.sh"
 if [ "$UPDATE_WORKSPACES" -eq 1 ]; then
     write_update_progress "host-convergence" "Converging the host and rebuilding the workspace image"
     # Rebuild once in install.sh, after the new backend has been built. The
@@ -142,6 +150,16 @@ fi
 write_update_progress "finishing" "Finishing the infrastructure update"
 echo
 echo "✓ update complete"
+}
+
+main() {
+    remote_load_configuration
+    remote_parse_update_arguments "$@"
+    require_root "this updater"
+    remote_migrate_legacy_install
+    remote_refresh_checkout
+    remote_detect_hostname
+    remote_converge_update
 }
 
 # Sourced (e.g. by tests) - definitions only. Note the guard

--- a/infra/update.sh
+++ b/infra/update.sh
@@ -41,14 +41,15 @@
 # FUTRX_SERVICE_UNIT_PATH, and FUTRX_LEGACY_SERVICE_UNIT_PATH.
 set -euo pipefail
 
-INSTALL_DIR="${FUTRX_INSTALL_DIR:-/opt/remote.futrx}"
-LEGACY_INSTALL_DIR="${FUTRX_LEGACY_INSTALL_DIR:-/opt/remote.futrx.dev}"
-UNIT="${FUTRX_SERVICE_UNIT_PATH:-/etc/systemd/system/remote.futrx.service}"
-LEGACY_UNIT="${FUTRX_LEGACY_SERVICE_UNIT_PATH:-/etc/systemd/system/remote.futrx.dev.service}"
-
 usage() {
     sed -n '2,/^set -euo pipefail$/ { /^set -euo pipefail$/d; s/^# \{0,1\}//p; }' "$0"
 }
+main() {
+INSTALL_DIR="${FUTRX_INSTALL_DIR:-$FUTRX_DEFAULT_INSTALL_DIR}"
+LEGACY_INSTALL_DIR="${FUTRX_LEGACY_INSTALL_DIR:-$FUTRX_DEFAULT_LEGACY_INSTALL_DIR}"
+UNIT="${FUTRX_SERVICE_UNIT_PATH:-/etc/systemd/system/remote.futrx.service}"
+LEGACY_UNIT="${FUTRX_LEGACY_SERVICE_UNIT_PATH:-/etc/systemd/system/remote.futrx.dev.service}"
+
 
 HOSTNAME=""
 INCLUDE_BUSY=0
@@ -74,6 +75,8 @@ done
 SCRIPT_INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=lib/common.sh
 . "$SCRIPT_INFRA_DIR/lib/common.sh"
+# shellcheck source=lib/../config/defaults.sh
+. "$SCRIPT_INFRA_DIR/config/defaults.sh"
 
 require_root "this updater"
 # shellcheck source=lib/install-migration.sh
@@ -139,3 +142,12 @@ fi
 write_update_progress "finishing" "Finishing the infrastructure update"
 echo
 echo "✓ update complete"
+}
+
+# Sourced (e.g. by tests) - definitions only. Note the guard
+# defaults to *executing*: BASH_SOURCE is unset when bash reads
+# from stdin (`bash -s`), which must still run (curl|bash mode).
+if [[ -n "${BASH_SOURCE[0]:-}" ]] && [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+main "$@"

--- a/infra/upgrade-workspaces.sh
+++ b/infra/upgrade-workspaces.sh
@@ -27,6 +27,20 @@
 #   --include-busy   also replace containers with an active agent process
 set -euo pipefail
 
+begin_maintenance() {
+    local maintenance_dir temporary
+    maintenance_dir="$(dirname "$MAINTENANCE_FILE")"
+    mkdir -p "$maintenance_dir"
+    chmod 700 "$maintenance_dir"
+    temporary="${MAINTENANCE_FILE}.tmp.$$"
+    printf '{"pid":%d,"startedAt":%d}\n' "$$" "$(date +%s)" > "$temporary"
+    chmod 600 "$temporary"
+    mv "$temporary" "$MAINTENANCE_FILE"
+}
+end_maintenance() {
+    rm -f "$MAINTENANCE_FILE"
+}
+main() {
 INFRA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=lib/common.sh
 . "$INFRA_DIR/lib/common.sh"
@@ -73,19 +87,6 @@ GO_ARGS=()
 # Keep the control plane and update-status polling available throughout the
 # migration. The backend checks this live-PID marker before accepting a new
 # prompt, closing the race that previously required stopping the whole service.
-begin_maintenance() {
-    local maintenance_dir temporary
-    maintenance_dir="$(dirname "$MAINTENANCE_FILE")"
-    mkdir -p "$maintenance_dir"
-    chmod 700 "$maintenance_dir"
-    temporary="${MAINTENANCE_FILE}.tmp.$$"
-    printf '{"pid":%d,"startedAt":%d}\n' "$$" "$(date +%s)" > "$temporary"
-    chmod 600 "$temporary"
-    mv "$temporary" "$MAINTENANCE_FILE"
-}
-end_maintenance() {
-    rm -f "$MAINTENANCE_FILE"
-}
 if [ "$DRY_RUN" -eq 0 ]; then
     begin_maintenance
     trap end_maintenance EXIT
@@ -99,3 +100,12 @@ if [ "$DRY_RUN" -eq 0 ]; then
     trap - EXIT
 fi
 ok "workspace lifecycle convergence complete"
+}
+
+# Sourced (e.g. by tests) - definitions only. Note the guard
+# defaults to *executing*: BASH_SOURCE is unset when bash reads
+# from stdin (`bash -s`), which must still run (curl|bash mode).
+if [[ -n "${BASH_SOURCE[0]:-}" ]] && [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+main "$@"

--- a/infra/upgrade-workspaces.sh
+++ b/infra/upgrade-workspaces.sh
@@ -40,13 +40,15 @@ begin_maintenance() {
 end_maintenance() {
     rm -f "$MAINTENANCE_FILE"
 }
-main() {
+remote_load_configuration() {
 INFRA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=lib/common.sh
 . "$INFRA_DIR/lib/common.sh"
 DATA_DIR="${FUTRX_DATA_DIR:-/opt/remote.futrx/data}"
 MAINTENANCE_FILE="${FUTRX_MAINTENANCE_FILE:-$DATA_DIR/self-update/maintenance.json}"
+}
 
+remote_parse_workspace_arguments() {
 DRY_RUN=0
 REBAKE=1
 INCLUDE_BUSY=0
@@ -58,12 +60,17 @@ for a in "$@"; do
         *) err "unknown flag: $a"; exit 1 ;;
     esac
 done
+}
 
-require_root "upgrade-workspaces"
+remote_validate_host() {
+# ───────────────── 0. validate ─────────────────
 if ! command -v lxc >/dev/null; then
     err "lxc CLI not found"
     exit 1
 fi
+}
+
+remote_rebake_base_image() {
 # ───────────────── 1. rebake ─────────────────
 if [ "$REBAKE" -eq 1 ]; then
     if [ "$DRY_RUN" -eq 1 ]; then
@@ -76,7 +83,9 @@ if [ "$REBAKE" -eq 1 ]; then
 else
     log "Skipping rebake (--no-rebake) — recycling containers onto the existing image"
 fi
+}
 
+remote_migrate_containers() {
 # ───────────────── 2. migrate + replace through Go ─────────────────
 log "Migrating and replacing project containers"
 GO_ARGS=()
@@ -100,6 +109,15 @@ if [ "$DRY_RUN" -eq 0 ]; then
     trap - EXIT
 fi
 ok "workspace lifecycle convergence complete"
+}
+
+main() {
+    remote_load_configuration
+    remote_parse_workspace_arguments "$@"
+    require_root "upgrade-workspaces"
+    remote_validate_host
+    remote_rebake_base_image
+    remote_migrate_containers
 }
 
 # Sourced (e.g. by tests) - definitions only. Note the guard


### PR DESCRIPTION
Follow-up to #182 as discussed there.Combine two changes:1. infra/config/defaults.sh centralizes the shared install dir, service name/port, base image and repo URL constants (env overrides preserved exactly, including deploy-app's PORT vs SERVICE_PORT wiring).2. All 8 steps/*.sh are now function-only libraries (step_NN_*) called explicitly from main(); the 4 entry points gained main() plus source-safe guards. The guard defaults to executing because BASH_SOURCE is unset under set -u when bash reads from stdin - the existing qa-scripts-test curl-mode case caught the naive version during development.Two behavior notes: step-file sourcing no longer executes (remote-cli-test updated with the one-line call, same subshell-abort semantics); QA operator scripts untouched.Verified here: bash -n clean on all 14 files, qa-scripts-test (full) + remote-cli-test green, host-agent-install-test static contracts hold. The Go-dependent part of host-agent-install-test needs CI (no Go toolchain on this machine).