### PR TITLE
fix(chat): keep a chat's uploads working after its project is deleted

### DIFF
--- a/backend/internal/service/chat/errors.go
+++ b/backend/internal/service/chat/errors.go
@@ -3,12 +3,16 @@ package chat
 import "errors"
 
 var (
-	ErrInvalidID                       = errors.New("invalid chat id")
-	ErrInvalidProvider                 = errors.New("invalid chat provider")
-	ErrInvalidTmuxSession              = errors.New("invalid tmux session")
-	ErrInvalidRewindTimestamp          = errors.New("invalid rewind timestamp")
-	ErrChatRunning                     = errors.New("chat has an active run")
-	ErrNotFound                        = errors.New("chat not found")
+	ErrInvalidID              = errors.New("invalid chat id")
+	ErrInvalidProvider        = errors.New("invalid chat provider")
+	ErrInvalidTmuxSession     = errors.New("invalid tmux session")
+	ErrInvalidRewindTimestamp = errors.New("invalid rewind timestamp")
+	ErrChatRunning            = errors.New("chat has an active run")
+	ErrNotFound               = errors.New("chat not found")
+	// ErrProjectNotFound is what a ProjectResolver reports for a project that
+	// no longer exists. A chat outlives its project, so this is a state the
+	// chat service has to answer rather than an error to propagate.
+	ErrProjectNotFound                 = errors.New("project not found")
 	ErrTranscriptContentNotFound       = errors.New("transcript content not found")
 	ErrTranscriptProjectionUnavailable = errors.New("transcript projection unavailable")
 )

--- a/backend/internal/service/chat/ports.go
+++ b/backend/internal/service/chat/ports.go
@@ -54,6 +54,9 @@ type CopiedEventAppender interface {
 	AppendCopiedEvent(ctx context.Context, id ID, event Event) (Event, error)
 }
 
+// ProjectResolver answers where a project's workspace lives. It reports
+// ErrProjectNotFound when the project is gone, which callers distinguish from a
+// workspace that could not be read.
 type ProjectResolver interface {
 	WorkspaceForProject(ctx context.Context, id ProjectID) (string, error)
 }

--- a/backend/internal/service/chat/service.go
+++ b/backend/internal/service/chat/service.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -413,7 +414,18 @@ func (s *Service) UploadTarget(ctx context.Context, id ID) (string, error) {
 	// subdir isolates attachments from the source tree.
 	root := meta.Cwd
 	if meta.ProjectID != "" && s.projects != nil {
-		if ws, err := s.projects.WorkspaceForProject(ctx, meta.ProjectID); err == nil && ws != "" {
+		ws, err := s.projects.WorkspaceForProject(ctx, meta.ProjectID)
+		// A deleted project is not a failure to look one up: the chat and its
+		// transcript outlive the project, and it can still take an attachment
+		// into the directory it was working in. Every other error means the
+		// workspace exists but could not be resolved, and uploading into the
+		// chat's own cwd instead would put the file somewhere the caller is not
+		// expecting it.
+		switch {
+		case errors.Is(err, ErrProjectNotFound):
+		case err != nil:
+			return "", err
+		case ws != "":
 			root = ws
 		}
 	}

--- a/backend/internal/service/chat/upload_target_test.go
+++ b/backend/internal/service/chat/upload_target_test.go
@@ -1,0 +1,65 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+type uploadRepository struct {
+	Repository
+	meta Meta
+}
+
+func (r *uploadRepository) Get(context.Context, ID) (Meta, error) { return r.meta, nil }
+
+type uploadProjects struct {
+	workspace string
+	err       error
+}
+
+func (p uploadProjects) WorkspaceForProject(context.Context, ProjectID) (string, error) {
+	return p.workspace, p.err
+}
+
+func uploadTarget(t *testing.T, projects ProjectResolver) (string, error) {
+	t.Helper()
+	repo := &uploadRepository{meta: Meta{ID: "deadbeef", ProjectID: "p1", Cwd: "/chat/cwd"}}
+	return New(repo, projects, nil, nil).UploadTarget(context.Background(), "deadbeef")
+}
+
+// The workspace root is what the frontend predicts the upload path from, so it
+// wins over the chat's own directory whenever it can be resolved.
+func TestUploadTargetPrefersTheProjectWorkspace(t *testing.T) {
+	got, err := uploadTarget(t, uploadProjects{workspace: "/workspace/p1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join("/workspace/p1", ".uploads"); got != want {
+		t.Errorf("target = %q, want %q", got, want)
+	}
+}
+
+// A chat outlives the project it belonged to. Refusing its attachments because
+// that project is gone would break a conversation the user can still open and
+// still read, so it falls back to the directory it was working in.
+func TestUploadTargetFallsBackWhenTheProjectIsGone(t *testing.T) {
+	got, err := uploadTarget(t, uploadProjects{err: ErrProjectNotFound})
+	if err != nil {
+		t.Fatalf("a deleted project failed the lookup: %v", err)
+	}
+	if want := filepath.Join("/chat/cwd", ".uploads"); got != want {
+		t.Errorf("target = %q, want %q", got, want)
+	}
+}
+
+// Any other failure means the workspace exists but could not be resolved.
+// Writing into the chat's cwd instead would put the file somewhere neither the
+// user nor the frontend is looking for it.
+func TestUploadTargetFailsWhenTheWorkspaceCannotBeResolved(t *testing.T) {
+	unavailable := errors.New("project store unavailable")
+	if _, err := uploadTarget(t, uploadProjects{err: unavailable}); !errors.Is(err, unavailable) {
+		t.Errorf("err = %v, want %v", err, unavailable)
+	}
+}

--- a/backend/internal/service/services.go
+++ b/backend/internal/service/services.go
@@ -430,7 +430,14 @@ type chatProjectResolver struct {
 }
 
 func (r chatProjectResolver) WorkspaceForProject(ctx context.Context, id servicechat.ProjectID) (string, error) {
-	return r.projects.WorkspaceForProject(ctx, serviceproject.ID(id))
+	cwd, err := r.projects.WorkspaceForProject(ctx, serviceproject.ID(id))
+	// The chat service has its own name for a project that is gone, so it can
+	// tell that apart from a workspace it failed to read without importing the
+	// project package.
+	if errors.Is(err, serviceproject.ErrNotFound) {
+		return "", servicechat.ErrProjectNotFound
+	}
+	return cwd, err
 }
 
 type chatTmuxResolver struct {


### PR DESCRIPTION
A chat outlives the project it was started in, and its transcript stays readable — but attaching a file to it stopped working once the project was gone. UploadTarget resolved the project's workspace, and on any error fell back to the chat's own cwd.

Two things were wrong with that. A deleted project is not a failed lookup: the chat can still take an attachment into the directory it was working in, so that case should succeed rather than be treated as an error. And every *other* error means the workspace exists but could not be resolved, where silently writing into the chat's cwd instead puts the file somewhere the caller is not expecting it.

So the two are now told apart. The chat service names a missing project (ErrProjectNotFound) and the resolver translates the project service's own sentinel into it, which keeps the chat package from importing the project package. Anything else fails the upload.

Found while splitting #50, which carried this fix; it has nothing to do with installable images, so it is on its own here.