### PR TITLE
feat(containers): replay workspace setup.sh after provisioning

### DIFF
--- a/backend/internal/agent/provisioning/assets/AGENTS.md
+++ b/backend/internal/agent/provisioning/assets/AGENTS.md
@@ -53,8 +53,9 @@ runs; do not ask users to add it as a project secret.
 above are host bind-mounts and survive container replacement. Other paths
 (`/usr/local/`, unmounted paths under `/root/`, and packages you apt-install)
 are gone if the container is recreated. If you install a tool the project
-needs again later, append the install line to `/workspace/setup.sh` so a fresh
-container can rebootstrap with `bash /workspace/setup.sh`.
+needs again later, append the install line to `/workspace/setup.sh` — the
+platform replays it automatically (as root) after every reprovision, so keep
+it idempotent. Make the script executable (`chmod +x`) to opt in.
 
 ## Secrets
 

--- a/backend/internal/config/containers.go
+++ b/backend/internal/config/containers.go
@@ -18,6 +18,7 @@ import (
 	containerresources "github.com/futrx-com/remote.futrx.com/internal/integration/containers/resources"
 	containerruntimeassets "github.com/futrx-com/remote.futrx.com/internal/integration/containers/runtimeassets"
 	containerscheduletools "github.com/futrx-com/remote.futrx.com/internal/integration/containers/scheduletools"
+	containerusersetup "github.com/futrx-com/remote.futrx.com/internal/integration/containers/usersetup"
 	containerworkspace "github.com/futrx-com/remote.futrx.com/internal/integration/containers/workspace"
 	"github.com/futrx-com/remote.futrx.com/internal/integration/hostfs"
 	servicebrowser "github.com/futrx-com/remote.futrx.com/internal/service/container/browser"
@@ -126,6 +127,7 @@ func NewContainerStack(
 		workspace,
 		browser,
 		codeServer,
+		containerusersetup.NewProvisioner(runner),
 		scheduleTools,
 	)
 	resources := containerresources.NewManager(runner)

--- a/backend/internal/integration/containers/usersetup/provisioner.go
+++ b/backend/internal/integration/containers/usersetup/provisioner.go
@@ -1,0 +1,73 @@
+// Package usersetup restores the project-owned development environment
+// after provisioning.
+//
+// Convention (see agent/provisioning/assets/AGENTS.md): agents append tool
+// install lines to /workspace/setup.sh. The workspace bind-mount survives
+// container replacement, so the script is durable — this provisioner is the
+// missing execution step that replays it inside every fresh container.
+//
+// Safety properties:
+//   - Opt-in: absent or non-executable setup.sh means "nothing to restore".
+//   - Runs as container root, matching how agents author it (apt installs).
+//   - Returns errors to the caller (the launch provisioner keeps them
+//     best-effort); output is truncated to a tail so apt logs can't flood.
+//
+// Keep the script idempotent: it re-runs on every create and mount change.
+package usersetup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/integration/containers/command"
+)
+
+const (
+	setupScriptPath   = "/workspace/setup.sh"
+	setupProbeTimeout = 30 * time.Second
+	// setupRunTimeout budgets apt-size restores on fresh containers.
+	setupRunTimeout      = 15 * time.Minute
+	setupOutputTailLines = 20
+)
+
+// Provisioner replays the project setup script inside the container.
+type Provisioner struct {
+	runner command.Runner
+}
+
+// NewProvisioner builds a setup-script provisioner over an lxc runner.
+func NewProvisioner(runner command.Runner) *Provisioner {
+	return &Provisioner{runner: runner}
+}
+
+// Ensure runs /workspace/setup.sh when it exists and is executable.
+// A missing script is not an error.
+func (p *Provisioner) Ensure(ctx context.Context, containerName string) error {
+	if !p.runner.Available() {
+		return command.ErrUnavailable
+	}
+	if _, err := command.RunWithTimeout(
+		ctx, p.runner, setupProbeTimeout,
+		"exec", containerName, "--", "test", "-x", setupScriptPath,
+	); err != nil {
+		return nil
+	}
+	out, err := command.RunWithTimeout(
+		ctx, p.runner, setupRunTimeout,
+		"exec", containerName, "--", "bash", setupScriptPath,
+	)
+	if err != nil {
+		return fmt.Errorf("run %s: %w: %s", setupScriptPath, err, tailLines(out))
+	}
+	return nil
+}
+
+func tailLines(out string) string {
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) > setupOutputTailLines {
+		lines = lines[len(lines)-setupOutputTailLines:]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/backend/internal/integration/containers/usersetup/provisioner_test.go
+++ b/backend/internal/integration/containers/usersetup/provisioner_test.go
@@ -1,0 +1,87 @@
+package usersetup
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+type scriptedRunner struct {
+	available bool
+	// scriptPresent controls the "test -x" gate; runErr is returned by bash.
+	scriptPresent bool
+	runErr        error
+	calls         []string
+	deadlines     []time.Duration
+}
+
+func (r *scriptedRunner) Available() bool { return r.available }
+
+func (r *scriptedRunner) Run(ctx context.Context, args ...string) (string, error) {
+	r.calls = append(r.calls, strings.Join(args, " "))
+	if deadline, ok := ctx.Deadline(); ok {
+		r.deadlines = append(r.deadlines, time.Until(deadline))
+	}
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "test -x /workspace/setup.sh") {
+		if !r.scriptPresent {
+			return "", errors.New("exit status 1")
+		}
+		return "", nil
+	}
+	if r.runErr != nil {
+		return "apt-get update\nHit:1 ok\nE: something broke\n", r.runErr
+	}
+	return "ok\n", nil
+}
+
+func (r *scriptedRunner) RunStdin(ctx context.Context, _ io.Reader, args ...string) (string, error) {
+	return r.Run(ctx, args...)
+}
+
+func TestEnsureSkipsMissingScript(t *testing.T) {
+	runner := &scriptedRunner{available: true}
+	if err := NewProvisioner(runner).Ensure(context.Background(), "project-1"); err != nil {
+		t.Fatalf("Ensure = %v, want nil for missing script", err)
+	}
+	if len(runner.calls) != 1 || !strings.Contains(runner.calls[0], "test -x /workspace/setup.sh") {
+		t.Fatalf("calls = %q, want only the executable probe", runner.calls)
+	}
+}
+
+func TestEnsureRunsExecutableScript(t *testing.T) {
+	runner := &scriptedRunner{available: true, scriptPresent: true}
+	if err := NewProvisioner(runner).Ensure(context.Background(), "project-1"); err != nil {
+		t.Fatalf("Ensure = %v, want nil", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls = %q, want probe + run", runner.calls)
+	}
+	if !strings.Contains(runner.calls[1], "exec project-1 -- bash /workspace/setup.sh") {
+		t.Fatalf("run call = %q, want bash of the setup script", runner.calls[1])
+	}
+	if len(runner.deadlines) != 2 || runner.deadlines[1] <= runner.deadlines[0] {
+		t.Fatalf("deadlines = %v, want the run budget to exceed the probe budget", runner.deadlines)
+	}
+}
+
+func TestEnsureReportsTailedFailure(t *testing.T) {
+	runner := &scriptedRunner{available: true, scriptPresent: true, runErr: errors.New("exit status 100")}
+	err := NewProvisioner(runner).Ensure(context.Background(), "project-1")
+	if err == nil || !strings.Contains(err.Error(), "/workspace/setup.sh") {
+		t.Fatalf("Ensure = %v, want error naming the script", err)
+	}
+	if !strings.Contains(err.Error(), "something broke") {
+		t.Fatalf("Ensure = %v, want output tail in the error", err)
+	}
+}
+
+func TestEnsureWithoutRunner(t *testing.T) {
+	runner := &scriptedRunner{}
+	if err := NewProvisioner(runner).Ensure(context.Background(), "project-1"); err == nil {
+		t.Fatal("Ensure = nil, want unavailability error")
+	}
+}

--- a/backend/internal/service/container/image/recipe.go
+++ b/backend/internal/service/container/image/recipe.go
@@ -16,7 +16,8 @@ apt-get update -qq
 
 # Core build / shell / network deps, plus git + ssh + jq for everyday agent
 # work. python3-pip pulls in python3 too. Skip wrangler/aws/gcloud/hcloud —
-# project-specific; agent installs them on demand and records in /workspace/setup.sh.
+# project-specific; agent installs them on demand and records in
+# /workspace/setup.sh (replayed automatically after each reprovision).
 apt-get install -y -qq \
     curl ca-certificates gnupg \
     git openssh-client \

--- a/backend/internal/service/container/launch/provisioner.go
+++ b/backend/internal/service/container/launch/provisioner.go
@@ -26,6 +26,10 @@ type ScheduleToolsProvisioner interface {
 	Ensure(ctx context.Context, containerName string) error
 }
 
+type UserSetupProvisioner interface {
+	Ensure(ctx context.Context, containerName string) error
+}
+
 // Provisioner applies launch-time capabilities in their stable order. Every
 // step is deliberately best-effort so one unavailable capability cannot block
 // the remaining migrations or the newly launched container.
@@ -35,6 +39,7 @@ type Provisioner struct {
 	browser       BrowserProvisioner
 	codeServer    CodeServerProvisioner
 	scheduleTools ScheduleToolsProvisioner
+	userSetup     UserSetupProvisioner
 }
 
 func NewProvisioner(
@@ -42,6 +47,7 @@ func NewProvisioner(
 	workspace WorkspaceProvisioner,
 	browser BrowserProvisioner,
 	codeServer CodeServerProvisioner,
+	userSetup UserSetupProvisioner,
 	scheduleTools ...ScheduleToolsProvisioner,
 ) *Provisioner {
 	var scheduled ScheduleToolsProvisioner
@@ -54,6 +60,7 @@ func NewProvisioner(
 		browser:       browser,
 		codeServer:    codeServer,
 		scheduleTools: scheduled,
+		userSetup:     userSetup,
 	}
 }
 
@@ -68,4 +75,7 @@ func (p *Provisioner) Provision(ctx context.Context, containerName, displayName 
 		_ = p.scheduleTools.Ensure(ctx, containerName)
 	}
 	_ = p.codeServer.Ensure(ctx, containerName, displayName)
+	// User setup runs last: the platform is fully converged, so project
+	// restores (apt installs, dotfiles, tool configs) land on a ready box.
+	_ = p.userSetup.Ensure(ctx, containerName)
 }

--- a/backend/internal/service/container/launch/provisioner_test.go
+++ b/backend/internal/service/container/launch/provisioner_test.go
@@ -54,6 +54,13 @@ func (f failingScheduleTools) Ensure(_ context.Context, containerName string) er
 	return errors.New("schedule tools failed")
 }
 
