### PR TITLE
fix(chat): summarize approval requests for non-technical users

### DIFF
--- a/frontend/src/ui/chat/interactions/ApprovalInteractionForm.tsx
+++ b/frontend/src/ui/chat/interactions/ApprovalInteractionForm.tsx
@@ -1,4 +1,5 @@
 import { DecisionButton, RequestDetails } from "./InteractionControls";
+import { summarizeApprovalRequest } from "./approvalSummary";
 import type { InteractionFormProps } from "./types";
 
 export function ApprovalInteractionForm({
@@ -7,8 +8,21 @@ export function ApprovalInteractionForm({
   supportsCancellation,
   onSubmit,
 }: InteractionFormProps & { supportsCancellation: boolean }) {
+  const summary = summarizeApprovalRequest(input);
   return (
     <div class="space-y-3">
+      {summary.reason && <p class="text-[13px] leading-relaxed text-ink-100">{summary.reason}</p>}
+      {summary.command && (
+        <div>
+          <div class="mb-1 text-[10px] font-medium text-ink-400">Command</div>
+          <pre class="overflow-x-auto whitespace-pre-wrap break-all rounded-control border border-line bg-canvas p-2 font-mono text-[11px] leading-relaxed text-ink-100">
+            {summary.command}
+          </pre>
+          {summary.cwd && (
+            <div class="mt-1 font-mono text-[10px] text-ink-400">in {summary.cwd}</div>
+          )}
+        </div>
+      )}
       <RequestDetails input={input} />
       <div class="flex flex-wrap gap-2">
         <DecisionButton disabled={disabled} onClick={() => onSubmit({ kind: "approve", scope: "once" })}>

--- a/frontend/src/ui/chat/interactions/approvalSummary.test.ts
+++ b/frontend/src/ui/chat/interactions/approvalSummary.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { summarizeApprovalRequest } from "./approvalSummary.ts";
+
+test("summarizes a command approval with reason, command and cwd", () => {
+  assert.deepEqual(
+    summarizeApprovalRequest({
+      kind: "command",
+      threadId: "01a06c52-5c04-7091-b209-0c294712e68a",
+      reason: "May I refresh apt metadata so I can install Go?",
+      command: "/bin/bash -lc 'apt-get update'",
+      cwd: "/workspace/remote.futrx",
+    }),
+    {
+      reason: "May I refresh apt metadata so I can install Go?",
+      command: "/bin/bash -lc 'apt-get update'",
+      cwd: "/workspace/remote.futrx",
+    }
+  );
+});
+
+test("ignores machine-only payloads without user-facing fields", () => {
+  assert.deepEqual(
+    summarizeApprovalRequest({ threadId: "abc", turnId: "def", startedAtMs: 17852399269 }),
+    {}
+  );
+});
+
+test("drops blank strings", () => {
+  assert.deepEqual(summarizeApprovalRequest({ reason: "  ", command: "", cwd: " " }), {});
+});

--- a/frontend/src/ui/chat/interactions/approvalSummary.ts
+++ b/frontend/src/ui/chat/interactions/approvalSummary.ts
@@ -1,0 +1,32 @@
+/**
+ * Human-readable summary of an approval interaction input.
+ *
+ * Provider payloads (e.g. Codex `item/commandExecution/requestApproval`) carry
+ * machine fields (thread/exec IDs, timestamps) that mean nothing to most
+ * users. Surface what the decision is about: why the agent asks (`reason`),
+ * what it wants to run (`command`) and where (`cwd`). Anything else stays
+ * available behind the raw "Request details" disclosure.
+ */
+export interface ApprovalSummary {
+  reason?: string;
+  command?: string;
+  cwd?: string;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? value : undefined;
+}
+
+export function summarizeApprovalRequest(input: Record<string, unknown>): ApprovalSummary {
+  const summary: ApprovalSummary = {};
+  const reason = nonEmptyString(input.reason);
+  if (reason) summary.reason = reason;
+  // A field literally named "command" is unambiguous: show it verbatim.
+  const command = nonEmptyString(input.command);
+  if (command) summary.command = command;
+  const cwd = nonEmptyString(input.cwd);
+  if (cwd) summary.cwd = cwd;
+  return summary;
+}


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #156: approval cards (e.g. Codex `item/commandExecution/requestApproval`) showed only the raw provider JSON
— thread/exec IDs, timestamps, internal fields — leaving non-technical users unable to judge the decision.

`ApprovalInteractionForm` now renders a human summary first: the agent's `reason`, the exact `command` in a mono
block, and the working directory. The raw payload stays available behind the existing "Request details and scope"
disclosure for advanced users. Matches the established `PermissionInteractionForm` pattern, which already surfaces
`reason` above its details.

## Change

- New pure `summarizeApprovalRequest()` helper (`approvalSummary.ts`) with `node:test` coverage.
- `ApprovalInteractionForm` renders the summary; raw JSON fallback unchanged.

## Verification

- `tsc -b` clean.
- Full frontend suite: 329/329 tests pass (326 existing + 3 new).
