### PR TITLE
fix(chat): reveal tool output shell when Load full response expands

### DIFF
--- a/frontend/src/ui/chat/tool-calls/ToolShell.tsx
+++ b/frontend/src/ui/chat/tool-calls/ToolShell.tsx
@@ -1,5 +1,5 @@
 import type { ComponentChildren } from "preact";
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { AlertCircle, ChevronDown, ChevronRight, Loader } from "../../primitives/icons";
 
 export function ToolShell({
@@ -9,6 +9,7 @@ export function ToolShell({
   status,
   isError,
   defaultOpen,
+  revealSignal,
   children,
 }: {
   icon: ComponentChildren;
@@ -17,9 +18,19 @@ export function ToolShell({
   status: "running" | "done";
   isError?: boolean;
   defaultOpen?: boolean;
+  /**
+   * When this flips to true, the shell opens so newly revealed content
+   * (e.g. a "Load full response" expansion) is actually visible instead of
+   * staying hidden inside a collapsed shell. Afterwards the user can still
+   * collapse it manually.
+   */
+  revealSignal?: boolean;
   children?: ComponentChildren;
 }) {
   const [open, setOpen] = useState(!!defaultOpen);
+  useEffect(() => {
+    if (revealSignal) setOpen(true);
+  }, [revealSignal]);
   return (
     <div class={`codex-tool-shell my-2 overflow-hidden rounded-card border text-sm
                 ${isError ? "border-accent-red/30 bg-accent-red/[0.05]" : "border-line bg-surface"}`}>

--- a/frontend/src/ui/chat/tool-calls/renderers/BashCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/BashCall.tsx
@@ -15,6 +15,7 @@ export function BashCall({ input, output, outputExpanded, status, isError }: Omi
       badge={description ? truncate(description, 30) : undefined}
       status={status}
       isError={isError}
+      revealSignal={outputExpanded}
     >
       {output ? <CodeBlock text={outputExpanded ? output : truncate(output, DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS)} /> : null}
     </ToolShell>

--- a/frontend/src/ui/chat/tool-calls/renderers/EditCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/EditCall.tsx
@@ -26,6 +26,7 @@ export function EditCall({ input, output, outputExpanded, status, isError }: Omi
       status={status}
       isError={isError}
       defaultOpen
+      revealSignal={outputExpanded}
     >
       <div class="divide-y divide-ink-500">
         {patches.map((parts, index) => (

--- a/frontend/src/ui/chat/tool-calls/renderers/GenericCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/GenericCall.tsx
@@ -12,6 +12,7 @@ export function GenericCall({ name, input, output, outputExpanded, status, isErr
       label={<span class="text-ink-300">{name}</span>}
       status={status}
       isError={isError}
+      revealSignal={outputExpanded}
     >
       <div class="divide-y divide-ink-500">
         {input && Object.keys(input).length > 0 && (

--- a/frontend/src/ui/chat/tool-calls/renderers/ReadCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/ReadCall.tsx
@@ -13,6 +13,7 @@ export function ReadCall({ input, output, outputExpanded, status, isError }: Omi
       label={<><span class="text-ink-300">Read</span> <span class="font-mono">{shortPath(path)}</span></>}
       status={status}
       isError={isError}
+      revealSignal={outputExpanded}
     >
       {output ? <CodeBlock text={outputExpanded ? output : truncate(output, READ_TOOL_OUTPUT_PREVIEW_CHARS)} /> : null}
     </ToolShell>

--- a/frontend/src/ui/chat/tool-calls/renderers/SearchCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/SearchCall.tsx
@@ -20,6 +20,7 @@ export function SearchCall({ name, input, output, outputExpanded, status, isErro
       }
       status={status}
       isError={isError}
+      revealSignal={outputExpanded}
     >
       {output ? <CodeBlock text={outputExpanded ? output : truncate(output, DEFAULT_TOOL_OUTPUT_PREVIEW_CHARS)} /> : null}
     </ToolShell>

--- a/frontend/src/ui/chat/tool-calls/renderers/WriteCall.tsx
+++ b/frontend/src/ui/chat/tool-calls/renderers/WriteCall.tsx
@@ -14,6 +14,7 @@ export function WriteCall({ input, output, outputExpanded, status, isError }: Om
       badge={`${content.split("\n").length} lines`}
       status={status}
       isError={isError}
+      revealSignal={outputExpanded}
     >
       <CodeBlock text={truncate(content, 8000)} />
       {output && (isError || outputExpanded) ? (


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #190: clicking "Load full response" on a tool call did visibly nothing.

Root cause: the button renders in `ToolCall`, outside the collapsible `ToolShell`, while the output it expands
lives inside it. Tool shells start collapsed, so expanding the data left the shell closed — the revealed content
stayed hidden and the click appeared to do nothing (matches the issue screenshot: enabled button, collapsed tool
rows, no size suffix).

## Change

- `ToolShell` accepts an optional `revealSignal`: when it flips to `true`, the shell opens. Afterwards the user
  can still collapse it manually (the effect only fires on the transition).
- All tool renderers (`Bash`, `Generic`, `Search`, `Read`, `Write`, `Edit`) pass `outputExpanded` as the signal.

## Verification

- `tsc -b` clean.
- Full frontend suite: 326/326 tests pass (`node --experimental-strip-types --test`).
- No behavior change for the ref/fetch path or for already-open shells; the collaboration-card buttons sit inside
  already-expanded details and needed no change.