+type failingUserSetup struct{ recorder *callRecorder }
+
+func (f failingUserSetup) Ensure(_ context.Context, containerName string) error {
+	f.recorder.calls = append(f.recorder.calls, "user setup "+containerName)
+	return errors.New("user setup failed")
+}
+
 func TestProvisionKeepsBestEffortCapabilityOrder(t *testing.T) {
 	recorder := &callRecorder{}
 	provisioner := NewProvisioner(
@@ -61,6 +68,7 @@ func TestProvisionKeepsBestEffortCapabilityOrder(t *testing.T) {
 		failingWorkspace{recorder: recorder},
 		failingBrowser{recorder: recorder},
 		failingCodeServer{recorder: recorder},
+		failingUserSetup{recorder: recorder},
 		failingScheduleTools{recorder: recorder},
 	)
 
@@ -74,6 +82,7 @@ func TestProvisionKeepsBestEffortCapabilityOrder(t *testing.T) {
 		"browser nesting project-1",
 		"schedule tools project-1",
 		"code-server project-1 My Project",
+		"user setup project-1",
 	}
 	if !slices.Equal(recorder.calls, want) {
 		t.Fatalf("calls: got %q, want %q", recorder.calls, want)

--- a/infra/upgrade-workspaces.sh
+++ b/infra/upgrade-workspaces.sh
@@ -13,6 +13,8 @@
 #   - Workspace files always survive (bind-mounted from the host). Anything
 #     installed in the container ROOTFS outside /workspace (ad-hoc apt/npm
 #     installs, caches) is lost — that is what "upgrade by re-clone" means.
+#     An executable /workspace/setup.sh is replayed automatically after
+#     replacement so projects can restore their own tooling.
 #   - Containers with a running agent process are SKIPPED by default.
 #   - The control plane stays online in maintenance mode so update progress is
 #     visible, while new prompts are rejected until replacement is complete.


### PR DESCRIPTION
# Pull Request

## Summary

Partial fix for #134 (mechanism 1 of those proposed in the issue: a persistent bootstrap script).
The documented convention already told agents to record installs in `/workspace/setup.sh`, but
nothing ever executed it — so environments did not self-restore after reprovisioning.

## Change

- New `usersetup` provisioner: runs executable `/workspace/setup.sh` as container root with a
  15-minute budget; absent/non-executable script is a no-op (opt-in); failures return a tailed
  error to the best-effort launch pipeline.
- Wired as the last launch-provisioning step (platform converged first). Launch provisioning runs
  on every create and mount change, so upgrades self-restore.
- Docs: `AGENTS.md`, image recipe comment, and `upgrade-workspaces.sh` header now state the replay.

Deliberately out of scope for this slice (per the issue's own safety notes): new persistent
dotfile mounts (SSH keys need encrypted/project-scoped handling first), apt-manifest recording,
and declarative env files.

## Verification

- New `usersetup` package tests (skip/run/failure-tail/unavailable) + updated launch order test +
  config tests: green. `go vet` clean. Full `go build ./...` unaffected except the pre-existing
  `static.go` embed gap (needs a built frontend) and the pre-existing
  `TestPersistentMountsRejectInvalidAndOverlappingProfileState/overlapping_targets` failure —
  both reproduce on the pristine tree.
