### PR TITLE
feat(runs): record per-run workspace changesets

### DIFF
--- a/backend/cmd/remote/main.go
+++ b/backend/cmd/remote/main.go
@@ -29,6 +29,7 @@ import (
 	service "github.com/futrx-com/remote.futrx.com/internal/service"
 	servicegithistory "github.com/futrx-com/remote.futrx.com/internal/service/githistory"
 	servicemaintenance "github.com/futrx-com/remote.futrx.com/internal/service/maintenance"
+	"github.com/futrx-com/remote.futrx.com/internal/service/runchanges"
 	serviceselfupdate "github.com/futrx-com/remote.futrx.com/internal/service/selfupdate"
 	serviceserverinfo "github.com/futrx-com/remote.futrx.com/internal/service/serverinfo"
 	serviceworkspacefiles "github.com/futrx-com/remote.futrx.com/internal/service/workspacefiles"
@@ -103,6 +104,7 @@ func main() {
 		SessionRegistry:   storeSet.SessionRegistry,
 		Push:              storeSet.Push,
 		Usage:             storeSet.Usage,
+		RunChanges:        runchanges.NewTracker(cfg.DataDir, gitcli.NewHistoryClient()),
 		AuthBaseURL:       cfg.BaseURL,
 		ProjectContainers: containerStack.ProjectDependencies(),
 		AgentContainers:   containerStack.AgentDependencies(),

--- a/backend/internal/integration/gitcli/diffsummary_test.go
+++ b/backend/internal/integration/gitcli/diffsummary_test.go
@@ -1,0 +1,95 @@
+package gitcli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func makeTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) string {
+		t.Helper()
+		command := exec.Command("git", args...)
+		command.Dir = dir
+		command.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, output)
+		}
+		return strings.TrimSpace(string(output))
+	}
+	run("init", "-q")
+	run("commit", "-q", "--allow-empty", "-m", "init")
+	if err := os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("one\ntwo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-q", "-m", "add tracked")
+	return dir
+}
+
+func TestDiffSummaryTalliesTrackedAndUntrackedChanges(t *testing.T) {
+	client := NewHistoryClient()
+	ctx := context.Background()
+	repo := makeTestRepo(t)
+
+	base, err := client.Head(ctx, repo)
+	if err != nil {
+		t.Fatalf("Head = %v", err)
+	}
+
+	if err := os.WriteFile(
+		filepath.Join(repo, "tracked.txt"), []byte("one\ntwo\nthree\n"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "sub", "new.txt"), []byte("a\nb\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := client.DiffSummary(ctx, repo, base)
+	if err != nil {
+		t.Fatalf("DiffSummary = %v", err)
+	}
+	wantFiles := []string{"sub/new.txt", "tracked.txt"}
+	if len(summary.Files) != len(wantFiles) {
+		t.Fatalf("Files = %q, want %q", summary.Files, wantFiles)
+	}
+	for i, want := range wantFiles {
+		if summary.Files[i] != want {
+			t.Fatalf("Files = %q, want %q", summary.Files, wantFiles)
+		}
+	}
+	if summary.Insertions != 3 || summary.Deletions != 0 {
+		t.Fatalf("Insertions/Deletions = %d/%d, want 3/0", summary.Insertions, summary.Deletions)
+	}
+}
+
+func TestDiffSummaryRejectsUnknownBase(t *testing.T) {
+	client := NewHistoryClient()
+	repo := makeTestRepo(t)
+	if _, err := client.DiffSummary(context.Background(), repo, "deadbeef"); err == nil {
+		t.Fatal("DiffSummary = nil, want error for unknown base")
+	}
+}
+
+func TestDiffSummaryOnMissingDirectory(t *testing.T) {
+	client := NewHistoryClient()
+	base := filepath.Join(t.TempDir(), "nope")
+	if _, err := client.DiffSummary(context.Background(), base, "HEAD"); err == nil {
+		t.Fatal("DiffSummary = nil, want error for missing directory")
+	}
+}

--- a/backend/internal/integration/gitcli/history.go
+++ b/backend/internal/integration/gitcli/history.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -119,6 +121,69 @@ func (c *HistoryClient) CommitDiff(ctx context.Context, repositoryPath, sha stri
 
 func (c *HistoryClient) ResolveCommit(ctx context.Context, repositoryPath, sha string) (string, error) {
 	return c.run(ctx, repositoryPath, 5*time.Second, "rev-parse", "--verify", sha+"^{commit}")
+}
+
+// DiffSummary tallies worktree changes (tracked modifications plus untracked
+// files) against a base commit. Renames surface as delete+add pairs; binary
+// files count as changed paths without line counts.
+type DiffSummary struct {
+	Files      []string
+	Insertions int64
+	Deletions  int64
+}
+
+// maxUntrackedReadBytes bounds line counting for newly created files.
+const maxUntrackedReadBytes = 10 << 20
+
+func (c *HistoryClient) DiffSummary(ctx context.Context, repositoryPath, base string) (DiffSummary, error) {
+	var summary DiffSummary
+	seen := map[string]bool{}
+	numstat, err := c.run(ctx, repositoryPath, 20*time.Second, "diff", "--numstat", base, "--", ".")
+	if err != nil {
+		return summary, err
+	}
+	for _, line := range strings.Split(numstat, "\n") {
+		fields := strings.SplitN(line, "\t", 3)
+		if len(fields) != 3 || fields[2] == "" {
+			continue
+		}
+		path := fields[2]
+		if !seen[path] {
+			seen[path] = true
+			summary.Files = append(summary.Files, path)
+		}
+		// Binary entries report "-" counts: the path still changed.
+		if added, aerr := strconv.ParseInt(fields[0], 10, 64); aerr == nil {
+			summary.Insertions += added
+		}
+		if deleted, derr := strconv.ParseInt(fields[1], 10, 64); derr == nil {
+			summary.Deletions += deleted
+		}
+	}
+	status, err := c.run(ctx, repositoryPath, 20*time.Second, "status", "--porcelain=v1", "-uall", "--", ".")
+	if err != nil {
+		return summary, err
+	}
+	for _, line := range strings.Split(status, "\n") {
+		if !strings.HasPrefix(line, "?? ") || len(line) < 4 {
+			continue
+		}
+		path := line[3:]
+		content, rerr := os.ReadFile(filepath.Join(repositoryPath, filepath.FromSlash(path)))
+		if rerr != nil {
+			continue
+		}
+		if len(content) > maxUntrackedReadBytes {
+			continue
+		}
+		if !seen[path] {
+			seen[path] = true
+			summary.Files = append(summary.Files, path)
+		}
+		summary.Insertions += int64(strings.Count(string(content), "\n"))
+	}
+	sort.Strings(summary.Files)
+	return summary, nil
 }
 
 func (c *HistoryClient) StageAll(ctx context.Context, repositoryPath string) error {

--- a/backend/internal/service/prompt/service.go
+++ b/backend/internal/service/prompt/service.go
@@ -12,6 +12,7 @@ import (
 	agentmodule "github.com/futrx-com/remote.futrx.com/internal/service/agent/module"
 	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
 	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
+	"github.com/futrx-com/remote.futrx.com/internal/service/runchanges"
 	"github.com/futrx-com/remote.futrx.com/internal/service/runhub"
 	serviceusage "github.com/futrx-com/remote.futrx.com/internal/service/usage"
 )
@@ -115,6 +116,14 @@ func WithUsageRecorder(recorder UsageRecorder) Option {
 	}
 }
 
+// WithRunChangeTracker enables per-run workspace changeset recording. A nil
+// tracker disables it; every hook below is nil-safe either way.
+func WithRunChangeTracker(tracker *runchanges.Tracker) Option {
+	return func(service *Service) {
+		service.changes = tracker
+	}
+}
+
 type AgentPolicy interface {
 	Descriptor(provider string) (agentmodule.Descriptor, bool)
 	SupportsScope(provider string, scope agentmodule.ExecutionScope) bool
@@ -140,6 +149,7 @@ type Service struct {
 	scheduleTools ScheduleToolIssuer
 	usage         UsageRecorder
 	startGate     StartGate
+	changes       *runchanges.Tracker
 	interactions  interactionResponseRouter
 }
 
@@ -432,6 +442,11 @@ func (rnr *Service) runPromptAs(
 		})
 	}
 
+	// Baseline the workspace before the agent runs so the changeset can be
+	// attributed to this run when it finishes. meta.Cwd is the host path in
+	// every scope (container runs see it bind-mounted at /workspace).
+	changeScope := rnr.beginRunChange(ctx, id, ledgerRunID, string(providerID), meta.Model, meta.Cwd)
+
 	err = run(effectivePrompt, resumeID)
 	if errors.Is(err, agent.ErrSessionNotFound) && resumeID != "" {
 		_, _ = rnr.store.Update(ctx, id, func(m *ChatMeta) {
@@ -454,6 +469,14 @@ func (rnr *Service) runPromptAs(
 	if err != nil && !errors.Is(err, agent.ErrRunFailed) {
 		emit(ChatEvent{T: time.Now().UnixMilli(), Type: "error", Message: string(providerID) + " exit: " + err.Error()})
 	}
+	// WithoutCancel: the run context may already be canceled (user interrupt),
+	// but the changeset read is short, local, and must not be lost with it.
+	changeScope.Finish(
+		context.WithoutCancel(ctx),
+		runchanges.OutcomeFor(ctx.Err(), err, func(runErr error) bool {
+			return errors.Is(runErr, agent.ErrRunFailed)
+		}),
+	)
 	return err
 }
 
@@ -462,6 +485,20 @@ func withTurnID(turnID string, emit func(ChatEvent)) func(ChatEvent) {
 		event.TurnID = turnID
 		emit(event)
 	}
+}
+
+// beginRunChange captures the workspace baseline for later changeset
+// attribution. It returns nil when tracking is disabled or there is nothing
+// trackable; the returned scope is always safe to Finish.
+func (rnr *Service) beginRunChange(
+	ctx context.Context,
+	id servicechat.ID,
+	runID, provider, model, repoPath string,
+) *runchanges.Scope {
+	if rnr.changes == nil {
+		return nil
+	}
+	return rnr.changes.BeginRun(ctx, id, runID, provider, model, repoPath)
 }
 
 func clearSessionIDForProvider(meta *ChatMeta, provider agent.ProviderID) {

--- a/backend/internal/service/runchanges/tracker.go
+++ b/backend/internal/service/runchanges/tracker.go
@@ -1,0 +1,178 @@
+// Package runchanges records per-agent-run workspace changesets.
+//
+// When an agent run starts inside a git repository, the tracker captures the
+// HEAD baseline; when the run finishes it diffs the worktree against that
+// baseline and appends one JSON record per run to
+// <dataDir>/chats/<chatID>/runs.jsonl. That answers "what exactly did this
+// specific agent run change" without disturbing the repository (read-only git
+// use; no staging, no commits, no checkouts).
+package runchanges
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/futrx-com/remote.futrx.com/internal/integration/gitcli"
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+)
+
+// Outcome classifies how an agent run ended.
+type Outcome string
+
+const (
+	OutcomeCompleted   Outcome = "completed"
+	OutcomeFailed      Outcome = "failed"
+	OutcomeInterrupted Outcome = "interrupted"
+	OutcomeError       Outcome = "error"
+)
+
+// OutcomeFor maps run termination to an Outcome: a canceled context means the
+// user (or scheduler) interrupted the run even when the provider returned nil.
+func OutcomeFor(ctxErr, runErr error, runFailed func(error) bool) Outcome {
+	if ctxErr != nil {
+		return OutcomeInterrupted
+	}
+	if runErr == nil {
+		return OutcomeCompleted
+	}
+	if runFailed(runErr) {
+		return OutcomeFailed
+	}
+	return OutcomeError
+}
+
+// RunRecord is one appended line of runs.jsonl. File paths are repository
+// relative, so records carry no host layout.
+type RunRecord struct {
+	RunID       string   `json:"run_id"`
+	Provider    string   `json:"provider"`
+	Model       string   `json:"model"`
+	StartedAtMs int64    `json:"started_at_ms"`
+	EndedAtMs   int64    `json:"ended_at_ms"`
+	Outcome     Outcome  `json:"outcome"`
+	BaseCommit  string   `json:"base_commit"`
+	Files       []string `json:"files"`
+	Insertions  int64    `json:"insertions"`
+	Deletions   int64    `json:"deletions"`
+}
+
+// GitClient is the read-only git surface the tracker needs.
+type GitClient interface {
+	Head(ctx context.Context, repositoryPath string) (string, error)
+	DiffSummary(ctx context.Context, repositoryPath, base string) (gitcli.DiffSummary, error)
+}
+
+// Tracker captures baselines and persists per-run changeset records.
+// A nil *Tracker or nil *Scope is always safe to use (tracking disabled).
+type Tracker struct {
+	root  string
+	git   GitClient
+	mu    sync.Mutex
+	locks map[servicechat.ID]*sync.Mutex
+}
+
+// NewTracker builds a tracker persisting under <dataDir>/chats/<chatID>/runs.jsonl.
+func NewTracker(dataDir string, git GitClient) *Tracker {
+	return &Tracker{root: dataDir, git: git, locks: map[servicechat.ID]*sync.Mutex{}}
+}
+
+func (t *Tracker) lock(id servicechat.ID) *sync.Mutex {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if lock, ok := t.locks[id]; ok {
+		return lock
+	}
+	lock := &sync.Mutex{}
+	t.locks[id] = lock
+	return lock
+}
+
+// Scope carries one run's baseline; Finish is safe on a nil Scope.
+type Scope struct {
+	tracker   *Tracker
+	chatID    servicechat.ID
+	runID     string
+	provider  string
+	model     string
+	repoPath  string
+	base      string
+	startedMs int64
+}
+
+// BeginRun captures the HEAD baseline. It returns nil when there is nothing
+// to track: empty repo path, missing git client, or HEAD unreadable (not a
+// repository, empty repository, or git unavailable).
+func (t *Tracker) BeginRun(
+	ctx context.Context,
+	chatID servicechat.ID,
+	runID, provider, model, repoPath string,
+) *Scope {
+	if t == nil || t.git == nil || repoPath == "" {
+		return nil
+	}
+	base, err := t.git.Head(ctx, repoPath)
+	if err != nil || base == "" {
+		return nil
+	}
+	return &Scope{
+		tracker:   t,
+		chatID:    chatID,
+		runID:     runID,
+		provider:  provider,
+		model:     model,
+		repoPath:  repoPath,
+		base:      base,
+		startedMs: time.Now().UnixMilli(),
+	}
+}
+
+// Finish diffs the worktree against the baseline and appends the record.
+// Errors are swallowed: change tracking must never break a chat turn.
+func (s *Scope) Finish(ctx context.Context, outcome Outcome) {
+	if s == nil {
+		return
+	}
+	record := RunRecord{
+		RunID:       s.runID,
+		Provider:    s.provider,
+		Model:       s.model,
+		StartedAtMs: s.startedMs,
+		EndedAtMs:   time.Now().UnixMilli(),
+		Outcome:     outcome,
+		BaseCommit:  s.base,
+	}
+	if summary, err := s.tracker.git.DiffSummary(ctx, s.repoPath, s.base); err == nil {
+		record.Files = summary.Files
+		record.Insertions = summary.Insertions
+		record.Deletions = summary.Deletions
+	}
+	if record.Files == nil {
+		record.Files = []string{}
+	}
+	s.tracker.append(s.chatID, record)
+}
+
+func (t *Tracker) append(chatID servicechat.ID, record RunRecord) {
+	line, err := json.Marshal(record)
+	if err != nil {
+		return
+	}
+	line = append(line, '\n')
+	lock := t.lock(chatID)
+	lock.Lock()
+	defer lock.Unlock()
+	dir := filepath.Join(t.root, "chats", string(chatID))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	file, err := os.OpenFile(filepath.Join(dir, "runs.jsonl"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	_, _ = file.Write(line)
+}

--- a/backend/internal/service/runchanges/tracker_test.go
+++ b/backend/internal/service/runchanges/tracker_test.go
@@ -1,0 +1,134 @@
+package runchanges
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/futrx-com/remote.futrx.com/internal/integration/gitcli"
+	servicechat "github.com/futrx-com/remote.futrx.com/internal/service/chat"
+)
+
+type scriptedGit struct {
+	head    string
+	headErr error
+	summary gitcli.DiffSummary
+	diffErr error
+}
+
+func (g *scriptedGit) Head(context.Context, string) (string, error) {
+	return g.head, g.headErr
+}
+
+func (g *scriptedGit) DiffSummary(context.Context, string, string) (gitcli.DiffSummary, error) {
+	return g.summary, g.diffErr
+}
+
+func readRecords(t *testing.T, root string, chatID servicechat.ID) []RunRecord {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(root, "chats", string(chatID), "runs.jsonl"))
+	if err != nil {
+		t.Fatalf("read runs.jsonl: %v", err)
+	}
+	var records []RunRecord
+	for _, line := range strings.Split(strings.TrimSpace(string(content)), "\n") {
+		var record RunRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func TestBeginFinishPersistsChangeset(t *testing.T) {
+	root := t.TempDir()
+	git := &scriptedGit{
+		head: "abc123",
+		summary: gitcli.DiffSummary{
+			Files:      []string{"a.go", "b.md"},
+			Insertions: 10,
+			Deletions:  2,
+		},
+	}
+	tracker := NewTracker(root, git)
+	scope := tracker.BeginRun(context.Background(), "chat1", "run-1", "codex", "gpt-x", "/repo")
+	if scope == nil {
+		t.Fatal("BeginRun = nil, want scope")
+	}
+	scope.Finish(context.Background(), OutcomeCompleted)
+
+	records := readRecords(t, root, "chat1")
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	record := records[0]
+	if record.RunID != "run-1" || record.Provider != "codex" || record.Model != "gpt-x" {
+		t.Fatalf("identity = %+v", record)
+	}
+	if record.Outcome != OutcomeCompleted || record.BaseCommit != "abc123" {
+		t.Fatalf("outcome/base = %+v", record)
+	}
+	if len(record.Files) != 2 || record.Insertions != 10 || record.Deletions != 2 {
+		t.Fatalf("changeset = %+v", record)
+	}
+	if record.StartedAtMs <= 0 || record.EndedAtMs < record.StartedAtMs {
+		t.Fatalf("timestamps = %+v", record)
+	}
+}
+
+func TestBeginRunSkipsNonRepositories(t *testing.T) {
+	tracker := NewTracker(t.TempDir(), &scriptedGit{headErr: errors.New("not a repo")})
+	if scope := tracker.BeginRun(context.Background(), "chat1", "run-1", "codex", "m", "/repo"); scope != nil {
+		t.Fatal("BeginRun = scope, want nil for unreadable HEAD")
+	}
+	// Nil tracker and nil scope are both safe no-ops.
+	var nilTracker *Tracker
+	if scope := nilTracker.BeginRun(context.Background(), "chat1", "run-1", "codex", "m", "/repo"); scope != nil {
+		t.Fatal("nil BeginRun = scope, want nil")
+	}
+	var nilScope *Scope
+	nilScope.Finish(context.Background(), OutcomeCompleted)
+	emptyTracker := NewTracker(t.TempDir(), &scriptedGit{})
+	if scope := emptyTracker.BeginRun(context.Background(), "chat1", "run-1", "codex", "m", ""); scope != nil {
+		t.Fatal("BeginRun with empty path = scope, want nil")
+	}
+}
+
+func TestFinishSurvivesDiffErrors(t *testing.T) {
+	root := t.TempDir()
+	git := &scriptedGit{head: "abc123", diffErr: errors.New("diff failed")}
+	tracker := NewTracker(root, git)
+	scope := tracker.BeginRun(context.Background(), "chat1", "run-1", "codex", "m", "/repo")
+	scope.Finish(context.Background(), OutcomeFailed)
+
+	records := readRecords(t, root, "chat1")
+	if len(records) != 1 || records[0].Outcome != OutcomeFailed {
+		t.Fatalf("records = %+v", records)
+	}
+	if records[0].Files == nil {
+		t.Fatal("Files = nil, want empty array for JSON consumers")
+	}
+}
+
+func TestOutcomeFor(t *testing.T) {
+	isFailed := func(err error) bool { return errors.Is(err, errRunFailed) }
+	if got := OutcomeFor(context.Canceled, nil, isFailed); got != OutcomeInterrupted {
+		t.Fatalf("canceled ctx = %q, want interrupted", got)
+	}
+	if got := OutcomeFor(nil, nil, isFailed); got != OutcomeCompleted {
+		t.Fatalf("nil err = %q, want completed", got)
+	}
+	if got := OutcomeFor(nil, errRunFailed, isFailed); got != OutcomeFailed {
+		t.Fatalf("run failure = %q, want failed", got)
+	}
+	if got := OutcomeFor(nil, errors.New("boom"), isFailed); got != OutcomeError {
+		t.Fatalf("other err = %q, want error", got)
+	}
+}
+
+var errRunFailed = errors.New("run failed")

--- a/backend/internal/service/services.go
+++ b/backend/internal/service/services.go
@@ -18,6 +18,7 @@ import (
 	serviceproject "github.com/futrx-com/remote.futrx.com/internal/service/project"
 	"github.com/futrx-com/remote.futrx.com/internal/service/prompt"
 	servicepush "github.com/futrx-com/remote.futrx.com/internal/service/push"
+	"github.com/futrx-com/remote.futrx.com/internal/service/runchanges"
 	"github.com/futrx-com/remote.futrx.com/internal/service/runhub"
 	serviceschedule "github.com/futrx-com/remote.futrx.com/internal/service/schedule"
 	"github.com/futrx-com/remote.futrx.com/internal/service/schedulecapability"
@@ -81,6 +82,7 @@ type Dependencies struct {
 	ValidTmuxName     func(string) bool
 	ScheduleLimits    ScheduleLimits
 	PromptStartGate   prompt.StartGate
+	RunChanges        *runchanges.Tracker
 }
 
 // ScheduleLimits mirrors the deployment's scheduled-task guardrails without
@@ -249,6 +251,9 @@ func New(ctx context.Context, deps Dependencies) (Services, error) {
 	if deps.Usage != nil {
 		usageService = serviceusage.New(deps.Usage, projectService, chats)
 		promptOptions = append(promptOptions, prompt.WithUsageRecorder(usageService))
+	}
+	if deps.RunChanges != nil {
+		promptOptions = append(promptOptions, prompt.WithRunChangeTracker(deps.RunChanges))
 	}
 	promptService := prompt.New(
 		chats,


### PR DESCRIPTION
# Pull Request

## Summary

Foundation for #83 (run-scoped agent change tracking): answers "what exactly did this specific
agent run change" at the data layer. Captures the git HEAD baseline when an agent run starts and
appends one changeset record per run to `chats/<id>/runs.jsonl` when it finishes.

## Change

- `gitcli.DiffSummary`: numstat-based file/insertion/deletion tally vs a base commit, plus
  untracked files (with line counts). Read-only git use.
- New `runchanges` tracker + file store: `BeginRun` (nil when no repository — non-repos skip
  silently), `Finish` (nil-safe, error-swallowing; tracking can never break a turn). Record:
  run/provider/model/timestamps/outcome/base/files/insertions/deletions, paths repo-relative.
- `prompt` hooks in `runPromptAs` with outcome mapping (completed/failed/interrupted/error),
  `WithoutCancel` finish, keyed by the existing ledger run ID so records correlate with turn events.
- Composition wiring (`Dependencies.RunChanges`, built from `DATA_DIR` in `cmd/remote`).

Deliberately out of scope: HTTP API + UI over `runs.jsonl` (proposed follow-up once the record
shape is accepted).

## Verification

- New unit tests (gitcli diff incl. real temp repos, tracker incl. nil-safety, outcome mapping).
- Full `gitcli`, `runchanges`, `prompt`, `service` suites green; `go vet` clean.
- Pre-existing failures untouched and verified on the pristine tree: `githistory`
  `resolveRepositoryPath` (this machine), `lifecycle` overlapping-targets, `static.go` embed
  (needs a built frontend).
