### PR TITLE
fix(chat): surface terminal overlay load failures with retry

### DIFF
--- a/frontend/src/app/containers/ChatContainer.tsx
+++ b/frontend/src/app/containers/ChatContainer.tsx
@@ -243,12 +243,35 @@ export function ChatContainer({
           onCaptureElement={browser.insertBrowserElementContext}
           onClose={browser.closeBrowserDrawer}
         />
-        {terminal.TerminalOverlay && (
+        {terminal.TerminalOverlay ? (
           <terminal.TerminalOverlay
             chat={displayMeta}
             open={drawers.terminalOpen}
             onClose={drawers.closeTerminal}
           />
+        ) : (
+          drawers.terminalOpen && (
+            <aside
+              id="workspace-terminal-pane"
+              class="workspace-pane workspace-terminal-pane relative z-20 h-full flex-none overflow-hidden bg-surface border-l border-line"
+              aria-label="Terminal"
+            >
+              <div class="flex h-full flex-col items-start justify-center gap-2 p-4">
+                <div class="text-[13px] font-medium text-ink-100">
+                  {terminal.overlayError ?? "Loading terminal…"}
+                </div>
+                {terminal.overlayError && (
+                  <button
+                    type="button"
+                    onClick={terminal.retryTerminalOverlay}
+                    class="h-8 rounded-control border border-line-strong px-3 text-[11px] font-medium text-ink-200 hover:bg-tint-strong"
+                  >
+                    Retry
+                  </button>
+                )}
+              </div>
+            </aside>
+          )
         )}
       </div>
       <MediaViewerOverlay />

--- a/frontend/src/config/terminal.ts
+++ b/frontend/src/config/terminal.ts
@@ -34,6 +34,8 @@ export const TERMINAL_OPTIONS: ITerminalOptions = {
 
 export const TERMINAL_WEB_SOCKET_BINARY_TYPE = "arraybuffer";
 export const TERMINAL_CONNECTION_ERROR_MESSAGE = "Terminal connection failed.";
+export const TERMINAL_OVERLAY_LOAD_ERROR_MESSAGE =
+  "Terminal failed to load. The app may have updated in the background — retry, or refresh the page.";
 export const TERMINAL_DEFAULT_TITLE = "workspace";
 export const TERMINAL_INITIAL_FIT_DELAY_MS = 0;
 export const TERMINAL_STATUS = {

--- a/frontend/src/ui/chat/terminal/useTerminalOverlayController.ts
+++ b/frontend/src/ui/chat/terminal/useTerminalOverlayController.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from "preact";
 import { useEffect, useState } from "preact/hooks";
 import type { ChatMeta } from "../../../models/chat";
+import { TERMINAL_OVERLAY_LOAD_ERROR_MESSAGE } from "../../../config/terminal";
 
 type TerminalOverlayComponent = ComponentType<{
   chat: ChatMeta;
@@ -10,17 +11,36 @@ type TerminalOverlayComponent = ComponentType<{
 
 export function useTerminalOverlayController(terminalOpen: boolean) {
   const [TerminalOverlay, setTerminalOverlay] = useState<TerminalOverlayComponent | null>(null);
+  const [overlayError, setOverlayError] = useState<string | null>(null);
+  // Bumped by retryTerminalOverlay so a failed chunk import is attempted
+  // again even though terminalOpen did not change.
+  const [loadAttempt, setLoadAttempt] = useState(0);
 
   useEffect(() => {
     if (!terminalOpen || TerminalOverlay) return;
     let cancelled = false;
-    import("./TerminalOverlay").then((module) => {
-      if (!cancelled) setTerminalOverlay(() => module.TerminalOverlay);
-    });
+    setOverlayError(null);
+    import("./TerminalOverlay").then(
+      (module) => {
+        if (!cancelled) setTerminalOverlay(() => module.TerminalOverlay);
+      },
+      () => {
+        // A stale cached bundle after a deploy (or a flaky network) rejects
+        // the chunk import. Without surfacing it, the open button appears to
+        // do nothing until a page refresh.
+        if (!cancelled) setOverlayError(TERMINAL_OVERLAY_LOAD_ERROR_MESSAGE);
+      }
+    );
     return () => {
       cancelled = true;
     };
-  }, [TerminalOverlay, terminalOpen]);
+  }, [TerminalOverlay, terminalOpen, loadAttempt]);
 
-  return { TerminalOverlay };
+  function retryTerminalOverlay() {
+    if (TerminalOverlay) return;
+    setOverlayError(null);
+    setLoadAttempt((attempt) => attempt + 1);
+  }
+
+  return { TerminalOverlay, overlayError, retryTerminalOverlay };
 }


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #186: clicking the terminal button sometimes opened nothing, recovering only after a page refresh.

Root cause: the terminal overlay is lazy-loaded (`import("./TerminalOverlay")`) on first open. When that chunk
import rejects — a stale cached bundle right after a deploy, or a flaky network — `TerminalOverlay` stayed `null`
while `terminalOpen` was `true`: no pane rendered, no error surfaced, and no retry was attempted until the button
was toggled. A refresh (fresh chunk manifest) is exactly what recovered it.

## Change

- `useTerminalOverlayController` surfaces the chunk-load failure (`overlayError`) and exposes
  `retryTerminalOverlay()`, which re-attempts the import without requiring a toggle cycle.
- `ChatContainer` renders a fallback pane while the overlay module is unavailable: a loading state normally, or
  the error with a Retry button on failure.
- New `TERMINAL_OVERLAY_LOAD_ERROR_MESSAGE` constant next to the other terminal strings.

## Verification

- `tsc -b` clean.
- Full frontend suite: 329/329 tests pass.
